### PR TITLE
feat: bump miniscript crate to 12.3.4

### DIFF
--- a/packages/wasm-utxo/Cargo.lock
+++ b/packages/wasm-utxo/Cargo.lock
@@ -149,8 +149,8 @@ checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "miniscript"
-version = "12.2.0"
-source = "git+https://github.com/BitGo/rust-miniscript?branch=opdrop#eb984856a2e560a7ee98b248519eb7ef5d650e5e"
+version = "12.3.4"
+source = "git+https://github.com/BitGo/rust-miniscript?tag=miniscript-12.3.4-opdrop#4e730b3a1ccc0116e6f6e05ddbf132938cc8395c"
 dependencies = [
  "bech32",
  "bitcoin",

--- a/packages/wasm-utxo/Cargo.toml
+++ b/packages/wasm-utxo/Cargo.toml
@@ -9,7 +9,7 @@ crate-type = ["cdylib"]
 [dependencies]
 wasm-bindgen = "0.2"
 js-sys = "0.3"
-miniscript = { git = "https://github.com/BitGo/rust-miniscript", branch = "opdrop" }
+miniscript = { git = "https://github.com/BitGo/rust-miniscript", tag = "miniscript-12.3.4-opdrop" }
 
 [dev-dependencies]
 base64 = "0.22.1"

--- a/packages/wasm-utxo/test/fixtures/2.json
+++ b/packages/wasm-utxo/test/fixtures/2.json
@@ -1,11 +1,11 @@
 {
-  "descriptor": "pkh([deadbeef/1/2'/3/4']03a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd)#v0p5w8jl",
+  "descriptor": "pkh(03a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd)#wf36a0pg",
   "wasmNode": {
     "Pkh": {
-      "Single": "[deadbeef/1/2'/3/4']03a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd"
+      "Single": "03a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd"
     }
   },
   "ast": {
-    "pkh": "[deadbeef/1/2'/3/4']03a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd"
+    "pkh": "03a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd"
   }
 }

--- a/packages/wasm-utxo/test/opdrop.ts
+++ b/packages/wasm-utxo/test/opdrop.ts
@@ -13,9 +13,6 @@ function getDescriptorOpDropP2ms(locktime: number, keys: utxolib.BIP32Interface[
 }
 
 describe("CLV with OP_DROP", function () {
-  // OP_DROP enabled in this branch
-  // return;
-
   const locktime = 1024;
   const descriptor = Descriptor.fromString(
     getDescriptorOpDropP2ms(locktime, rootWalletKeys.triple),

--- a/packages/wasm-utxo/test/test.ts
+++ b/packages/wasm-utxo/test/test.ts
@@ -99,11 +99,11 @@ describe("Descriptor fixtures", function () {
       it("should parse (pkType derivable)", async function () {
         const descriptor = Descriptor.fromString(fixture.descriptor, "derivable");
 
-        assert.doesNotThrow(() =>
-          Descriptor.fromString(fixture.descriptor, "derivable").atDerivationIndex(0),
-        );
-
         if (isDerivable(i)) {
+          assert.doesNotThrow(() =>
+            Descriptor.fromString(fixture.descriptor, "derivable").atDerivationIndex(0),
+          );
+
           if (descriptor.descType() !== "Tr") {
             assert.doesNotThrow(() => descriptor.atDerivationIndex(0).encode());
           }


### PR DESCRIPTION
This PR updates the miniscript crate to version 12.3.4 and makes necessary
test adjustments to accommodate the new version.

### Changes:
- Bump miniscript crate to version 12.3.4
- Fix test by moving assertion inside derivable check
  - The new rust-miniscript version fails at `.atDerivationIndex(0)` which
    is more logical
- Remove path from pkh fixture due to small differences in the
  updated miniscript version

Issue: BTC-2650