### PR TITLE
feat: pin Rust toolchain to nightly-2025-10-23

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
-          toolchain: nightly
+          toolchain: nightly-2025-10-23
 
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@f13886b937689c021905a6b90929199931d60db1 # v2.8.1


### PR DESCRIPTION

Update CI workflow to use a specific nightly version of the Rust toolchain
for better reproducibility and caching.

Issue: BTC-2652