### PR TITLE
chore(wasm-utxo): update dependencies and type definitions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1866,13 +1866,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.14.10",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.10.tgz",
-      "integrity": "sha512-MdiXf+nDuMvY0gJKxyfZ7/6UFsETO7mGKF54MVD/ekJS6HdFtpZFBgrh6Pseu64XTb2MLyFPlbW6hj8HYRQNOQ==",
+      "version": "22.18.12",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.18.12.tgz",
+      "integrity": "sha512-BICHQ67iqxQGFSzfCFTT7MRQ5XcBjG5aeKh5Ok38UBbPe5fxTyE+aHFxwVrGyr8GNlqFMLKD1D3P2K/1ks8tog==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~5.26.4"
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/@types/node-forge": {
@@ -16869,9 +16869,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -17722,10 +17722,10 @@
       "devDependencies": {
         "@bitgo/utxo-lib": "^10.1.0",
         "@types/mocha": "^10.0.7",
-        "@types/node": "^20.14.10",
+        "@types/node": "^22.10.5",
         "mocha": "^10.6.0",
         "ts-node": "^10.9.2",
-        "typescript": "^5.8.3"
+        "typescript": "^5.5.3"
       }
     },
     "packages/wasm-utxo-ui": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -16841,9 +16841,9 @@
       "license": "MIT"
     },
     "node_modules/typescript": {
-      "version": "5.5.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.3.tgz",
-      "integrity": "sha512-/hreyEujaB0w76zKo6717l3L0o/qEUtRgdvUBvlkhoWeOVMjMuHNHk0BRBzikzuGDqNmPQbg5ifMEqsHLiIUcQ==",
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -17725,7 +17725,7 @@
         "@types/node": "^20.14.10",
         "mocha": "^10.6.0",
         "ts-node": "^10.9.2",
-        "typescript": "^5.5.3"
+        "typescript": "^5.8.3"
       }
     },
     "packages/wasm-utxo-ui": {

--- a/packages/wasm-utxo/js/index.ts
+++ b/packages/wasm-utxo/js/index.ts
@@ -35,7 +35,7 @@ declare module "./wasm/wasm_utxo" {
 
   interface WrapPsbt {
     signWithXprv(this: WrapPsbt, xprv: string): SignPsbtResult;
-    signWithPrv(this: WrapPsbt, prv: Buffer): SignPsbtResult;
+    signWithPrv(this: WrapPsbt, prv: Uint8Array): SignPsbtResult;
   }
 }
 

--- a/packages/wasm-utxo/package.json
+++ b/packages/wasm-utxo/package.json
@@ -37,7 +37,7 @@
   "devDependencies": {
     "@bitgo/utxo-lib": "^10.1.0",
     "@types/mocha": "^10.0.7",
-    "@types/node": "^20.14.10",
+    "@types/node": "^22.10.5",
     "mocha": "^10.6.0",
     "ts-node": "^10.9.2",
     "typescript": "^5.5.3"


### PR DESCRIPTION

This PR updates dependencies and type definitions in the wasm-utxo module:

- feat: bump Node.js type definitions from v20 to v22
- fix: update TypeScript dependency from 5.5.3 to 5.9.3
- fix: update type for signWithPrv to use Uint8Array for consistent usage
  of typed arrays for binary data in the API

Issue: BTC-2652