### PR TITLE
feat(wasm-utxo): improve address handling and network validation

### DIFF
--- a/packages/wasm-utxo/js/address.ts
+++ b/packages/wasm-utxo/js/address.ts
@@ -1,6 +1,10 @@
 import { AddressNamespace } from "./wasm/wasm_utxo";
 import type { CoinName } from "./coinName";
 
+/**
+ * Most coins only have one unambiguous address format (base58check and bech32/bech32m)
+ * For Bitcoin Cash and eCash, we can select between base58check and cashaddr.
+ */
 export type AddressFormat = "default" | "cashaddr";
 
 export function toOutputScriptWithCoin(address: string, coin: CoinName): Uint8Array {

--- a/packages/wasm-utxo/js/fixedScriptWallet.ts
+++ b/packages/wasm-utxo/js/fixedScriptWallet.ts
@@ -1,6 +1,7 @@
 import { FixedScriptWalletNamespace } from "./wasm/wasm_utxo";
 import type { UtxolibNetwork, UtxolibRootWalletKeys } from "./utxolibCompat";
 import { Triple } from "./triple";
+import { AddressFormat } from "./address";
 
 export type WalletKeys =
   /** Just an xpub triple, will assume default derivation prefixes  */
@@ -18,12 +19,21 @@ export function outputScript(keys: WalletKeys, chain: number, index: number): Ui
 /**
  * Create the address for a given wallet keys and chain and index and network.
  * Wrapper for outputScript that also encodes the script to an address.
+ * @param keys - The wallet keys to use.
+ * @param chain - The chain to use.
+ * @param index - The index to use.
+ * @param network - The network to use.
+ * @param addressFormat - The address format to use.
+ *   Only relevant for Bitcoin Cash and eCash networks, where:
+ *   - "default" means base58check,
+ *   - "cashaddr" means cashaddr.
  */
 export function address(
   keys: WalletKeys,
   chain: number,
   index: number,
   network: UtxolibNetwork,
+  addressFormat?: AddressFormat,
 ): string {
-  return FixedScriptWalletNamespace.address(keys, chain, index, network);
+  return FixedScriptWalletNamespace.address(keys, chain, index, network, addressFormat);
 }

--- a/packages/wasm-utxo/js/fixedScriptWallet.ts
+++ b/packages/wasm-utxo/js/fixedScriptWallet.ts
@@ -12,8 +12,13 @@ export type WalletKeys =
 /**
  * Create the output script for a given wallet keys and chain and index
  */
-export function outputScript(keys: WalletKeys, chain: number, index: number): Uint8Array {
-  return FixedScriptWalletNamespace.output_script(keys, chain, index);
+export function outputScript(
+  keys: WalletKeys,
+  chain: number,
+  index: number,
+  network: UtxolibNetwork,
+): Uint8Array {
+  return FixedScriptWalletNamespace.output_script(keys, chain, index, network);
 }
 
 /**

--- a/packages/wasm-utxo/src/fixed_script_wallet/mod.rs
+++ b/packages/wasm-utxo/src/fixed_script_wallet/mod.rs
@@ -12,10 +12,10 @@ pub use wallet_keys::*;
 pub use wallet_scripts::*;
 use wasm_bindgen::prelude::*;
 
-use crate::address::networks::{AddressFormat};
+use crate::address::networks::AddressFormat;
 use crate::error::WasmMiniscriptError;
 use crate::try_from_js_value::TryFromJsValue;
-use crate::utxolib_compat::Network;
+use crate::utxolib_compat::UtxolibNetwork;
 
 #[wasm_bindgen]
 pub struct FixedScriptWalletNamespace;
@@ -29,12 +29,17 @@ impl FixedScriptWalletNamespace {
         index: u32,
         network: JsValue,
     ) -> Result<Vec<u8>, WasmMiniscriptError> {
-        let network = Network::try_from_js_value(&network)?;
+        let network = UtxolibNetwork::try_from_js_value(&network)?;
         let chain = Chain::try_from(chain)
             .map_err(|e| WasmMiniscriptError::new(&format!("Invalid chain: {}", e)))?;
 
         let wallet_keys = RootWalletKeys::from_jsvalue(&keys)?;
-        let scripts = WalletScripts::from_wallet_keys(&wallet_keys, chain, index, &network.output_script_support())?;
+        let scripts = WalletScripts::from_wallet_keys(
+            &wallet_keys,
+            chain,
+            index,
+            &network.output_script_support(),
+        )?;
         Ok(scripts.output_script().to_bytes())
     }
 
@@ -46,11 +51,16 @@ impl FixedScriptWalletNamespace {
         network: JsValue,
         address_format: Option<String>,
     ) -> Result<String, WasmMiniscriptError> {
-        let network = Network::try_from_js_value(&network)?;
+        let network = UtxolibNetwork::try_from_js_value(&network)?;
         let wallet_keys = RootWalletKeys::from_jsvalue(&keys)?;
         let chain = Chain::try_from(chain)
             .map_err(|e| WasmMiniscriptError::new(&format!("Invalid chain: {}", e)))?;
-        let scripts = WalletScripts::from_wallet_keys(&wallet_keys, chain, index, &network.output_script_support())?;
+        let scripts = WalletScripts::from_wallet_keys(
+            &wallet_keys,
+            chain,
+            index,
+            &network.output_script_support(),
+        )?;
         let script = scripts.output_script();
         let address_format = AddressFormat::from_optional_str(address_format.as_deref())
             .map_err(|e| WasmMiniscriptError::new(&format!("Invalid address format: {}", e)))?;

--- a/packages/wasm-utxo/src/fixed_script_wallet/mod.rs
+++ b/packages/wasm-utxo/src/fixed_script_wallet/mod.rs
@@ -42,6 +42,7 @@ impl FixedScriptWalletNamespace {
         chain: u32,
         index: u32,
         network: JsValue,
+        address_format: Option<String>,
     ) -> Result<String, WasmMiniscriptError> {
         let network = Network::try_from_js_value(&network)?;
         let wallet_keys = RootWalletKeys::from_jsvalue(&keys)?;
@@ -49,10 +50,12 @@ impl FixedScriptWalletNamespace {
             .map_err(|e| WasmMiniscriptError::new(&format!("Invalid chain: {}", e)))?;
         let scripts = WalletScripts::from_wallet_keys(&wallet_keys, chain, index);
         let script = scripts.output_script();
+        let address_format = AddressFormat::from_optional_str(address_format.as_deref())
+            .map_err(|e| WasmMiniscriptError::new(&format!("Invalid address format: {}", e)))?;
         let address = crate::address::utxolib_compat::from_output_script_with_network(
             &script,
             &network,
-            AddressFormat::Default,
+            address_format,
         )
         .map_err(|e| WasmMiniscriptError::new(&format!("Failed to generate address: {}", e)))?;
         Ok(address.to_string())

--- a/packages/wasm-utxo/src/fixed_script_wallet/mod.rs
+++ b/packages/wasm-utxo/src/fixed_script_wallet/mod.rs
@@ -12,7 +12,7 @@ pub use wallet_keys::*;
 pub use wallet_scripts::*;
 use wasm_bindgen::prelude::*;
 
-use crate::address::networks::AddressFormat;
+use crate::address::networks::{AddressFormat};
 use crate::error::WasmMiniscriptError;
 use crate::try_from_js_value::TryFromJsValue;
 use crate::utxolib_compat::Network;
@@ -27,12 +27,14 @@ impl FixedScriptWalletNamespace {
         keys: JsValue,
         chain: u32,
         index: u32,
+        network: JsValue,
     ) -> Result<Vec<u8>, WasmMiniscriptError> {
+        let network = Network::try_from_js_value(&network)?;
         let chain = Chain::try_from(chain)
             .map_err(|e| WasmMiniscriptError::new(&format!("Invalid chain: {}", e)))?;
 
         let wallet_keys = RootWalletKeys::from_jsvalue(&keys)?;
-        let scripts = WalletScripts::from_wallet_keys(&wallet_keys, chain, index);
+        let scripts = WalletScripts::from_wallet_keys(&wallet_keys, chain, index, &network.output_script_support())?;
         Ok(scripts.output_script().to_bytes())
     }
 
@@ -48,7 +50,7 @@ impl FixedScriptWalletNamespace {
         let wallet_keys = RootWalletKeys::from_jsvalue(&keys)?;
         let chain = Chain::try_from(chain)
             .map_err(|e| WasmMiniscriptError::new(&format!("Invalid chain: {}", e)))?;
-        let scripts = WalletScripts::from_wallet_keys(&wallet_keys, chain, index);
+        let scripts = WalletScripts::from_wallet_keys(&wallet_keys, chain, index, &network.output_script_support())?;
         let script = scripts.output_script();
         let address_format = AddressFormat::from_optional_str(address_format.as_deref())
             .map_err(|e| WasmMiniscriptError::new(&format!("Invalid address format: {}", e)))?;

--- a/packages/wasm-utxo/src/fixed_script_wallet/test_utils/mod.rs
+++ b/packages/wasm-utxo/src/fixed_script_wallet/test_utils/mod.rs
@@ -7,7 +7,7 @@ use super::wallet_scripts::{Chain, WalletScripts};
 use crate::bitcoin::bip32::{DerivationPath, Fingerprint, Xpriv, Xpub};
 use crate::bitcoin::psbt::{Input as PsbtInput, Output as PsbtOutput, Psbt};
 use crate::bitcoin::{Transaction, TxIn, TxOut};
-use crate::RootWalletKeys;
+use crate::{Network, RootWalletKeys};
 use std::collections::BTreeMap;
 use std::str::FromStr;
 
@@ -32,8 +32,13 @@ pub fn get_test_wallet_keys(seed: &str) -> XpubTriple {
 /// Create a PSBT output for an external wallet (different keys)
 pub fn create_external_output(seed: &str) -> PsbtOutput {
     let xpubs = get_test_wallet_keys(seed);
-    let _scripts =
-        WalletScripts::from_wallet_keys(&RootWalletKeys::new(xpubs), Chain::P2wshExternal, 0);
+    let _scripts = WalletScripts::from_wallet_keys(
+        &RootWalletKeys::new(xpubs),
+        Chain::P2wshExternal,
+        0,
+        &Network::Bitcoin.output_script_support(),
+    )
+    .unwrap();
     PsbtOutput {
         bip32_derivation: BTreeMap::new(),
         // witness_script: scripts.witness_script,

--- a/packages/wasm-utxo/src/try_from_js_value.rs
+++ b/packages/wasm-utxo/src/try_from_js_value.rs
@@ -1,4 +1,4 @@
-use crate::address::utxolib_compat::{CashAddr, Network};
+use crate::address::utxolib_compat::{CashAddr, UtxolibNetwork};
 use crate::error::WasmMiniscriptError;
 use wasm_bindgen::JsValue;
 
@@ -119,14 +119,14 @@ pub(crate) fn get_buffer_field_vec(
     Ok(bytes)
 }
 
-impl TryFromJsValue for Network {
+impl TryFromJsValue for UtxolibNetwork {
     fn try_from_js_value(value: &JsValue) -> Result<Self, WasmMiniscriptError> {
         let pub_key_hash = get_field(value, "pubKeyHash")?;
         let script_hash = get_field(value, "scriptHash")?;
         let bech32 = get_field(value, "bech32")?;
         let cash_addr = get_field(value, "cashAddr")?;
 
-        Ok(Network {
+        Ok(UtxolibNetwork {
             pub_key_hash,
             script_hash,
             cash_addr,


### PR DESCRIPTION

This PR enhances the WASM UTXO module with several improvements to address
handling and network validation:

1. Add optional addressFormat parameter to the address function, allowing
   control over output format (e.g., cashaddr for BCH/ECASH)

2. Add network parameter to output script validation to ensure scripts are
   only created for networks that support specific features:
   - Add OutputScriptSupport struct for compatibility verification
   - Implement per-network script validation logic
   - Document supported features across different networks

3. Rename Network class to UtxolibNetwork for better semantics and to
   avoid confusion with other network objects while maintaining functionality

BTC-2652