### PR TITLE
refactor(wasm-utxo): rename error type from WasmMiniscriptError to WasmUtxoError

### DIFF
--- a/packages/wasm-utxo/src/error.rs
+++ b/packages/wasm-utxo/src/error.rs
@@ -1,51 +1,51 @@
 use core::fmt;
 
 #[derive(Debug, Clone)]
-pub enum WasmMiniscriptError {
+pub enum WasmUtxoError {
     StringError(String),
 }
 
-impl std::error::Error for WasmMiniscriptError {}
-impl fmt::Display for WasmMiniscriptError {
+impl std::error::Error for WasmUtxoError {}
+impl fmt::Display for WasmUtxoError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            WasmMiniscriptError::StringError(s) => write!(f, "{}", s),
+            WasmUtxoError::StringError(s) => write!(f, "{}", s),
         }
     }
 }
 
-impl From<&str> for WasmMiniscriptError {
+impl From<&str> for WasmUtxoError {
     fn from(s: &str) -> Self {
-        WasmMiniscriptError::StringError(s.to_string())
+        WasmUtxoError::StringError(s.to_string())
     }
 }
 
-impl From<String> for WasmMiniscriptError {
+impl From<String> for WasmUtxoError {
     fn from(s: String) -> Self {
-        WasmMiniscriptError::StringError(s)
+        WasmUtxoError::StringError(s)
     }
 }
 
-impl From<miniscript::Error> for WasmMiniscriptError {
+impl From<miniscript::Error> for WasmUtxoError {
     fn from(err: miniscript::Error) -> Self {
-        WasmMiniscriptError::StringError(err.to_string())
+        WasmUtxoError::StringError(err.to_string())
     }
 }
 
-impl From<miniscript::descriptor::ConversionError> for WasmMiniscriptError {
+impl From<miniscript::descriptor::ConversionError> for WasmUtxoError {
     fn from(err: miniscript::descriptor::ConversionError) -> Self {
-        WasmMiniscriptError::StringError(err.to_string())
+        WasmUtxoError::StringError(err.to_string())
     }
 }
 
-impl WasmMiniscriptError {
-    pub fn new(s: &str) -> WasmMiniscriptError {
-        WasmMiniscriptError::StringError(s.to_string())
+impl WasmUtxoError {
+    pub fn new(s: &str) -> WasmUtxoError {
+        WasmUtxoError::StringError(s.to_string())
     }
 }
 
-impl From<crate::address::AddressError> for WasmMiniscriptError {
+impl From<crate::address::AddressError> for WasmUtxoError {
     fn from(err: crate::address::AddressError) -> Self {
-        WasmMiniscriptError::StringError(err.to_string())
+        WasmUtxoError::StringError(err.to_string())
     }
 }

--- a/packages/wasm-utxo/src/fixed_script_wallet/bip32interface.rs
+++ b/packages/wasm-utxo/src/fixed_script_wallet/bip32interface.rs
@@ -1,11 +1,11 @@
 use std::str::FromStr;
 
 use crate::bitcoin::bip32::Xpub;
-use crate::error::WasmMiniscriptError;
+use crate::error::WasmUtxoError;
 use crate::try_from_js_value::{get_buffer_field, get_field, get_nested_field};
 use wasm_bindgen::JsValue;
 
-fn try_xpub_from_bip32_properties(bip32_key: &JsValue) -> Result<Xpub, WasmMiniscriptError> {
+fn try_xpub_from_bip32_properties(bip32_key: &JsValue) -> Result<Xpub, WasmUtxoError> {
     // Extract properties using helper functions
     let version: u32 = get_nested_field(bip32_key, "network.bip32.public")?;
     let depth: u8 = get_field(bip32_key, "depth")?;
@@ -24,33 +24,32 @@ fn try_xpub_from_bip32_properties(bip32_key: &JsValue) -> Result<Xpub, WasmMinis
     data.extend_from_slice(&public_key_bytes); // 33 bytes: public key
 
     // Use the Xpub::decode method which properly handles network detection and constructs the Xpub
-    Xpub::decode(&data)
-        .map_err(|e| WasmMiniscriptError::new(&format!("Failed to decode xpub: {}", e)))
+    Xpub::decode(&data).map_err(|e| WasmUtxoError::new(&format!("Failed to decode xpub: {}", e)))
 }
 
-fn xpub_from_base58_method(bip32_key: &JsValue) -> Result<Xpub, WasmMiniscriptError> {
+fn xpub_from_base58_method(bip32_key: &JsValue) -> Result<Xpub, WasmUtxoError> {
     // Fallback: Call toBase58() method on BIP32Interface
     let to_base58 = js_sys::Reflect::get(bip32_key, &JsValue::from_str("toBase58"))
-        .map_err(|_| WasmMiniscriptError::new("Failed to get 'toBase58' method"))?;
+        .map_err(|_| WasmUtxoError::new("Failed to get 'toBase58' method"))?;
 
     if !to_base58.is_function() {
-        return Err(WasmMiniscriptError::new("'toBase58' is not a function"));
+        return Err(WasmUtxoError::new("'toBase58' is not a function"));
     }
 
     let to_base58_fn = js_sys::Function::from(to_base58);
     let xpub_str = to_base58_fn
         .call0(bip32_key)
-        .map_err(|_| WasmMiniscriptError::new("Failed to call 'toBase58'"))?;
+        .map_err(|_| WasmUtxoError::new("Failed to call 'toBase58'"))?;
 
     let xpub_string = xpub_str
         .as_string()
-        .ok_or_else(|| WasmMiniscriptError::new("'toBase58' did not return a string"))?;
+        .ok_or_else(|| WasmUtxoError::new("'toBase58' did not return a string"))?;
 
     Xpub::from_str(&xpub_string)
-        .map_err(|e| WasmMiniscriptError::new(&format!("Failed to parse xpub: {}", e)))
+        .map_err(|e| WasmUtxoError::new(&format!("Failed to parse xpub: {}", e)))
 }
 
-pub fn xpub_from_bip32interface(bip32_key: &JsValue) -> Result<Xpub, WasmMiniscriptError> {
+pub fn xpub_from_bip32interface(bip32_key: &JsValue) -> Result<Xpub, WasmUtxoError> {
     // Try to construct from properties first, fall back to toBase58() if that fails
     try_xpub_from_bip32_properties(bip32_key).or_else(|_| xpub_from_base58_method(bip32_key))
 }

--- a/packages/wasm-utxo/src/fixed_script_wallet/mod.rs
+++ b/packages/wasm-utxo/src/fixed_script_wallet/mod.rs
@@ -13,7 +13,7 @@ pub use wallet_scripts::*;
 use wasm_bindgen::prelude::*;
 
 use crate::address::networks::AddressFormat;
-use crate::error::WasmMiniscriptError;
+use crate::error::WasmUtxoError;
 use crate::try_from_js_value::TryFromJsValue;
 use crate::utxolib_compat::UtxolibNetwork;
 
@@ -28,10 +28,10 @@ impl FixedScriptWalletNamespace {
         chain: u32,
         index: u32,
         network: JsValue,
-    ) -> Result<Vec<u8>, WasmMiniscriptError> {
+    ) -> Result<Vec<u8>, WasmUtxoError> {
         let network = UtxolibNetwork::try_from_js_value(&network)?;
         let chain = Chain::try_from(chain)
-            .map_err(|e| WasmMiniscriptError::new(&format!("Invalid chain: {}", e)))?;
+            .map_err(|e| WasmUtxoError::new(&format!("Invalid chain: {}", e)))?;
 
         let wallet_keys = RootWalletKeys::from_jsvalue(&keys)?;
         let scripts = WalletScripts::from_wallet_keys(
@@ -50,11 +50,11 @@ impl FixedScriptWalletNamespace {
         index: u32,
         network: JsValue,
         address_format: Option<String>,
-    ) -> Result<String, WasmMiniscriptError> {
+    ) -> Result<String, WasmUtxoError> {
         let network = UtxolibNetwork::try_from_js_value(&network)?;
         let wallet_keys = RootWalletKeys::from_jsvalue(&keys)?;
         let chain = Chain::try_from(chain)
-            .map_err(|e| WasmMiniscriptError::new(&format!("Invalid chain: {}", e)))?;
+            .map_err(|e| WasmUtxoError::new(&format!("Invalid chain: {}", e)))?;
         let scripts = WalletScripts::from_wallet_keys(
             &wallet_keys,
             chain,
@@ -63,13 +63,13 @@ impl FixedScriptWalletNamespace {
         )?;
         let script = scripts.output_script();
         let address_format = AddressFormat::from_optional_str(address_format.as_deref())
-            .map_err(|e| WasmMiniscriptError::new(&format!("Invalid address format: {}", e)))?;
+            .map_err(|e| WasmUtxoError::new(&format!("Invalid address format: {}", e)))?;
         let address = crate::address::utxolib_compat::from_output_script_with_network(
             &script,
             &network,
             address_format,
         )
-        .map_err(|e| WasmMiniscriptError::new(&format!("Failed to generate address: {}", e)))?;
+        .map_err(|e| WasmUtxoError::new(&format!("Failed to generate address: {}", e)))?;
         Ok(address.to_string())
     }
 }

--- a/packages/wasm-utxo/src/fixed_script_wallet/wallet_scripts/mod.rs
+++ b/packages/wasm-utxo/src/fixed_script_wallet/wallet_scripts/mod.rs
@@ -15,7 +15,7 @@ pub use singlesig::{build_p2pk_script, ScriptP2shP2pk};
 use crate::address::networks::OutputScriptSupport;
 use crate::bitcoin::bip32::{ChildNumber, DerivationPath};
 use crate::bitcoin::ScriptBuf;
-use crate::error::WasmMiniscriptError;
+use crate::error::WasmUtxoError;
 use crate::fixed_script_wallet::wallet_keys::{to_pub_triple, PubTriple, XpubTriple};
 use crate::RootWalletKeys;
 use std::convert::TryFrom;
@@ -57,7 +57,7 @@ impl WalletScripts {
         keys: &PubTriple,
         chain: Chain,
         script_support: &OutputScriptSupport,
-    ) -> Result<WalletScripts, WasmMiniscriptError> {
+    ) -> Result<WalletScripts, WasmUtxoError> {
         match chain {
             Chain::P2shExternal | Chain::P2shInternal => {
                 script_support.assert_legacy()?;
@@ -97,7 +97,7 @@ impl WalletScripts {
         chain: Chain,
         index: u32,
         script_support: &OutputScriptSupport,
-    ) -> Result<WalletScripts, WasmMiniscriptError> {
+    ) -> Result<WalletScripts, WasmUtxoError> {
         let derived_keys = wallet_keys
             .derive_for_chain_and_index(chain as u32, index)
             .unwrap();

--- a/packages/wasm-utxo/src/miniscript.rs
+++ b/packages/wasm-utxo/src/miniscript.rs
@@ -1,4 +1,4 @@
-use crate::error::WasmMiniscriptError;
+use crate::error::WasmUtxoError;
 use crate::try_into_js_value::TryIntoJsValue;
 use miniscript::bitcoin::{PublicKey, XOnlyPublicKey};
 use miniscript::{bitcoin, Legacy, Miniscript, Segwitv0, Tap};
@@ -31,7 +31,7 @@ pub struct WrapMiniscript(WrapMiniscriptEnum);
 #[wasm_bindgen]
 impl WrapMiniscript {
     #[wasm_bindgen(js_name = node)]
-    pub fn node(&self) -> Result<JsValue, WasmMiniscriptError> {
+    pub fn node(&self) -> Result<JsValue, WasmUtxoError> {
         unwrap_apply!(&self.0, |ms| ms.try_to_js_value())
     }
 
@@ -47,29 +47,23 @@ impl WrapMiniscript {
     }
 
     #[wasm_bindgen(js_name = toAsmString)]
-    pub fn to_asm_string(&self) -> Result<String, WasmMiniscriptError> {
+    pub fn to_asm_string(&self) -> Result<String, WasmUtxoError> {
         unwrap_apply!(&self.0, |ms| Ok(ms.encode().to_asm_string()))
     }
 
     #[wasm_bindgen(js_name = fromString, skip_typescript)]
-    pub fn from_string(
-        script: &str,
-        context_type: &str,
-    ) -> Result<WrapMiniscript, WasmMiniscriptError> {
+    pub fn from_string(script: &str, context_type: &str) -> Result<WrapMiniscript, WasmUtxoError> {
         match context_type {
             "tap" => Ok(WrapMiniscript::from(
-                Miniscript::<XOnlyPublicKey, Tap>::from_str(script)
-                    .map_err(WasmMiniscriptError::from)?,
+                Miniscript::<XOnlyPublicKey, Tap>::from_str(script).map_err(WasmUtxoError::from)?,
             )),
             "segwitv0" => Ok(WrapMiniscript::from(
-                Miniscript::<PublicKey, Segwitv0>::from_str(script)
-                    .map_err(WasmMiniscriptError::from)?,
+                Miniscript::<PublicKey, Segwitv0>::from_str(script).map_err(WasmUtxoError::from)?,
             )),
             "legacy" => Ok(WrapMiniscript::from(
-                Miniscript::<PublicKey, Legacy>::from_str(script)
-                    .map_err(WasmMiniscriptError::from)?,
+                Miniscript::<PublicKey, Legacy>::from_str(script).map_err(WasmUtxoError::from)?,
             )),
-            _ => Err(WasmMiniscriptError::new("Invalid context type")),
+            _ => Err(WasmUtxoError::new("Invalid context type")),
         }
     }
 
@@ -77,22 +71,19 @@ impl WrapMiniscript {
     pub fn from_bitcoin_script(
         script: &[u8],
         context_type: &str,
-    ) -> Result<WrapMiniscript, WasmMiniscriptError> {
+    ) -> Result<WrapMiniscript, WasmUtxoError> {
         let script = bitcoin::Script::from_bytes(script);
         match context_type {
             "tap" => Ok(WrapMiniscript::from(
-                Miniscript::<XOnlyPublicKey, Tap>::parse(script)
-                    .map_err(WasmMiniscriptError::from)?,
+                Miniscript::<XOnlyPublicKey, Tap>::parse(script).map_err(WasmUtxoError::from)?,
             )),
             "segwitv0" => Ok(WrapMiniscript::from(
-                Miniscript::<PublicKey, Segwitv0>::parse(script)
-                    .map_err(WasmMiniscriptError::from)?,
+                Miniscript::<PublicKey, Segwitv0>::parse(script).map_err(WasmUtxoError::from)?,
             )),
             "legacy" => Ok(WrapMiniscript::from(
-                Miniscript::<PublicKey, Legacy>::parse(script)
-                    .map_err(WasmMiniscriptError::from)?,
+                Miniscript::<PublicKey, Legacy>::parse(script).map_err(WasmUtxoError::from)?,
             )),
-            _ => Err(WasmMiniscriptError::new("Invalid context type")),
+            _ => Err(WasmUtxoError::new("Invalid context type")),
         }
     }
 }

--- a/packages/wasm-utxo/src/psbt.rs
+++ b/packages/wasm-utxo/src/psbt.rs
@@ -1,5 +1,5 @@
 use crate::descriptor::WrapDescriptorEnum;
-use crate::error::WasmMiniscriptError;
+use crate::error::WasmUtxoError;
 use crate::try_into_js_value::TryIntoJsValue;
 use crate::WrapDescriptor;
 use miniscript::bitcoin::bip32::Fingerprint;
@@ -132,36 +132,35 @@ impl WrapPsbt {
     }
 
     #[wasm_bindgen(js_name = signWithXprv)]
-    pub fn sign_with_xprv(&mut self, xprv: String) -> Result<JsValue, WasmMiniscriptError> {
-        let key =
-            bip32::Xpriv::from_str(&xprv).map_err(|_| WasmMiniscriptError::new("Invalid xprv"))?;
+    pub fn sign_with_xprv(&mut self, xprv: String) -> Result<JsValue, WasmUtxoError> {
+        let key = bip32::Xpriv::from_str(&xprv).map_err(|_| WasmUtxoError::new("Invalid xprv"))?;
         self.0
             .sign(&key, &Secp256k1::new())
             .map_err(|(_, errors)| {
-                WasmMiniscriptError::new(&format!("{} errors: {:?}", errors.len(), errors))
+                WasmUtxoError::new(&format!("{} errors: {:?}", errors.len(), errors))
             })
             .and_then(|r| r.try_to_js_value())
     }
 
     #[wasm_bindgen(js_name = signWithPrv)]
-    pub fn sign_with_prv(&mut self, prv: Vec<u8>) -> Result<JsValue, WasmMiniscriptError> {
+    pub fn sign_with_prv(&mut self, prv: Vec<u8>) -> Result<JsValue, WasmUtxoError> {
         let privkey = PrivateKey::from_slice(&prv, miniscript::bitcoin::network::Network::Bitcoin)
-            .map_err(|_| WasmMiniscriptError::new("Invalid private key"))?;
+            .map_err(|_| WasmUtxoError::new("Invalid private key"))?;
         let secp = Secp256k1::new();
         self.0
             .sign(&SingleKeySigner::from_privkey(privkey, &secp), &secp)
             .map_err(|(_r, errors)| {
-                WasmMiniscriptError::new(&format!("{} errors: {:?}", errors.len(), errors))
+                WasmUtxoError::new(&format!("{} errors: {:?}", errors.len(), errors))
             })
             .and_then(|r| r.try_to_js_value())
     }
 
     #[wasm_bindgen(js_name = finalize)]
-    pub fn finalize_mut(&mut self) -> Result<(), WasmMiniscriptError> {
+    pub fn finalize_mut(&mut self) -> Result<(), WasmUtxoError> {
         self.0
             .finalize_mut(&Secp256k1::verification_only())
             .map_err(|vec_err| {
-                WasmMiniscriptError::new(&format!("{} errors: {:?}", vec_err.len(), vec_err))
+                WasmUtxoError::new(&format!("{} errors: {:?}", vec_err.len(), vec_err))
             })
     }
 }

--- a/packages/wasm-utxo/src/try_into_js_value.rs
+++ b/packages/wasm-utxo/src/try_into_js_value.rs
@@ -1,4 +1,4 @@
-use crate::error::WasmMiniscriptError;
+use crate::error::WasmUtxoError;
 use js_sys::Array;
 use miniscript::bitcoin::hashes::{hash160, ripemd160};
 use miniscript::bitcoin::psbt::{SigningKeys, SigningKeysMap};
@@ -12,7 +12,7 @@ use std::sync::Arc;
 use wasm_bindgen::JsValue;
 
 pub(crate) trait TryIntoJsValue {
-    fn try_to_js_value(&self) -> Result<JsValue, WasmMiniscriptError>;
+    fn try_to_js_value(&self) -> Result<JsValue, WasmUtxoError>;
 }
 
 macro_rules! js_obj {
@@ -20,9 +20,9 @@ macro_rules! js_obj {
         let obj = js_sys::Object::new();
         $(
             js_sys::Reflect::set(&obj, &$key.into(), &$value.try_to_js_value()?.into())
-                .map_err(|_| WasmMiniscriptError::new("Failed to set object property"))?;
+                .map_err(|_| WasmUtxoError::new("Failed to set object property"))?;
         )*
-        Ok(Into::<JsValue>::into(obj)) as Result<JsValue, WasmMiniscriptError>
+        Ok(Into::<JsValue>::into(obj)) as Result<JsValue, WasmUtxoError>
     }};
 }
 
@@ -36,33 +36,33 @@ macro_rules! js_arr {
     }};
 }
 
-impl From<WasmMiniscriptError> for JsValue {
-    fn from(err: WasmMiniscriptError) -> Self {
+impl From<WasmUtxoError> for JsValue {
+    fn from(err: WasmUtxoError) -> Self {
         js_sys::Error::new(&err.to_string()).into()
     }
 }
 
 impl TryIntoJsValue for JsValue {
-    fn try_to_js_value(&self) -> Result<JsValue, WasmMiniscriptError> {
+    fn try_to_js_value(&self) -> Result<JsValue, WasmUtxoError> {
         Ok(self.clone())
     }
 }
 
 impl<T: TryIntoJsValue> TryIntoJsValue for Arc<T> {
-    fn try_to_js_value(&self) -> Result<JsValue, WasmMiniscriptError> {
+    fn try_to_js_value(&self) -> Result<JsValue, WasmUtxoError> {
         self.as_ref().try_to_js_value()
     }
 }
 
 impl TryIntoJsValue for String {
-    fn try_to_js_value(&self) -> Result<JsValue, WasmMiniscriptError> {
+    fn try_to_js_value(&self) -> Result<JsValue, WasmUtxoError> {
         Ok(JsValue::from_str(self))
     }
 }
 
 // array of TryToJsValue
 impl<T: TryIntoJsValue> TryIntoJsValue for Vec<T> {
-    fn try_to_js_value(&self) -> Result<JsValue, WasmMiniscriptError> {
+    fn try_to_js_value(&self) -> Result<JsValue, WasmUtxoError> {
         let arr = Array::new();
         for item in self.iter() {
             arr.push(&item.try_to_js_value()?);
@@ -72,7 +72,7 @@ impl<T: TryIntoJsValue> TryIntoJsValue for Vec<T> {
 }
 
 impl<T: TryIntoJsValue> TryIntoJsValue for Option<T> {
-    fn try_to_js_value(&self) -> Result<JsValue, WasmMiniscriptError> {
+    fn try_to_js_value(&self) -> Result<JsValue, WasmUtxoError> {
         match self {
             Some(v) => v.try_to_js_value(),
             None => Ok(JsValue::NULL),
@@ -81,55 +81,55 @@ impl<T: TryIntoJsValue> TryIntoJsValue for Option<T> {
 }
 
 impl TryIntoJsValue for XOnlyPublicKey {
-    fn try_to_js_value(&self) -> Result<JsValue, WasmMiniscriptError> {
+    fn try_to_js_value(&self) -> Result<JsValue, WasmUtxoError> {
         Ok(JsValue::from_str(&self.to_string()))
     }
 }
 
 impl TryIntoJsValue for PublicKey {
-    fn try_to_js_value(&self) -> Result<JsValue, WasmMiniscriptError> {
+    fn try_to_js_value(&self) -> Result<JsValue, WasmUtxoError> {
         Ok(JsValue::from_str(&self.to_string()))
     }
 }
 
 impl TryIntoJsValue for AbsLockTime {
-    fn try_to_js_value(&self) -> Result<JsValue, WasmMiniscriptError> {
+    fn try_to_js_value(&self) -> Result<JsValue, WasmUtxoError> {
         Ok(JsValue::from_f64(self.to_consensus_u32() as f64))
     }
 }
 
 impl TryIntoJsValue for RelLockTime {
-    fn try_to_js_value(&self) -> Result<JsValue, WasmMiniscriptError> {
+    fn try_to_js_value(&self) -> Result<JsValue, WasmUtxoError> {
         Ok(JsValue::from_f64(self.to_consensus_u32() as f64))
     }
 }
 
 impl TryIntoJsValue for ripemd160::Hash {
-    fn try_to_js_value(&self) -> Result<JsValue, WasmMiniscriptError> {
+    fn try_to_js_value(&self) -> Result<JsValue, WasmUtxoError> {
         Ok(JsValue::from_str(&self.to_string()))
     }
 }
 
 impl TryIntoJsValue for hash160::Hash {
-    fn try_to_js_value(&self) -> Result<JsValue, WasmMiniscriptError> {
+    fn try_to_js_value(&self) -> Result<JsValue, WasmUtxoError> {
         Ok(JsValue::from_str(&self.to_string()))
     }
 }
 
 impl TryIntoJsValue for hash256::Hash {
-    fn try_to_js_value(&self) -> Result<JsValue, WasmMiniscriptError> {
+    fn try_to_js_value(&self) -> Result<JsValue, WasmUtxoError> {
         Ok(JsValue::from_str(&self.to_string()))
     }
 }
 
 impl TryIntoJsValue for usize {
-    fn try_to_js_value(&self) -> Result<JsValue, WasmMiniscriptError> {
+    fn try_to_js_value(&self) -> Result<JsValue, WasmUtxoError> {
         Ok(JsValue::from_f64(*self as f64))
     }
 }
 
 impl<T: TryIntoJsValue, const MAX: usize> TryIntoJsValue for Threshold<T, MAX> {
-    fn try_to_js_value(&self) -> Result<JsValue, WasmMiniscriptError> {
+    fn try_to_js_value(&self) -> Result<JsValue, WasmUtxoError> {
         let arr = Array::new();
         arr.push(&self.k().try_to_js_value()?);
         for v in self.iter() {
@@ -142,13 +142,13 @@ impl<T: TryIntoJsValue, const MAX: usize> TryIntoJsValue for Threshold<T, MAX> {
 impl<Pk: MiniscriptKey + TryIntoJsValue, Ctx: ScriptContext> TryIntoJsValue
     for Miniscript<Pk, Ctx>
 {
-    fn try_to_js_value(&self) -> Result<JsValue, WasmMiniscriptError> {
+    fn try_to_js_value(&self) -> Result<JsValue, WasmUtxoError> {
         self.node.try_to_js_value()
     }
 }
 
 impl<Pk: MiniscriptKey + TryIntoJsValue, Ctx: ScriptContext> TryIntoJsValue for Terminal<Pk, Ctx> {
-    fn try_to_js_value(&self) -> Result<JsValue, WasmMiniscriptError> {
+    fn try_to_js_value(&self) -> Result<JsValue, WasmUtxoError> {
         match self {
             Terminal::True => Ok(JsValue::TRUE),
             Terminal::False => Ok(JsValue::FALSE),
@@ -186,7 +186,7 @@ impl<Pk: MiniscriptKey + TryIntoJsValue, Ctx: ScriptContext> TryIntoJsValue for 
 impl<Pk: MiniscriptKey + TryIntoJsValue, Ctx: ScriptContext> TryIntoJsValue
     for SortedMultiVec<Pk, Ctx>
 {
-    fn try_to_js_value(&self) -> Result<JsValue, WasmMiniscriptError> {
+    fn try_to_js_value(&self) -> Result<JsValue, WasmUtxoError> {
         js_obj!(
             "k" => self.k(),
             "n" => self.n(),
@@ -196,7 +196,7 @@ impl<Pk: MiniscriptKey + TryIntoJsValue, Ctx: ScriptContext> TryIntoJsValue
 }
 
 impl<Pk: MiniscriptKey + TryIntoJsValue> TryIntoJsValue for ShInner<Pk> {
-    fn try_to_js_value(&self) -> Result<JsValue, WasmMiniscriptError> {
+    fn try_to_js_value(&self) -> Result<JsValue, WasmUtxoError> {
         match self {
             ShInner::Wsh(v) => js_obj!("Wsh" => v.as_inner()),
             ShInner::Wpkh(v) => js_obj!("Wpkh" => v.as_inner()),
@@ -207,7 +207,7 @@ impl<Pk: MiniscriptKey + TryIntoJsValue> TryIntoJsValue for ShInner<Pk> {
 }
 
 impl<Pk: MiniscriptKey + TryIntoJsValue> TryIntoJsValue for WshInner<Pk> {
-    fn try_to_js_value(&self) -> Result<JsValue, WasmMiniscriptError> {
+    fn try_to_js_value(&self) -> Result<JsValue, WasmUtxoError> {
         match self {
             WshInner::SortedMulti(v) => js_obj!("SortedMulti" => v),
             WshInner::Ms(v) => js_obj!("Ms" => v),
@@ -216,13 +216,13 @@ impl<Pk: MiniscriptKey + TryIntoJsValue> TryIntoJsValue for WshInner<Pk> {
 }
 
 impl<Pk: MiniscriptKey + TryIntoJsValue> TryIntoJsValue for Tr<Pk> {
-    fn try_to_js_value(&self) -> Result<JsValue, WasmMiniscriptError> {
+    fn try_to_js_value(&self) -> Result<JsValue, WasmUtxoError> {
         Ok(js_arr!(self.internal_key(), self.tap_tree()))
     }
 }
 
 impl<Pk: MiniscriptKey + TryIntoJsValue> TryIntoJsValue for TapTree<Pk> {
-    fn try_to_js_value(&self) -> Result<JsValue, WasmMiniscriptError> {
+    fn try_to_js_value(&self) -> Result<JsValue, WasmUtxoError> {
         match self {
             TapTree::Tree { left, right, .. } => js_obj!("Tree" => js_arr!(left, right)),
             TapTree::Leaf(ms) => ms.try_to_js_value(),
@@ -231,7 +231,7 @@ impl<Pk: MiniscriptKey + TryIntoJsValue> TryIntoJsValue for TapTree<Pk> {
 }
 
 impl TryIntoJsValue for DescriptorPublicKey {
-    fn try_to_js_value(&self) -> Result<JsValue, WasmMiniscriptError> {
+    fn try_to_js_value(&self) -> Result<JsValue, WasmUtxoError> {
         match self {
             DescriptorPublicKey::Single(_v) => js_obj!("Single" => self.to_string()),
             DescriptorPublicKey::XPub(_v) => js_obj!("XPub" => self.to_string()),
@@ -241,13 +241,13 @@ impl TryIntoJsValue for DescriptorPublicKey {
 }
 
 impl TryIntoJsValue for DefiniteDescriptorKey {
-    fn try_to_js_value(&self) -> Result<JsValue, WasmMiniscriptError> {
+    fn try_to_js_value(&self) -> Result<JsValue, WasmUtxoError> {
         self.as_descriptor_public_key().try_to_js_value()
     }
 }
 
 impl<Pk: MiniscriptKey + TryIntoJsValue> TryIntoJsValue for Descriptor<Pk> {
-    fn try_to_js_value(&self) -> Result<JsValue, WasmMiniscriptError> {
+    fn try_to_js_value(&self) -> Result<JsValue, WasmUtxoError> {
         match self {
             Descriptor::Bare(v) => js_obj!("Bare" => v.as_inner()),
             Descriptor::Pkh(v) => js_obj!("Pkh" => v.as_inner()),
@@ -260,14 +260,14 @@ impl<Pk: MiniscriptKey + TryIntoJsValue> TryIntoJsValue for Descriptor<Pk> {
 }
 
 impl TryIntoJsValue for DescriptorType {
-    fn try_to_js_value(&self) -> Result<JsValue, WasmMiniscriptError> {
+    fn try_to_js_value(&self) -> Result<JsValue, WasmUtxoError> {
         let str_from_enum = format!("{:?}", self);
         Ok(JsValue::from_str(&str_from_enum))
     }
 }
 
 impl TryIntoJsValue for SigningKeys {
-    fn try_to_js_value(&self) -> Result<JsValue, WasmMiniscriptError> {
+    fn try_to_js_value(&self) -> Result<JsValue, WasmUtxoError> {
         match self {
             SigningKeys::Ecdsa(v) => {
                 js_obj!("Ecdsa" => v)
@@ -280,11 +280,11 @@ impl TryIntoJsValue for SigningKeys {
 }
 
 impl TryIntoJsValue for SigningKeysMap {
-    fn try_to_js_value(&self) -> Result<JsValue, WasmMiniscriptError> {
+    fn try_to_js_value(&self) -> Result<JsValue, WasmUtxoError> {
         let obj = js_sys::Object::new();
         for (key, value) in self.iter() {
             js_sys::Reflect::set(&obj, &key.to_string().into(), &value.try_to_js_value()?)
-                .map_err(|_| WasmMiniscriptError::new("Failed to set object property"))?;
+                .map_err(|_| WasmUtxoError::new("Failed to set object property"))?;
         }
         Ok(obj.into())
     }


### PR DESCRIPTION

This change renames the main error type to better align with the package name.
The previous name was a remnant from when this was primarily a miniscript
wrapper, but now it's a more general UTXO handling library.

BTC-2652