### PR TITLE
feat(wasm-utxo): implement MuSig2 finalization support for PSBT handling

### DIFF
--- a/packages/wasm-utxo/Cargo.lock
+++ b/packages/wasm-utxo/Cargo.lock
@@ -857,6 +857,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pastey"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
+
+[[package]]
 name = "pathdiff"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1560,6 +1566,7 @@ dependencies = [
  "js-sys",
  "miniscript",
  "musig2",
+ "pastey",
  "rstest",
  "serde",
  "serde_json",

--- a/packages/wasm-utxo/Cargo.toml
+++ b/packages/wasm-utxo/Cargo.toml
@@ -20,6 +20,7 @@ miniscript = { git = "https://github.com/BitGo/rust-miniscript", tag = "miniscri
 bech32 = "0.11"
 musig2 = { version = "0.3.1", default-features = false, features = ["k256"] }
 getrandom = { version = "0.2", features = ["js"] }
+pastey = "0.1"
 
 [dev-dependencies]
 base64 = "0.22.1"
@@ -28,6 +29,7 @@ serde_json = "1.0"
 hex = "0.4"
 wasm-bindgen-test = "0.3"
 rstest = "0.26.1"
+pastey = "0.1"
 
 [profile.release]
 # this is required to make webpack happy

--- a/packages/wasm-utxo/cli/test/fixtures/psbt_bitcoin_fullsigned.txt
+++ b/packages/wasm-utxo/cli/test/fixtures/psbt_bitcoin_fullsigned.txt
@@ -182,31 +182,28 @@ psbt: None
 │  │  ├─ sighash_type: 0u32
 │  │  ├─ sighash_type: SIGHASH_DEFAULT
 │  │  └─ proprietary: 5u64
-│  │     ├─ key: None
-│  │     │  ├─ prefix: BITGO
-│  │     │  ├─ subtype: 1u8
-│  │     │  ├─ key_data: 15c5815026f6a54b10194fc6980f1866a02d9ec128533c7997cdb4289bf3ef16eb5ad29a85aed24de2880e774caaf624f9cb1be09c67ed4aefbb9b7bc12ddf1a (64 bytes)
-│  │     │  └─ value: 021d978a17486ff9e47c82990269e531fc63981419d4ce73ee8bd2c99661c53953020fdea69e40a3adef3cdc7fa6f3af02f4c9d9e3254503c96a6a2b4aa66e778171 (66 bytes)
-│  │     ├─ key: None
-│  │     │  ├─ prefix: BITGO
-│  │     │  ├─ subtype: 2u8
-│  │     │  ├─ key_data: 020fdea69e40a3adef3cdc7fa6f3af02f4c9d9e3254503c96a6a2b4aa66e77817115c5815026f6a54b10194fc6980f1866a02d9ec128533c7997cdb4289bf3ef16 (65 bytes)
-│  │     │  └─ value: 02826949740dff45d408b1f19d94c720f53411e02c525b28ab3c593b6b530fe0370374b8a0ffcaaaee6b772dac5f7c23ef33670b32ec77c6d41efb3c36df2165a094 (66 bytes)
-│  │     ├─ key: None
-│  │     │  ├─ prefix: BITGO
-│  │     │  ├─ subtype: 2u8
-│  │     │  ├─ key_data: 021d978a17486ff9e47c82990269e531fc63981419d4ce73ee8bd2c99661c5395315c5815026f6a54b10194fc6980f1866a02d9ec128533c7997cdb4289bf3ef16 (65 bytes)
-│  │     │  └─ value: 03a4aaf46f3a0bc39a73855fa875b2f2f04bdb06235afbaedf857b593dddc63cb402cdb7f1a93ec526282198d834423371757e8f43932d03b9f43c3f7378300ae508 (66 bytes)
-│  │     ├─ key: None
-│  │     │  ├─ prefix: BITGO
-│  │     │  ├─ subtype: 3u8
-│  │     │  ├─ key_data: 020fdea69e40a3adef3cdc7fa6f3af02f4c9d9e3254503c96a6a2b4aa66e77817115c5815026f6a54b10194fc6980f1866a02d9ec128533c7997cdb4289bf3ef16 (65 bytes)
-│  │     │  └─ value: fbdc39c3b8ffca4e6caf3298fa1a4be546b99163c2f21bd374d2254ec5b3c0f4 (32 bytes)
-│  │     └─ key: None
-│  │        ├─ prefix: BITGO
-│  │        ├─ subtype: 3u8
-│  │        ├─ key_data: 021d978a17486ff9e47c82990269e531fc63981419d4ce73ee8bd2c99661c5395315c5815026f6a54b10194fc6980f1866a02d9ec128533c7997cdb4289bf3ef16 (65 bytes)
-│  │        └─ value: 1cd8a0c0598b0d88f889fdf9a3140f8f088e2187803a2faaee3f13c0163eb76c (32 bytes)
+│  │     ├─ musig2_participants: None
+│  │     │  ├─ tap_output_key: 15c5815026f6a54b10194fc6980f1866a02d9ec128533c7997cdb4289bf3ef16 (32 bytes)
+│  │     │  ├─ tap_internal_key: eb5ad29a85aed24de2880e774caaf624f9cb1be09c67ed4aefbb9b7bc12ddf1a (32 bytes)
+│  │     │  └─ participant_pub_keys: 2u64
+│  │     │     ├─ participant_0: 021d978a17486ff9e47c82990269e531fc63981419d4ce73ee8bd2c99661c53953 (33 bytes)
+│  │     │     └─ participant_1: 020fdea69e40a3adef3cdc7fa6f3af02f4c9d9e3254503c96a6a2b4aa66e778171 (33 bytes)
+│  │     ├─ musig2_pub_nonce: None
+│  │     │  ├─ participant_pub_key: 020fdea69e40a3adef3cdc7fa6f3af02f4c9d9e3254503c96a6a2b4aa66e778171 (33 bytes)
+│  │     │  ├─ tap_output_key: 15c5815026f6a54b10194fc6980f1866a02d9ec128533c7997cdb4289bf3ef16 (32 bytes)
+│  │     │  └─ pub_nonce: 02826949740dff45d408b1f19d94c720f53411e02c525b28ab3c593b6b530fe0370374b8a0ffcaaaee6b772dac5f7c23ef33670b32ec77c6d41efb3c36df2165a094 (66 bytes)
+│  │     ├─ musig2_pub_nonce: None
+│  │     │  ├─ participant_pub_key: 021d978a17486ff9e47c82990269e531fc63981419d4ce73ee8bd2c99661c53953 (33 bytes)
+│  │     │  ├─ tap_output_key: 15c5815026f6a54b10194fc6980f1866a02d9ec128533c7997cdb4289bf3ef16 (32 bytes)
+│  │     │  └─ pub_nonce: 03a4aaf46f3a0bc39a73855fa875b2f2f04bdb06235afbaedf857b593dddc63cb402cdb7f1a93ec526282198d834423371757e8f43932d03b9f43c3f7378300ae508 (66 bytes)
+│  │     ├─ musig2_partial_sig: None
+│  │     │  ├─ participant_pub_key: 020fdea69e40a3adef3cdc7fa6f3af02f4c9d9e3254503c96a6a2b4aa66e778171 (33 bytes)
+│  │     │  ├─ tap_output_key: 15c5815026f6a54b10194fc6980f1866a02d9ec128533c7997cdb4289bf3ef16 (32 bytes)
+│  │     │  └─ partial_sig: fbdc39c3b8ffca4e6caf3298fa1a4be546b99163c2f21bd374d2254ec5b3c0f4 (32 bytes)
+│  │     └─ musig2_partial_sig: None
+│  │        ├─ participant_pub_key: 021d978a17486ff9e47c82990269e531fc63981419d4ce73ee8bd2c99661c53953 (33 bytes)
+│  │        ├─ tap_output_key: 15c5815026f6a54b10194fc6980f1866a02d9ec128533c7997cdb4289bf3ef16 (32 bytes)
+│  │        └─ partial_sig: 1cd8a0c0598b0d88f889fdf9a3140f8f088e2187803a2faaee3f13c0163eb76c (32 bytes)
 │  └─ input_6: None
 │     ├─ non_witness_utxo: 97441d99a8d66f124ab3c9de26b87bd00aeb1547051c842a88165c1b089ee902 (32 bytes)
 │     ├─ redeem_script: 210336ef228ffe9b8efffba052c32d334660dd1f8366cf8fe44ae5aa672b6b629095ac (35 bytes)

--- a/packages/wasm-utxo/deny.toml
+++ b/packages/wasm-utxo/deny.toml
@@ -10,7 +10,16 @@ allow-git = ["https://github.com/BitGo/rust-miniscript"]
 
 # Allow common licenses used in the Rust ecosystem
 [licenses]
-allow = ["MIT", "Apache-2.0", "CC0-1.0", "MITNFA", "Unicode-DFS-2016", "BSD-3-Clause", "Unlicense"]
+allow = [
+    "MIT",
+    "Apache-2.0",
+    "CC0-1.0",
+    "MITNFA",
+    "Unicode-DFS-2016",
+    "Unicode-3.0",
+    "BSD-3-Clause",
+    "Unlicense",
+]
 # Clarify license for unlicensed crate
 [[licenses.clarify]]
 name = "wasm-utxo"

--- a/packages/wasm-utxo/src/fixed_script_wallet/wallet_scripts/mod.rs
+++ b/packages/wasm-utxo/src/fixed_script_wallet/wallet_scripts/mod.rs
@@ -1,10 +1,10 @@
 /// Code relating to script types of BitGo's 2-of-3 multisig wallets.
-mod bitgo_musig;
+pub mod bitgo_musig;
 mod checkmultisig;
 mod checksigverify;
 mod singlesig;
 
-pub use bitgo_musig::{key_agg_bitgo_p2tr_legacy, BitGoMusigError};
+pub use bitgo_musig::BitGoMusigError;
 pub use checkmultisig::{
     build_multisig_script_2_of_3, parse_multisig_script_2_of_3, ScriptP2sh, ScriptP2shP2wsh,
     ScriptP2wsh,


### PR DESCRIPTION
This PR adds MuSig2 finalization support to our PSBT handling in the wasm-utxo
module:

- Add proper parsing for BitGo PSBT extensions including structured parsing
  for Musig2 participants data, public nonces, and partial signatures
  
- Add PSBT finalization support for MuSig2 with new finalize_input, 
  finalize_mut, and finalize methods to BitGoPsbt for proper finalization of 
  P2TR MuSig2 inputs
  
- Export BitGoKeyValue and related constants from the propkv module
  
- Add paste dependency to test dependencies for cleaner macro expansion in
  upcoming MuSig2 implementation

All changes include comprehensive test coverage with fixtures to verify proper
finalization and transaction extraction.

Issue: BTC-2652