### PR TITLE
feat(wasm-utxo): implement partial PSBT signing and improve test infrastructure

### DIFF
--- a/packages/wasm-utxo/src/bitgo_psbt/mod.rs
+++ b/packages/wasm-utxo/src/bitgo_psbt/mod.rs
@@ -385,6 +385,20 @@ mod tests {
         output.script_pubkey.to_hex_string()
     }
 
+    // ensure we can put the first signature (user signature) on an unsigned PSBT
+    fn assert_half_sign(
+        network: Network,
+        tx_format: fixtures::TxFormat,
+        unsigned_bitgo_psbt: &BitGoPsbt,
+        wallet_keys: &RootWalletKeys,
+        input_index: usize,
+        input_fixture: &fixtures::PsbtInputFixture,
+        halfsigned_fixture: &fixtures::PsbtInputFixture,
+    ) -> Result<(), String> {
+        // todo!()
+        Ok(())
+    }
+
     fn assert_full_signed_matches_wallet_scripts(
         network: Network,
         tx_format: fixtures::TxFormat,
@@ -512,6 +526,19 @@ mod tests {
         }
 
         let psbt_input_stages = psbt_input_stages.unwrap();
+
+        assert_half_sign(
+            network,
+            tx_format,
+            &psbt_stages
+                .unsigned
+                .to_bitgo_psbt(network)
+                .expect("Failed to convert to BitGo PSBT"),
+            &psbt_input_stages.wallet_keys,
+            psbt_input_stages.input_index,
+            &psbt_input_stages.input_fixture_unsigned,
+            &psbt_input_stages.input_fixture_halfsigned,
+        )?;
 
         assert_full_signed_matches_wallet_scripts(
             network,

--- a/packages/wasm-utxo/src/bitgo_psbt/mod.rs
+++ b/packages/wasm-utxo/src/bitgo_psbt/mod.rs
@@ -614,9 +614,9 @@ mod tests {
 
         let psbt_input_stages = psbt_input_stages.unwrap();
 
-        if script_type != fixtures::ScriptType::TaprootKeypath
-            && script_type != fixtures::ScriptType::P2trMusig2
-            && script_type != fixtures::ScriptType::P2tr
+        if script_type != fixtures::ScriptType::P2trMusig2TaprootKeypath
+            && script_type != fixtures::ScriptType::P2trMusig2ScriptPath
+            && script_type != fixtures::ScriptType::P2trLegacyScriptPath
         {
             assert_half_sign(
                 &psbt_stages
@@ -651,7 +651,7 @@ mod tests {
         Ok(())
     }
 
-    crate::test_psbt_fixtures!(test_p2sh_script_generation_from_fixture, network, format, {
+    crate::test_psbt_fixtures!(test_p2sh_suite, network, format, {
         test_wallet_script_type(fixtures::ScriptType::P2sh, network, format).unwrap();
     }, ignore: [
         // TODO: sighash support
@@ -661,7 +661,7 @@ mod tests {
         ]);
 
     crate::test_psbt_fixtures!(
-        test_p2sh_p2wsh_script_generation_from_fixture,
+        test_p2sh_p2wsh_suite,
         network,
         format,
         {
@@ -672,7 +672,7 @@ mod tests {
     );
 
     crate::test_psbt_fixtures!(
-        test_p2wsh_script_generation_from_fixture,
+        test_p2wsh_suite,
         network,
         format,
         {
@@ -682,27 +682,24 @@ mod tests {
         ignore: [BitcoinGold]
     );
 
-    crate::test_psbt_fixtures!(test_p2tr_script_generation_from_fixture, network, format, {
-        test_wallet_script_type(fixtures::ScriptType::P2tr, network, format).unwrap();
+    crate::test_psbt_fixtures!(test_p2tr_legacy_script_path_suite, network, format, {
+        test_wallet_script_type(fixtures::ScriptType::P2trLegacyScriptPath, network, format)
+            .unwrap();
     });
 
-    crate::test_psbt_fixtures!(
-        test_p2tr_musig2_script_path_generation_from_fixture,
-        network,
-        format,
-        {
-            test_wallet_script_type(fixtures::ScriptType::P2trMusig2, network, format).unwrap();
-        }
-    );
+    crate::test_psbt_fixtures!(test_p2tr_musig2_script_path_suite, network, format, {
+        test_wallet_script_type(fixtures::ScriptType::P2trMusig2ScriptPath, network, format)
+            .unwrap();
+    });
 
-    crate::test_psbt_fixtures!(
-        test_p2tr_musig2_key_path_spend_script_generation_from_fixture,
-        network,
-        format,
-        {
-            test_wallet_script_type(fixtures::ScriptType::TaprootKeypath, network, format).unwrap();
-        }
-    );
+    crate::test_psbt_fixtures!(test_p2tr_musig2_key_path_suite, network, format, {
+        test_wallet_script_type(
+            fixtures::ScriptType::P2trMusig2TaprootKeypath,
+            network,
+            format,
+        )
+        .unwrap();
+    });
 
     crate::test_psbt_fixtures!(test_extract_transaction, network, format, {
         let fixture = fixtures::load_psbt_fixture_with_format(

--- a/packages/wasm-utxo/src/bitgo_psbt/mod.rs
+++ b/packages/wasm-utxo/src/bitgo_psbt/mod.rs
@@ -390,12 +390,12 @@ mod tests {
         network: Network,
         tx_format: fixtures::TxFormat,
         unsigned_bitgo_psbt: &BitGoPsbt,
-        wallet_keys: &RootWalletKeys,
+        wallet_keys: &fixtures::XprvTriple,
         input_index: usize,
         input_fixture: &fixtures::PsbtInputFixture,
         halfsigned_fixture: &fixtures::PsbtInputFixture,
     ) -> Result<(), String> {
-        // todo!()
+        let user_key = wallet_keys.user_key();
         Ok(())
     }
 
@@ -403,14 +403,14 @@ mod tests {
         network: Network,
         tx_format: fixtures::TxFormat,
         fixture: &fixtures::PsbtFixture,
-        wallet_keys: &RootWalletKeys,
+        wallet_keys: &fixtures::XprvTriple,
         input_index: usize,
         input_fixture: &fixtures::PsbtInputFixture,
     ) -> Result<(), String> {
         let (chain, index) =
             parse_fixture_paths(input_fixture).expect("Failed to parse fixture paths");
         let scripts = WalletScripts::from_wallet_keys(
-            wallet_keys,
+            &wallet_keys.to_root_wallet_keys(),
             chain,
             index,
             &network.output_script_support(),

--- a/packages/wasm-utxo/src/bitgo_psbt/p2tr_musig2_input.rs
+++ b/packages/wasm-utxo/src/bitgo_psbt/p2tr_musig2_input.rs
@@ -689,12 +689,12 @@ mod tests {
             .expect("Failed to load fixture");
 
         let (input_index, input_fixture) = fixture
-            .find_input_with_script_type(ScriptType::TaprootKeypath)
+            .find_input_with_script_type(ScriptType::P2trMusig2TaprootKeypath)
             .expect("Failed to find taprootKeyPathSpend input");
 
         let finalized_input_fixture = if signature_state == SignatureState::Fullsigned {
             let (finalized_input_index, finalized_input_fixture) = fixture
-                .find_finalized_input_with_script_type(ScriptType::TaprootKeypath)
+                .find_finalized_input_with_script_type(ScriptType::P2trMusig2TaprootKeypath)
                 .expect("Failed to find taprootKeyPathSpend finalized input");
             assert_eq!(input_index, finalized_input_index);
             Some(finalized_input_fixture)

--- a/packages/wasm-utxo/src/fixed_script_wallet/test_utils/fixtures.rs
+++ b/packages/wasm-utxo/src/fixed_script_wallet/test_utils/fixtures.rs
@@ -525,7 +525,7 @@ pub struct PsbtFixture {
 pub struct PsbtStages {
     pub network: Network,
     pub tx_format: TxFormat,
-    pub wallet_keys: crate::fixed_script_wallet::RootWalletKeys,
+    pub wallet_keys: XprvTriple,
     pub unsigned: PsbtFixture,
     pub halfsigned: PsbtFixture,
     pub fullsigned: PsbtFixture,
@@ -562,12 +562,11 @@ impl PsbtStages {
             .expect("Failed to parse wallet keys");
         assert_eq!(wallet_keys_unsigned, wallet_keys_halfsigned);
         assert_eq!(wallet_keys_unsigned, wallet_keys_fullsigned);
-        let wallet_keys = wallet_keys_unsigned.to_root_wallet_keys();
 
         Ok(Self {
             network,
             tx_format,
-            wallet_keys,
+            wallet_keys: wallet_keys_unsigned.clone(),
             unsigned,
             halfsigned,
             fullsigned,
@@ -578,7 +577,7 @@ impl PsbtStages {
 pub struct PsbtInputStages {
     pub network: Network,
     pub tx_format: TxFormat,
-    pub wallet_keys: crate::fixed_script_wallet::RootWalletKeys,
+    pub wallet_keys: XprvTriple,
     pub wallet_script_type: ScriptType,
     pub input_index: usize,
     pub input_fixture_unsigned: PsbtInputFixture,

--- a/packages/wasm-utxo/src/fixed_script_wallet/test_utils/fixtures.rs
+++ b/packages/wasm-utxo/src/fixed_script_wallet/test_utils/fixtures.rs
@@ -1143,9 +1143,12 @@ pub enum ScriptType {
     P2sh,
     P2shP2wsh,
     P2wsh,
-    P2tr,
-    P2trMusig2,
-    TaprootKeypath,
+    // Chain 30 and 31 - we only support script path spending for these
+    P2trLegacyScriptPath,
+    // Chain 40 and 41 - script path spend
+    P2trMusig2ScriptPath,
+    // Chain 40 and 41 - keypath spend
+    P2trMusig2TaprootKeypath,
 }
 
 impl ScriptType {
@@ -1155,9 +1158,9 @@ impl ScriptType {
             ScriptType::P2sh => "p2sh",
             ScriptType::P2shP2wsh => "p2shP2wsh",
             ScriptType::P2wsh => "p2wsh",
-            ScriptType::P2tr => "p2tr",
-            ScriptType::P2trMusig2 => "p2trMusig2",
-            ScriptType::TaprootKeypath => "taprootKeypath",
+            ScriptType::P2trLegacyScriptPath => "p2tr",
+            ScriptType::P2trMusig2ScriptPath => "p2trMusig2",
+            ScriptType::P2trMusig2TaprootKeypath => "taprootKeypath",
         }
     }
 
@@ -1168,13 +1171,16 @@ impl ScriptType {
             (ScriptType::P2sh, PsbtInputFixture::P2sh(_))
                 | (ScriptType::P2shP2wsh, PsbtInputFixture::P2shP2wsh(_))
                 | (ScriptType::P2wsh, PsbtInputFixture::P2wsh(_))
-                | (ScriptType::P2tr, PsbtInputFixture::P2trLegacy(_))
                 | (
-                    ScriptType::P2trMusig2,
+                    ScriptType::P2trLegacyScriptPath,
+                    PsbtInputFixture::P2trLegacy(_)
+                )
+                | (
+                    ScriptType::P2trMusig2ScriptPath,
                     PsbtInputFixture::P2trMusig2ScriptPath(_)
                 )
                 | (
-                    ScriptType::TaprootKeypath,
+                    ScriptType::P2trMusig2TaprootKeypath,
                     PsbtInputFixture::P2trMusig2KeyPath(_)
                 )
         )
@@ -1187,13 +1193,16 @@ impl ScriptType {
             (ScriptType::P2sh, PsbtFinalInputFixture::P2sh(_))
                 | (ScriptType::P2shP2wsh, PsbtFinalInputFixture::P2shP2wsh(_))
                 | (ScriptType::P2wsh, PsbtFinalInputFixture::P2wsh(_))
-                | (ScriptType::P2tr, PsbtFinalInputFixture::P2trLegacy(_))
                 | (
-                    ScriptType::P2trMusig2,
+                    ScriptType::P2trLegacyScriptPath,
+                    PsbtFinalInputFixture::P2trLegacy(_)
+                )
+                | (
+                    ScriptType::P2trMusig2ScriptPath,
                     PsbtFinalInputFixture::P2trMusig2ScriptPath(_)
                 )
                 | (
-                    ScriptType::TaprootKeypath,
+                    ScriptType::P2trMusig2TaprootKeypath,
                     PsbtFinalInputFixture::P2trMusig2KeyPath(_)
                 )
         )
@@ -1206,7 +1215,9 @@ impl ScriptType {
     pub fn is_taproot(&self) -> bool {
         matches!(
             self,
-            ScriptType::P2tr | ScriptType::P2trMusig2 | ScriptType::TaprootKeypath
+            ScriptType::P2trLegacyScriptPath
+                | ScriptType::P2trMusig2ScriptPath
+                | ScriptType::P2trMusig2TaprootKeypath
         )
     }
 
@@ -1520,7 +1531,7 @@ mod tests {
 
         // Test finding taproot key path finalized input
         let (index, input) = fixture
-            .find_finalized_input_with_script_type(ScriptType::TaprootKeypath)
+            .find_finalized_input_with_script_type(ScriptType::P2trMusig2TaprootKeypath)
             .expect("Failed to find taproot key path finalized input");
         assert_eq!(index, 5);
         assert!(matches!(input, PsbtFinalInputFixture::P2trMusig2KeyPath(_)));

--- a/packages/wasm-utxo/src/fixed_script_wallet/test_utils/fixtures.rs
+++ b/packages/wasm-utxo/src/fixed_script_wallet/test_utils/fixtures.rs
@@ -397,6 +397,22 @@ pub enum PsbtInputFixture {
     P2shP2pk(P2shP2pkInput),
 }
 
+impl PsbtInputFixture {
+    /// Get partial signatures from PSBT input fixtures that support them.
+    /// Returns None for input types that don't use ECDSA partial signatures (e.g., Taproot).
+    pub fn partial_sigs(&self) -> Option<&Vec<PartialSig>> {
+        match self {
+            PsbtInputFixture::P2sh(fixture) => Some(&fixture.partial_sig),
+            PsbtInputFixture::P2shP2wsh(fixture) => Some(&fixture.partial_sig),
+            PsbtInputFixture::P2wsh(fixture) => Some(&fixture.partial_sig),
+            PsbtInputFixture::P2shP2pk(fixture) => Some(&fixture.partial_sig),
+            PsbtInputFixture::P2trLegacy(_)
+            | PsbtInputFixture::P2trMusig2ScriptPath(_)
+            | PsbtInputFixture::P2trMusig2KeyPath(_) => None,
+        }
+    }
+}
+
 // Finalized input type structs (depend on helper types above)
 
 #[derive(Debug, Clone, Deserialize, Serialize)]

--- a/packages/wasm-utxo/src/fixed_script_wallet/wallet_keys.rs
+++ b/packages/wasm-utxo/src/fixed_script_wallet/wallet_keys.rs
@@ -32,7 +32,7 @@ pub fn to_pub_triple(xpubs: &XpubTriple) -> PubTriple {
         .expect("could not convert vec to array")
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct RootWalletKeys {
     xpubs: XpubTriple,
     derivation_prefixes: [DerivationPath; 3],

--- a/packages/wasm-utxo/src/fixed_script_wallet/wallet_keys.rs
+++ b/packages/wasm-utxo/src/fixed_script_wallet/wallet_keys.rs
@@ -32,6 +32,12 @@ pub fn to_pub_triple(xpubs: &XpubTriple) -> PubTriple {
         .expect("could not convert vec to array")
 }
 
+pub fn derivation_path(prefix: &DerivationPath, chain: u32, index: u32) -> DerivationPath {
+    prefix
+        .child(ChildNumber::Normal { index: chain })
+        .child(ChildNumber::Normal { index })
+}
+
 #[derive(Debug, Clone)]
 pub struct RootWalletKeys {
     xpubs: XpubTriple,
@@ -68,10 +74,7 @@ impl RootWalletKeys {
         let paths: Vec<DerivationPath> = self
             .derivation_prefixes
             .iter()
-            .map(|p| {
-                p.child(ChildNumber::Normal { index: chain })
-                    .child(ChildNumber::Normal { index })
-            })
+            .map(|p| derivation_path(p, chain, index))
             .collect::<Vec<_>>();
 
         let ctx = Secp256k1::new();

--- a/packages/wasm-utxo/src/fixed_script_wallet/wallet_scripts/singlesig.rs
+++ b/packages/wasm-utxo/src/fixed_script_wallet/wallet_scripts/singlesig.rs
@@ -56,7 +56,7 @@ mod tests {
 
         // Get the expected values from the fixture
         let expected_redeem_script = &p2shp2pk_input.redeem_script;
-        let expected_pubkey = p2shp2pk_input
+        p2shp2pk_input
             .partial_sig
             .first()
             .map(|sig| &sig.pubkey)


### PR DESCRIPTION
Implements half-signing for script types

* p2sh
* p2shP2wsh
* p2wsh
* p2tr (legacy) script path
* p2trMusig2 script path

For bitcoin-like networks (bitcoin, litecoin, dogecoin, dash)

Missing:

* p2trMusig2 key path
* Bcash/Ecash/BitcoinGold

----

This PR enhances the WASM UTXO module with improved PSBT handling, key 
management, and testing utilities:

- Add `BitGoPsbt.sign()` method for direct transaction signing
- Create `XprvTriple` struct for type-safe wallet key management
- Implement `PsbtStages` and `PsbtInputStages` for structured test fixtures
- Improve script type naming for better clarity:
  - `P2tr` → `P2trLegacyScriptPath` 
  - `P2trMusig2` → `P2trMusig2ScriptPath`
  - `TaprootKeypath` → `P2trMusig2TaprootKeypath`
- Add half-signing test infrastructure for unsigned PSBTs
- Refactor test utilities to use the new `XprvTriple` directly

These changes provide a more robust and type-safe implementation for PSBT 
handling while improving the developer experience with better naming and 
more structured test fixtures.

Issue: BTC-2652