### PR TITLE
Enable OIDC trusted publishing for npm packages

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,6 +12,10 @@ jobs:
   publish:
     name: Publish Release
     runs-on: ubuntu-latest
+    environment: publish
+    permissions:
+      id-token: write
+      contents: read
 
     steps:
       - name: Checkout repository
@@ -55,9 +59,6 @@ jobs:
         run: |
           echo "workspaces-update = false" >> .npmrc
           echo "@bitgo:registry=https://registry.npmjs.org" >> .npmrc
-          echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" >> .npmrc
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Install Packages
         run: npm ci --workspaces --include-workspace-root
@@ -72,4 +73,3 @@ jobs:
         run: npx lerna publish --yes --no-verify-access
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Context

Configures the publish workflow to use OIDC authentication for npm publishing instead of long-lived NPM_TOKEN secrets. This provides better security and enables automatic provenance attestation.

## Changes

- Added `publish` environment to the workflow
- Added `id-token: write` and `contents: read` permissions
- Removed NPM_TOKEN configuration from workflow

## Next Steps

After merging, trusted publishing must be configured on npm.com for each package:
- Go to package settings → Publishing access → Trusted publishers
- Add GitHub Actions as trusted publisher:
  - Organization: BitGo
  - Repository: BitGoWASM
  - Workflow: publish.yml
  - Environment: publish

## References

- [Lerna OIDC Publishing Docs](https://lerna.js.org/docs/recipes/oidc-trusted-publishing)
- [npm Trusted Publishers Docs](https://docs.npmjs.com/trusted-publishers)

Ticket: VL-3686