### PR TITLE
fix(ci): grant write permissions for contents in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ jobs:
     environment: publish
     permissions:
       id-token: write
-      contents: read
+      contents: write
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Update GitHub workflow permissions to allow writing repository tags during the publish process.

Co-authored-by: llm-git <llm-git@ttll.de>

Ticket: BTC-2730