### PR TITLE
fix(ci): skip git push during release process

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -70,6 +70,6 @@ jobs:
         run: npm --workspaces test
 
       - name: Release
-        run: npx lerna publish --yes --no-verify-access
+        run: npx lerna publish --yes --no-verify-access --no-push
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This modifies the lerna publish command to skip pushing to the remote repository during release.

Co-authored-by: llm-git <llm-git@ttll.de>

Ticket: BTC-2724