### PR TITLE
fix: add license to root package.json and remove lint-staged

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "type": "git",
     "url": "git+https://github.com/BitGo/BitGoWASM.git"
   },
+  "license": "Apache-2.0",
   "scripts": {
     "check-fmt": "npm run --workspaces check-fmt"
   },

--- a/packages/wasm-utxo/package.json
+++ b/packages/wasm-utxo/package.json
@@ -2,7 +2,6 @@
   "name": "@bitgo/wasm-utxo",
   "description": "WebAssembly wrapper for rust-bitcoin (beta)",
   "version": "0.0.1",
-  "lint-staged": "MIT",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/BitGo/BitGoWASM"


### PR DESCRIPTION
BTC-2724-6: Adds Apache-2.0 license to root package.json and removes incorrect lint-staged property from wasm-utxo package.json.

Copying BitGoSDK

Co-authored-by: llm-git <llm-git@ttll.de>

Ticket: BTC-0