### PR TITLE
feat: update Node.js and actions/setup-node versions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,9 +24,9 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1


### PR DESCRIPTION
Update Node.js from v18 to v20 and actions/setup-node from v3 to v4 in the GitHub workflow.

Ticket: BTC-0