### PR TITLE
chore: improve CI publish pipeline

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,10 +28,20 @@ jobs:
         with:
           node-version: 20
 
+      - name: Ensure npm 11.5.1 or later for trusted publishing
+        run: |
+          npm install -g npm@latest
+
       - name: Install Rust
         uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
           toolchain: nightly
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@f13886b937689c021905a6b90929199931d60db1 # v2.8.1
+        with:
+          workspaces: "packages/wasm-utxo"
+          cache-on-failure: true
 
       - name: Install wasm tools
         run: |


### PR DESCRIPTION
Add npm 11.5+ requirement for trusted publishing and implement Rust dependency caching to speed up builds.

Co-authored-by: llm-git <llm-git@ttll.de>

Ticket: BTC-0