### PR TITLE
feat: pin specific versions for CI tooling

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,12 +30,12 @@ jobs:
 
       - name: Ensure npm 11.5.1 or later for trusted publishing
         run: |
-          npm install -g npm@latest
+          npm install -g npm@11.5.1
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
-          toolchain: nightly
+          toolchain: nightly-2025-10-23
 
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@f13886b937689c021905a6b90929199931d60db1 # v2.8.1


### PR DESCRIPTION
Use explicit versions for npm (11.5.1) and rust toolchain (nightly-2025-10-23) in the GitHub publish workflow to ensure build stability and reproducibility.

Co-authored-by: llm-git <llm-git@ttll.de>

Ticket: BTC-0