### PR TITLE
feat: add npm registry URL to GitHub workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,6 +27,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
+          registry-url: https://registry.npmjs.org
 
       - name: Ensure npm 11.5.1 or later for trusted publishing
         run: |


### PR DESCRIPTION
Add registry-url to setup-node action in publish workflow to ensure packages are published to the correct npm registry.

Ticket: BTC-0