### PR TITLE
chore(ci): add verbose logging to lerna publish command

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -81,6 +81,6 @@ jobs:
         run: npm --workspaces test
 
       - name: Release
-        run: npx lerna publish --yes --no-verify-access --no-push
+        run: npx lerna publish --yes --no-push --loglevel verbose -- --loglevel verbose
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Added verbose logging to lerna publish command in the CI workflow to help debug any publishing issues.

Co-authored-by: llm-git <llm-git@ttll.de>

Ticket: BTC-0