### PR TITLE
feat: simplify release workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -66,11 +66,6 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-      - name: Configure NPM
-        run: |
-          echo "workspaces-update = false" >> .npmrc
-          echo "@bitgo:registry=https://registry.npmjs.org" >> .npmrc
-
       - name: Install Packages
         run: npm ci --workspaces --include-workspace-root
 
@@ -80,7 +75,6 @@ jobs:
       - name: Unit Test
         run: npm --workspaces test
 
-      - name: Release
-        run: npx lerna publish --yes --no-push --loglevel verbose -- --loglevel verbose
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Release (npm publish via OIDC)
+        working-directory: packages/wasm-utxo
+        run: npm publish


### PR DESCRIPTION
Remove lerna publishing in favor of direct npm publish from WASM-UTXO package. Remove npm configuration that's no longer needed.

Co-authored-by: llm-git <llm-git@ttll.de>

Ticket: BTC-0