### PR TITLE
feat(ci): refactor workflows using reusable workflow pattern

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -1,0 +1,102 @@
+name: "Build and Test (Reusable)"
+
+on:
+  workflow_call:
+    inputs:
+      upload-artifacts:
+        description: "Upload build artifacts"
+        type: boolean
+        default: false
+
+jobs:
+  run:
+    name: "Test"
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+        with:
+          toolchain: nightly-2025-10-23
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@f13886b937689c021905a6b90929199931d60db1 # v2.8.1
+        with:
+          workspaces: "packages/wasm-utxo"
+          cache-on-failure: true
+
+      - name: Setup node 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Ensure npm 11.5.1
+        run: |
+          npm install -g npm@11.5.1
+
+      - name: Install wasm tools
+        run: |
+          rustup component add rustfmt
+          cargo install wasm-pack --version 0.13.1
+          cargo install wasm-opt --version 0.116.1
+          cargo install cargo-deny --locked
+
+      - name: Build Info
+        run: |
+          echo "node $(node --version)"
+          echo "npm $(npm --version)"
+          echo "rustc $(rustc --version)"
+          echo "wasm-pack $(wasm-pack --version)"
+          echo "wasm-opt $(wasm-opt --version)"
+          echo "cargo-deny $(cargo deny --version)"
+          git --version
+          echo "base ref $GITHUB_BASE_REF"
+          echo "head ref $GITHUB_HEAD_REF"
+
+      - name: Fetch Base Ref
+        if: github.event_name == 'pull_request'
+        run: |
+          git fetch origin $GITHUB_BASE_REF
+
+      - name: Install Packages
+        run: npm ci --workspaces --include-workspace-root
+
+      - name: Check dependencies with cargo-deny
+        run: cargo deny check
+        working-directory: packages/wasm-utxo
+
+      - name: build packages
+        run: npm --workspaces run build
+
+      - name: Check Source Code Formatting
+        run: npm run check-fmt
+
+      - name: wasm-utxo / cargo test
+        run: cargo test --workspace
+        working-directory: packages/wasm-utxo
+
+      - name: wasm-utxo / Wasm-Pack Test (Node)
+        run: npm run test:wasm-pack-node
+        working-directory: packages/wasm-utxo
+
+      - name: wasm-utxo / Wasm-Pack Test (Chrome)
+        run: npm run test:wasm-pack-chrome
+        working-directory: packages/wasm-utxo
+
+      - name: Unit Test
+        run: npm --workspaces test
+
+      - name: Upload build artifacts
+        if: inputs.upload-artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: wasm-utxo-build
+          path: |
+            packages/wasm-utxo/pkg/
+            packages/wasm-utxo/dist/
+          retention-days: 1
+

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,4 +1,4 @@
-name: "test / Test"
+name: "Build and Test"
 
 on:
   push:
@@ -12,83 +12,5 @@ on:
   workflow_dispatch:
 
 jobs:
-  unit-test:
-    name: "test / Test"
-
-    runs-on: ubuntu-latest
-
-    strategy:
-      fail-fast: false
-
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
-        with:
-          toolchain: nightly-2025-10-23
-
-      - name: Cache Rust dependencies
-        uses: Swatinem/rust-cache@f13886b937689c021905a6b90929199931d60db1 # v2.8.1
-        with:
-          workspaces: "packages/wasm-utxo"
-          cache-on-failure: true
-
-      - name: Setup node ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
-        with:
-          node-version: ${{ matrix.node-version }}
-
-      - name: Install wasm tools
-        run: |
-          rustup component add rustfmt
-          cargo install wasm-pack --version 0.13.1
-          cargo install wasm-opt --version 0.116.1
-          cargo install cargo-deny --locked
-
-      - name: Build Info
-        run: |
-          echo "node $(node --version)"
-          echo "npm $(npm --version)"
-          echo "npx $(npx --version)"
-          echo "rustc $(rustc --version)"
-          echo "wasm-pack $(wasm-pack --version)"
-          echo "wasm-opt $(wasm-opt --version)"
-          echo "cargo-deny $(cargo deny --version)"
-          git --version
-          echo "base ref $GITHUB_BASE_REF"
-          echo "head ref $GITHUB_HEAD_REF"
-
-      - name: Fetch Base Ref
-        run: |
-          git fetch origin $GITHUB_BASE_REF
-
-      - name: Install Packages
-        run: npm ci --workspaces --include-workspace-root
-
-      - name: Check dependencies with cargo-deny
-        run: cargo deny check
-        working-directory: packages/wasm-utxo
-
-      - name: build packages
-        run: npm --workspaces run build
-
-      - name: Check Source Code Formatting
-        run: npm run check-fmt
-
-      - name: wasm-utxo / cargo test
-        run: cargo test --workspace
-        working-directory: packages/wasm-utxo
-
-      - name: wasm-utxo / Wasm-Pack Test (Node)
-        run: npm run test:wasm-pack-node
-        working-directory: packages/wasm-utxo
-
-      - name: wasm-utxo / Wasm-Pack Test (Chrome)
-        run: npm run test:wasm-pack-chrome
-        working-directory: packages/wasm-utxo
-
-      - name: Unit Test
-        run: npm --workspaces test
+  test:
+    uses: ./.github/workflows/build-and-test.yaml

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -9,8 +9,15 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:
+  test:
+    name: Test
+    uses: ./.github/workflows/build-and-test.yaml
+    with:
+      upload-artifacts: true
+
   publish:
     name: Publish Release
+    needs: test
     runs-on: ubuntu-latest
     environment: publish
     permissions:
@@ -23,57 +30,26 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: wasm-utxo-build
+          path: packages/wasm-utxo/
+
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
           node-version: 20
           registry-url: https://registry.npmjs.org
 
-      - name: Ensure npm 11.5.1 or later for trusted publishing
+      - name: Ensure npm 11.5.1
         run: |
           npm install -g npm@11.5.1
-
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
-        with:
-          toolchain: nightly-2025-10-23
-
-      - name: Cache Rust dependencies
-        uses: Swatinem/rust-cache@f13886b937689c021905a6b90929199931d60db1 # v2.8.1
-        with:
-          workspaces: "packages/wasm-utxo"
-          cache-on-failure: true
-
-      - name: Install wasm tools
-        run: |
-          rustup component add rustfmt
-          cargo install wasm-pack --version 0.13.1
-          cargo install wasm-opt --version 0.116.1
-
-      - name: Build Info
-        run: |
-          echo "node $(node --version)"
-          echo "npm $(npm --version)"
-          echo "rustc $(rustc --version)"
-          echo "wasm-pack $(wasm-pack --version)"
-          echo "wasm-opt $(wasm-opt --version)"
-          git --version
-          echo "base ref $GITHUB_BASE_REF"
-          echo "head ref $GITHUB_HEAD_REF"
 
       - name: Configure Git
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-
-      - name: Install Packages
-        run: npm ci --workspaces --include-workspace-root
-
-      - name: build packages
-        run: npm --workspaces run build
-
-      - name: Unit Test
-        run: npm --workspaces test
 
       - name: Release (npm publish via OIDC)
         working-directory: packages/wasm-utxo

--- a/.github/workflows/status-check.yaml
+++ b/.github/workflows/status-check.yaml
@@ -1,0 +1,25 @@
+# This is a thin wrapper workflow that reflects the status of the "Build and Test" workflow.
+# It exists solely to provide a clean "test / Test" status check name in GitHub PR status checks,
+# avoiding the multi-level name composition that occurs with reusable workflows.
+# Configure branch protection rules to require "test / Test" as the status check.
+
+name: "test / Test"
+
+on:
+  workflow_run:
+    workflows: ["Build and Test"]
+    types:
+      - completed
+
+jobs:
+  status:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check Build and Test Status
+        run: |
+          if [ "${{ github.event.workflow_run.conclusion }}" != "success" ]; then
+            echo "Build and Test workflow failed"
+            exit 1
+          fi
+          echo "Build and Test workflow succeeded"
+


### PR DESCRIPTION

Create a reusable build-and-test workflow that can be used by both CI
and publish workflows. This reduces duplication and ensures consistent
build/test procedures across different workflows.

Notably this now uses caching in the publish workflow as well.

Issue: BTC-0