### PR TITLE
feat: publish modules required by index exports

### DIFF
--- a/packages/wasm-utxo/package.json
+++ b/packages/wasm-utxo/package.json
@@ -14,7 +14,12 @@
     "dist/*/js/wasm/wasm_utxo_bg.wasm",
     "dist/*/js/wasm/wasm_utxo_bg.wasm.d.ts",
     "dist/*/js/ast/*",
-    "dist/*/js/index.*"
+    "dist/*/js/index.*",
+    "dist/*/js/address.*",
+    "dist/*/js/utxolibCompat.*",
+    "dist/*/js/fixedScriptWallet.*",
+    "dist/*/js/coinName.*",
+    "dist/*/js/triple.*"
   ],
   "main": "dist/node/js/index.js",
   "types": "dist/node/js/index.d.ts",


### PR DESCRIPTION
The built entrypoint (index.js) imports ./address, ./fixedScriptWallet, and ./utxolibCompat (and re-exports types like AddressFormat). These files were excluded by the npm "files" allowlist, causing MODULE_NOT_FOUND at runtime for consumers
(e.g., BitGoJS @bitgo/utxo-core tests).

Include in the allowlist for both node/browser targets:
- dist/*/js/address.*
- dist/*/js/utxolibCompat.*
- dist/*/js/fixedScriptWallet.*
- dist/*/js/coinName.*
- dist/*/js/triple.*

This ensures both JS and .d.ts are published and makes the package consistent with its public API. No API changes; fixes packaging only.

TIcket: BTC-2740