### PR TITLE
feat: add sign extension flag to wasm-opt

### DIFF
--- a/packages/wasm-utxo/Dockerfile
+++ b/packages/wasm-utxo/Dockerfile
@@ -8,8 +8,8 @@ ENV PATH="/root/.cargo/bin:${PATH}"
 # Install wasm-pack
 RUN cargo install wasm-pack
 
-# Install clang
-RUN apt-get update && apt-get install -y clang
+# Install clang and binaryen (provides wasm-opt)
+RUN apt-get update && apt-get install -y clang binaryen
 
 # Create app directory
 WORKDIR /usr/src/app

--- a/packages/wasm-utxo/Makefile
+++ b/packages/wasm-utxo/Makefile
@@ -12,7 +12,7 @@ endef
 
 # run wasm-opt separately so we can pass `--enable-bulk-memory`
 define WASM_OPT_COMMAND
-    $(WASM_OPT) --enable-bulk-memory --enable-nontrapping-float-to-int -Oz $(1)/*.wasm -o $(1)/*.wasm
+    $(WASM_OPT) --enable-bulk-memory --enable-nontrapping-float-to-int --enable-sign-ext -Oz $(1)/*.wasm -o $(1)/*.wasm
 endef
 
 define REMOVE_GITIGNORE


### PR DESCRIPTION
Add binaryen package to Dockerfile and enable sign extension flag for wasm-opt command, which improves WASM optimization.

Co-authored-by: llm-git <llm-git@ttll.de>

Ticket: BTC-0