### PR TITLE
feat(wasm-utxo): add exports field to package.json

### DIFF
--- a/packages/wasm-utxo/package.json
+++ b/packages/wasm-utxo/package.json
@@ -23,6 +23,33 @@
   ],
   "main": "dist/node/js/index.js",
   "types": "dist/node/js/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/node/js/index.d.ts",
+      "browser": "./dist/browser/js/index.js",
+      "default": "./dist/node/js/index.js"
+    },
+    "./address": {
+      "types": "./dist/node/js/address.d.ts",
+      "browser": "./dist/browser/js/address.js",
+      "default": "./dist/node/js/address.js"
+    },
+    "./ast": {
+      "types": "./dist/node/js/ast/index.d.ts",
+      "browser": "./dist/browser/js/ast/index.js",
+      "default": "./dist/node/js/ast/index.js"
+    },
+    "./fixedScriptWallet": {
+      "types": "./dist/node/js/fixedScriptWallet.d.ts",
+      "browser": "./dist/browser/js/fixedScriptWallet.js",
+      "default": "./dist/node/js/fixedScriptWallet.js"
+    },
+    "./utxolibCompat": {
+      "types": "./dist/node/js/utxolibCompat.d.ts",
+      "browser": "./dist/browser/js/utxolibCompat.js",
+      "default": "./dist/node/js/utxolibCompat.js"
+    }
+  },
   "sideEffects": [
     "./dist/node/js/wasm/wasm_utxo.js",
     "./dist/browser/js/wasm/wasm_utxo.js"


### PR DESCRIPTION
Add modern exports field with conditional exports for Node.js and browser environments. This provides better control over the package's public API and prevents deep imports into internal paths.

Exports include:
- Main entry point (.)
- Submodules: address, ast, fixedScriptWallet, utxolibCompat

Each export properly specifies types, browser, and default (Node) paths. Maintains full backward compatibility with existing imports.