### PR TITLE
feat: export wasm background files for direct import

### DIFF
--- a/packages/wasm-utxo/package.json
+++ b/packages/wasm-utxo/package.json
@@ -48,7 +48,11 @@
       "types": "./dist/node/js/utxolibCompat.d.ts",
       "browser": "./dist/browser/js/utxolibCompat.js",
       "default": "./dist/node/js/utxolibCompat.js"
-    }
+    },
+    "./dist/browser/js/wasm/wasm_utxo_bg.js": "./dist/browser/js/wasm/wasm_utxo_bg.js",
+    "./dist/browser/js/wasm/wasm_utxo_bg.wasm": "./dist/browser/js/wasm/wasm_utxo_bg.wasm",
+    "./dist/node/js/wasm/wasm_utxo_bg.js": "./dist/node/js/wasm/wasm_utxo_bg.js",
+    "./dist/node/js/wasm/wasm_utxo_bg.wasm": "./dist/node/js/wasm/wasm_utxo_bg.wasm"
   },
   "sideEffects": [
     "./dist/node/js/wasm/wasm_utxo.js",


### PR DESCRIPTION
Add ./dist/browser/js/wasm/wasm_utxo_bg.js and wasm_utxo_bg.wasm to the exports field to allow webpack shims to import internal wasm modules directly. This resolves "Package path is not exported" errors when consuming this package in Next.js applications.

Also adds node variants for consistency.

Ticket: BTC-0