### PR TITLE
feat: remove exports field to enable deep imports

### DIFF
--- a/packages/wasm-utxo/package.json
+++ b/packages/wasm-utxo/package.json
@@ -23,37 +23,6 @@
   ],
   "main": "dist/node/js/index.js",
   "types": "dist/node/js/index.d.ts",
-  "exports": {
-    ".": {
-      "types": "./dist/node/js/index.d.ts",
-      "browser": "./dist/browser/js/index.js",
-      "default": "./dist/node/js/index.js"
-    },
-    "./address": {
-      "types": "./dist/node/js/address.d.ts",
-      "browser": "./dist/browser/js/address.js",
-      "default": "./dist/node/js/address.js"
-    },
-    "./ast": {
-      "types": "./dist/node/js/ast/index.d.ts",
-      "browser": "./dist/browser/js/ast/index.js",
-      "default": "./dist/node/js/ast/index.js"
-    },
-    "./fixedScriptWallet": {
-      "types": "./dist/node/js/fixedScriptWallet.d.ts",
-      "browser": "./dist/browser/js/fixedScriptWallet.js",
-      "default": "./dist/node/js/fixedScriptWallet.js"
-    },
-    "./utxolibCompat": {
-      "types": "./dist/node/js/utxolibCompat.d.ts",
-      "browser": "./dist/browser/js/utxolibCompat.js",
-      "default": "./dist/node/js/utxolibCompat.js"
-    },
-    "./dist/browser/js/wasm/wasm_utxo_bg.js": "./dist/browser/js/wasm/wasm_utxo_bg.js",
-    "./dist/browser/js/wasm/wasm_utxo_bg.wasm": "./dist/browser/js/wasm/wasm_utxo_bg.wasm",
-    "./dist/node/js/wasm/wasm_utxo_bg.js": "./dist/node/js/wasm/wasm_utxo_bg.js",
-    "./dist/node/js/wasm/wasm_utxo_bg.wasm": "./dist/node/js/wasm/wasm_utxo_bg.wasm"
-  },
   "sideEffects": [
     "./dist/node/js/wasm/wasm_utxo.js",
     "./dist/browser/js/wasm/wasm_utxo.js"


### PR DESCRIPTION
The exports field was preventing consumers from importing internal WASM wrapper files like 'dist/browser/js/wasm/wasm_utxo.js', which caused build failures in bitgo-ui during the migration from wasm-miniscript to wasm-utxo.

The wasm-miniscript package did not have an exports field, allowing all files to be accessible. Removing the exports field from wasm-utxo restores this behavior and allows bitgo-ui to use the existing webpack configuration without modifications.

This change enables:
- Direct imports of WASM initialization wrapper files
- Compatibility with existing build tooling that expects deep imports
- Drop-in replacement for wasm-miniscript without code changes

Resolves module resolution errors when building bitgo-ui with wasm-utxo.

Ticket: BTC-0