### PR TITLE
feat(wasm-utxo): convert to esm-first package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2681,7 +2681,6 @@
       "integrity": "sha512-/g2d4sW9nUDJOMz3mabVQvOGhVa4e/BN/Um7yca9Bb2XTzPPnfTWHWQg+IsEYO7M3Vx+EXvaM/I2pJWIMun1bg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^4.0.0",
         "@octokit/graphql": "^7.1.0",
@@ -3060,7 +3059,6 @@
       "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.3",
@@ -3291,7 +3289,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4634,7 +4631,6 @@
       "integrity": "sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4687,7 +4683,6 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -5485,7 +5480,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001646",
         "electron-to-chromium": "^1.5.4",
@@ -8269,8 +8263,7 @@
     "node_modules/fp-ts": {
       "version": "2.16.9",
       "resolved": "https://registry.npmjs.org/fp-ts/-/fp-ts-2.16.9.tgz",
-      "integrity": "sha512-+I2+FnVB+tVaxcYyQkHUq7ZdKScaBlX53A41mxQtpIccsfyv8PzdzP7fzp2AY832T4aoK6UZ5WRX/ebGd8uZuQ==",
-      "peer": true
+      "integrity": "sha512-+I2+FnVB+tVaxcYyQkHUq7ZdKScaBlX53A41mxQtpIccsfyv8PzdzP7fzp2AY832T4aoK6UZ5WRX/ebGd8uZuQ=="
     },
     "node_modules/fresh": {
       "version": "0.5.2",
@@ -9677,7 +9670,6 @@
       "version": "2.2.21",
       "resolved": "https://registry.npmjs.org/io-ts/-/io-ts-2.2.21.tgz",
       "integrity": "sha512-zz2Z69v9ZIC3mMLYWIeoUcwWD6f+O7yP92FMVVaXEOSZH1jnVBmET/urd/uoarD1WGBY4rCj8TAyMPzsGNzMFQ==",
-      "peer": true,
       "peerDependencies": {
         "fp-ts": "^2.5.0"
       }
@@ -11203,7 +11195,6 @@
       "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -11985,7 +11976,6 @@
       "version": "2.3.13",
       "resolved": "https://registry.npmjs.org/monocle-ts/-/monocle-ts-2.3.13.tgz",
       "integrity": "sha512-D5Ygd3oulEoAm3KuGO0eeJIrhFf1jlQIoEVV2DYsZUMz42j4tGxgct97Aq68+F8w4w4geEnwFa8HayTS/7lpKQ==",
-      "peer": true,
       "peerDependencies": {
         "fp-ts": "^2.5.0"
       }
@@ -12281,7 +12271,6 @@
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/newtype-ts/-/newtype-ts-0.3.5.tgz",
       "integrity": "sha512-v83UEQMlVR75yf1OUdoSFssjitxzjZlqBAjiGQ4WJaML8Jdc68LJ+BaSAXUmKY4bNzp7hygkKLYTsDi14PxI2g==",
-      "peer": true,
       "peerDependencies": {
         "fp-ts": "^2.0.0",
         "monocle-ts": "^2.0.0"
@@ -15058,7 +15047,6 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -15310,7 +15298,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@napi-rs/wasm-runtime": "0.2.4",
         "@yarnpkg/lockfile": "^1.1.0",
@@ -16717,7 +16704,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.7",
         "picocolors": "^1.0.1",
@@ -17851,7 +17837,6 @@
       "integrity": "sha512-6qGjWccl5yoyugHt3jTgztJ9Y0JVzyH8/Voc/D8PlLat9pwxQYXz7W1Dpnq5h0/G5GCYGUaDSlYcyk3AMh5A6g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@semantic-release/commit-analyzer": "^13.0.1",
         "@semantic-release/error": "^4.0.0",
@@ -19970,7 +19955,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -20140,8 +20124,7 @@
       "version": "2.6.3",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
       "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/tsx": {
       "version": "4.20.6",
@@ -20280,7 +20263,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -20642,7 +20624,6 @@
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.94.0.tgz",
       "integrity": "sha512-KcsGn50VT+06JH/iunZJedYGUJS5FGjow8wb9c0v5n1Om8O1g4L6LjtfxwlXIATopoQu+vOXXa7gYisWxCoPyg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@types/estree": "^1.0.5",
         "@webassemblyjs/ast": "^1.12.1",
@@ -20689,7 +20670,6 @@
       "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-5.1.4.tgz",
       "integrity": "sha512-pIDJHIEI9LR0yxHXQ+Qh95k2EvXpWzZ5l+d+jIo+RdSm9MiHfzazIxwwni/p7+x4eJZuvG1AJwgC4TNQ7NRgsg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@discoveryjs/json-ext": "^0.5.0",
         "@webpack-cli/configtest": "^2.1.1",
@@ -20773,7 +20753,6 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -20886,7 +20865,6 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",

--- a/packages/wasm-utxo-ui/package.json
+++ b/packages/wasm-utxo-ui/package.json
@@ -23,17 +23,11 @@
   },
   "dependencies": {
     "@bitgo/wasm-utxo": "*",
-    "assert": "^2.1.0",
-    "buffer": "^6.0.3",
-    "crypto-browserify": "^3.12.0",
     "fp-ts": "^2.16.8",
     "io-ts": "^2.2.21",
     "io-ts-types": "^0.5.19",
     "monocle-ts": "^2.3.13",
-    "newtype-ts": "^0.3.5",
-    "process": "^0.11.10",
-    "stream-browserify": "^3.0.0",
-    "vm-browserify": "^1.1.2"
+    "newtype-ts": "^0.3.5"
   },
   "devDependencies": {
     "css-loader": "^7.1.2",

--- a/packages/wasm-utxo-ui/package.json
+++ b/packages/wasm-utxo-ui/package.json
@@ -12,6 +12,7 @@
   "private": true,
   "scripts": {
     "build": "webpack --mode production --progress --config ./webpack.config.js",
+    "typecheck": "tsc --noEmit",
     "test": "echo \"Error: no test specified\"",
     "dev": "webpack serve --mode development --progress --hot --config ./webpack.config.js",
     "fmt": "prettier --write .",
@@ -21,7 +22,6 @@
     "deploy": "gh-pages -d dist"
   },
   "dependencies": {
-    "@bitgo/utxo-lib": "^10.1.0",
     "@bitgo/wasm-utxo": "*",
     "assert": "^2.1.0",
     "buffer": "^6.0.3",

--- a/packages/wasm-utxo-ui/src/index.ts
+++ b/packages/wasm-utxo-ui/src/index.ts
@@ -1,5 +1,4 @@
-import * as utxolib from "@bitgo/utxo-lib";
-import { Descriptor, Miniscript, ScriptContext } from "@bitgo/wasm-utxo";
+import { address, CoinName, Descriptor, Miniscript, ScriptContext } from "@bitgo/wasm-utxo";
 
 import "./style.css";
 
@@ -33,8 +32,8 @@ const elDescriptorAst = getElement("output-descriptor-ast", HTMLDivElement);
 const elMiniscriptAst = getElement("output-miniscript-ast", HTMLDivElement);
 const elStatus = getElement("status", HTMLElement);
 
-function toAddress(scriptPubkeyBytes: Uint8Array, network: utxolib.Network) {
-  return utxolib.address.fromOutputScript(Buffer.from(scriptPubkeyBytes), network);
+function toAddress(scriptPubkeyBytes: Uint8Array, coin: CoinName) {
+  return address.fromOutputScriptWithCoin(scriptPubkeyBytes, coin);
 }
 
 function setHtmlContent(el: HTMLElement, content: HTMLElement | undefined) {
@@ -137,7 +136,7 @@ function applyUpdateWith(
   if (scriptPubkeyBytes) {
     elScriptPubkeyBytes.value = toHex(scriptPubkeyBytes);
     try {
-      elAddress.value = toAddress(scriptPubkeyBytes, utxolib.networks.bitcoin);
+      elAddress.value = toAddress(scriptPubkeyBytes, "btc");
     } catch (e: any) {
       elAddress.value = `error: ${e.message}`;
     }

--- a/packages/wasm-utxo-ui/tsconfig.json
+++ b/packages/wasm-utxo-ui/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "composite": true,
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,

--- a/packages/wasm-utxo-ui/webpack.config.js
+++ b/packages/wasm-utxo-ui/webpack.config.js
@@ -1,5 +1,4 @@
 const path = require("path");
-const webpack = require("webpack");
 const HtmlWebpackPlugin = require("html-webpack-plugin");
 
 module.exports = {
@@ -23,13 +22,6 @@ module.exports = {
   },
   resolve: {
     extensions: [".ts", ".js"],
-    fallback: {
-      buffer: require.resolve("buffer/"),
-      assert: require.resolve("assert/"),
-      stream: require.resolve("stream-browserify"),
-      crypto: require.resolve("crypto-browserify"),
-      vm: require.resolve("vm-browserify"),
-    },
   },
   output: {
     filename: "bundle.js",
@@ -38,10 +30,6 @@ module.exports = {
   plugins: [
     new HtmlWebpackPlugin({
       template: "./src/index.html",
-    }),
-    new webpack.ProvidePlugin({
-      Buffer: ["buffer", "Buffer"],
-      process: "process/browser",
     }),
   ],
   mode: "development",

--- a/packages/wasm-utxo/.mocharc.json
+++ b/packages/wasm-utxo/.mocharc.json
@@ -1,4 +1,5 @@
 {
-  "extension": ["js", "ts"],
-  "node-option": ["import=tsx"]
+  "extensions": ["ts", "tsx", "js", "jsx"],
+  "spec": ["test/**/*.ts"],
+  "node-option": ["import=tsx/esm", "experimental-wasm-modules"]
 }

--- a/packages/wasm-utxo/Makefile
+++ b/packages/wasm-utxo/Makefile
@@ -23,6 +23,7 @@ define SHOW_WASM_SIZE
 	@find $(1) -name "*.wasm" -exec gzip -k {} \;
 	@find $(1) -name "*.wasm" -exec du -h {} \;
 	@find $(1) -name "*.wasm.gz" -exec du -h {} \;
+	@find $(1) -name "*.wasm.gz" -delete
 endef
 
 define BUILD
@@ -35,15 +36,15 @@ endef
 
 .PHONY: js/wasm/
 js/wasm/:
-	$(call BUILD,$@,nodejs)
+	$(call BUILD,$@,bundler)
 
-.PHONY: dist/node/js/wasm/
-dist/node/js/wasm/:
-	$(call BUILD,$@,nodejs)
+.PHONY: dist/esm/wasm/
+dist/esm/wasm/:
+	$(call BUILD,$@,bundler)
 
-.PHONY: dist/browser/js/wasm/
-dist/browser/js/wasm/:
-	$(call BUILD,$@,browser)
+.PHONY: dist/cjs/wasm/
+dist/cjs/wasm/:
+	$(call BUILD,$@,nodejs)
 
 .PHONY: lint
 lint:

--- a/packages/wasm-utxo/bundler-test/test-cjs-import.cjs
+++ b/packages/wasm-utxo/bundler-test/test-cjs-import.cjs
@@ -1,0 +1,48 @@
+/**
+ * Test script to verify CommonJS compatibility
+ * Run with: node bundler-test/test-cjs-import.cjs
+ */
+
+console.log("Testing CommonJS require() compatibility...\n");
+
+// Use standard CommonJS require
+let wasmUtxo;
+try {
+  wasmUtxo = require("../dist/cjs/index.js");
+} catch (error) {
+  console.error("✗ require() failed:", error.message);
+  process.exit(1);
+}
+
+console.log("✓ require() successful from CJS context");
+console.log("✓ Available exports:", Object.keys(wasmUtxo).join(", "));
+
+// Test that we can access the main APIs
+if (wasmUtxo.Descriptor) {
+  console.log("✓ Descriptor API available");
+}
+if (wasmUtxo.Psbt) {
+  console.log("✓ Psbt API available");
+}
+if (wasmUtxo.address) {
+  console.log("✓ address namespace available");
+}
+if (wasmUtxo.fixedScriptWallet) {
+  console.log("✓ fixedScriptWallet namespace available");
+}
+
+// Try to use the Descriptor API
+try {
+  const descriptor = wasmUtxo.Descriptor.fromString(
+    "wpkh(xpub6ERApfZwUNrhLCkDtcHTcxd75RbzS1ed54G1LkBUHQVHQKqhMkhgbmJbZRkrgZw4koxb5JaHWkY4ALHY2grBGRjaDMzQLcgJvLJuZZvRcEL/0/*)",
+    "derivable",
+  );
+  console.log("✓ Descriptor.fromString() works");
+  console.log("  Descriptor type:", descriptor.descType());
+} catch (err) {
+  console.log("✗ Descriptor test failed:", err.message);
+  process.exit(1);
+}
+
+console.log("\n✅ All CJS compatibility tests passed!");
+console.log("\nCJS consumers can use standard require() with this package.");

--- a/packages/wasm-utxo/bundler-test/test-esm-import.mjs
+++ b/packages/wasm-utxo/bundler-test/test-esm-import.mjs
@@ -1,0 +1,35 @@
+/**
+ * Test script to verify ESM import works correctly
+ * Run with: node --experimental-wasm-modules bundler-test/test-esm-import.mjs
+ */
+
+import { Descriptor, Psbt, address, fixedScriptWallet } from "../dist/esm/index.js";
+
+console.log("Testing ESM import...\n");
+
+console.log("✓ ESM import successful");
+console.log("✓ Descriptor API available");
+console.log("✓ Psbt API available");
+console.log("✓ address namespace available");
+console.log("✓ fixedScriptWallet namespace available");
+
+// Test that we can use the Descriptor API
+try {
+  const descriptor = Descriptor.fromString(
+    "wpkh(xpub6ERApfZwUNrhLCkDtcHTcxd75RbzS1ed54G1LkBUHQVHQKqhMkhgbmJbZRkrgZw4koxb5JaHWkY4ALHY2grBGRjaDMzQLcgJvLJuZZvRcEL/0/*)",
+    "derivable",
+  );
+  console.log("✓ Descriptor.fromString() works");
+  console.log("  Descriptor type:", descriptor.descType());
+
+  // Test address derivation
+  const derived = descriptor.atDerivationIndex(0);
+  console.log("✓ Descriptor derivation works");
+  console.log("  Script pubkey length:", derived.scriptPubkey().length);
+} catch (err) {
+  console.log("✗ Descriptor test failed:", err.message);
+  process.exit(1);
+}
+
+console.log("\n✅ All ESM tests passed!");
+console.log("\nThis is the primary/recommended way to use this package.");

--- a/packages/wasm-utxo/js/address.ts
+++ b/packages/wasm-utxo/js/address.ts
@@ -1,5 +1,5 @@
-import { AddressNamespace } from "./wasm/wasm_utxo";
-import type { CoinName } from "./coinName";
+import { AddressNamespace } from "./wasm/wasm_utxo.js";
+import type { CoinName } from "./coinName.js";
 
 /**
  * Most coins only have one unambiguous address format (base58check and bech32/bech32m)

--- a/packages/wasm-utxo/js/ast/fromWasmNode.ts
+++ b/packages/wasm-utxo/js/ast/fromWasmNode.ts
@@ -1,5 +1,5 @@
-import { DescriptorNode, MiniscriptNode, TapTreeNode } from "./formatNode";
-import { Descriptor, Miniscript } from "../index";
+import { DescriptorNode, MiniscriptNode, TapTreeNode } from "./formatNode.js";
+import { Descriptor, Miniscript } from "../index.js";
 
 function getSingleEntry(v: unknown): [string, unknown] {
   if (typeof v === "object" && v) {

--- a/packages/wasm-utxo/js/ast/index.ts
+++ b/packages/wasm-utxo/js/ast/index.ts
@@ -1,2 +1,2 @@
-export * from "./formatNode";
-export * from "./fromWasmNode";
+export * from "./formatNode.js";
+export * from "./fromWasmNode.js";

--- a/packages/wasm-utxo/js/fixedScriptWallet.ts
+++ b/packages/wasm-utxo/js/fixedScriptWallet.ts
@@ -1,8 +1,8 @@
-import { FixedScriptWalletNamespace } from "./wasm/wasm_utxo";
-import type { UtxolibName, UtxolibNetwork, UtxolibRootWalletKeys } from "./utxolibCompat";
-import type { CoinName } from "./coinName";
-import { Triple } from "./triple";
-import { AddressFormat } from "./address";
+import { FixedScriptWalletNamespace } from "./wasm/wasm_utxo.js";
+import type { UtxolibName, UtxolibNetwork, UtxolibRootWalletKeys } from "./utxolibCompat.js";
+import type { CoinName } from "./coinName.js";
+import { Triple } from "./triple.js";
+import { AddressFormat } from "./address.js";
 
 export type NetworkName = UtxolibName | CoinName;
 
@@ -78,7 +78,7 @@ export type ParsedTransaction = {
   virtualSize: number;
 };
 
-import { BitGoPsbt as WasmBitGoPsbt } from "./wasm/wasm_utxo";
+import { BitGoPsbt as WasmBitGoPsbt } from "./wasm/wasm_utxo.js";
 
 export class BitGoPsbt {
   private constructor(private wasm: WasmBitGoPsbt) {}

--- a/packages/wasm-utxo/js/index.ts
+++ b/packages/wasm-utxo/js/index.ts
@@ -1,17 +1,17 @@
-import * as wasm from "./wasm/wasm_utxo";
+import * as wasm from "./wasm/wasm_utxo.js";
 
 // we need to access the wasm module here, otherwise webpack gets all weird
 // and forgets to include it in the bundle
 void wasm;
 
-export * as address from "./address";
-export * as ast from "./ast";
-export * as utxolibCompat from "./utxolibCompat";
-export * as fixedScriptWallet from "./fixedScriptWallet";
+export * as address from "./address.js";
+export * as ast from "./ast/index.js";
+export * as utxolibCompat from "./utxolibCompat.js";
+export * as fixedScriptWallet from "./fixedScriptWallet.js";
 
-export type { CoinName } from "./coinName";
-export type { Triple } from "./triple";
-export type { AddressFormat } from "./address";
+export type { CoinName } from "./coinName.js";
+export type { Triple } from "./triple.js";
+export type { AddressFormat } from "./address.js";
 
 export type DescriptorPkType = "derivable" | "definite" | "string";
 
@@ -21,7 +21,7 @@ export type SignPsbtResult = {
   [inputIndex: number]: [pubkey: string][];
 };
 
-declare module "./wasm/wasm_utxo" {
+declare module "./wasm/wasm_utxo.js" {
   interface WrapDescriptor {
     /** These are not the same types of nodes as in the ast module */
     node(): unknown;
@@ -48,6 +48,6 @@ declare module "./wasm/wasm_utxo" {
   }
 }
 
-export { WrapDescriptor as Descriptor } from "./wasm/wasm_utxo";
-export { WrapMiniscript as Miniscript } from "./wasm/wasm_utxo";
-export { WrapPsbt as Psbt } from "./wasm/wasm_utxo";
+export { WrapDescriptor as Descriptor } from "./wasm/wasm_utxo.js";
+export { WrapMiniscript as Miniscript } from "./wasm/wasm_utxo.js";
+export { WrapPsbt as Psbt } from "./wasm/wasm_utxo.js";

--- a/packages/wasm-utxo/js/utxolibCompat.ts
+++ b/packages/wasm-utxo/js/utxolibCompat.ts
@@ -1,6 +1,6 @@
-import type { AddressFormat } from "./address";
-import { Triple } from "./triple";
-import { UtxolibCompatNamespace } from "./wasm/wasm_utxo";
+import type { AddressFormat } from "./address.js";
+import { Triple } from "./triple.js";
+import { UtxolibCompatNamespace } from "./wasm/wasm_utxo.js";
 
 export type UtxolibName =
   | "bitcoin"

--- a/packages/wasm-utxo/package.json
+++ b/packages/wasm-utxo/package.json
@@ -2,45 +2,50 @@
   "name": "@bitgo/wasm-utxo",
   "description": "WebAssembly wrapper for rust-bitcoin (beta)",
   "version": "0.0.2",
+  "type": "module",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/BitGo/BitGoWASM"
   },
   "license": "MIT",
   "files": [
-    "dist/*/js/wasm/wasm_utxo.d.ts",
-    "dist/*/js/wasm/wasm_utxo.js",
-    "dist/*/js/wasm/wasm_utxo_bg.js",
-    "dist/*/js/wasm/wasm_utxo_bg.wasm",
-    "dist/*/js/wasm/wasm_utxo_bg.wasm.d.ts",
-    "dist/*/js/ast/*",
-    "dist/*/js/index.*",
-    "dist/*/js/address.*",
-    "dist/*/js/utxolibCompat.*",
-    "dist/*/js/fixedScriptWallet.*",
-    "dist/*/js/coinName.*",
-    "dist/*/js/triple.*"
+    "dist/esm/**/*",
+    "dist/cjs/**/*"
   ],
-  "main": "dist/node/js/index.js",
-  "types": "dist/node/js/index.d.ts",
-  "sideEffects": [
-    "./dist/node/js/wasm/wasm_utxo.js",
-    "./dist/browser/js/wasm/wasm_utxo.js"
-  ],
-  "browser": {
-    "./dist/node/js/index.js": "./dist/browser/js/index.js"
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/esm/index.d.ts",
+        "default": "./dist/esm/index.js"
+      },
+      "require": {
+        "types": "./dist/cjs/index.d.ts",
+        "default": "./dist/cjs/index.js"
+      }
+    }
   },
+  "main": "./dist/cjs/index.js",
+  "module": "./dist/esm/index.js",
+  "types": "./dist/esm/index.d.ts",
+  "sideEffects": [
+    "./dist/esm/wasm/wasm_utxo.js",
+    "./dist/cjs/wasm/wasm_utxo.js"
+  ],
   "scripts": {
     "test": "npm run test:mocha && npm run test:wasm-pack",
     "test:mocha": "mocha --recursive test",
     "test:wasm-pack": "npm run test:wasm-pack-node && npm run test:wasm-pack-chrome",
     "test:wasm-pack-node": "wasm-pack test --node",
     "test:wasm-pack-chrome": "wasm-pack test --headless --chrome",
-    "build:wasm": "make js/wasm/ && make dist/node/js/wasm/ && make dist/browser/js/wasm/",
-    "build:ts-browser": "tsc --noEmit false --module es2020 --target es2020 --outDir dist/browser",
-    "build:ts-node": "tsc --noEmit false --outDir dist/node",
-    "build:ts": "npm run build:ts-browser && npm run build:ts-node",
-    "build": "npm run build:wasm && npm run build:ts",
+    "test:esm-import": "node --experimental-wasm-modules bundler-test/test-esm-import.mjs",
+    "test:cjs-import": "node bundler-test/test-cjs-import.cjs",
+    "test:imports": "npm run test:esm-import && npm run test:cjs-import",
+    "build:wasm": "make js/wasm/ && make dist/esm/wasm/ && make dist/cjs/wasm/",
+    "build:ts-esm": "tsc",
+    "build:ts-cjs": "tsc --project tsconfig.cjs.json",
+    "build:ts": "npm run build:ts-esm && npm run build:ts-cjs",
+    "build:package-json": "echo '{\"type\":\"commonjs\"}' > dist/cjs/package.json",
+    "build": "npm run build:wasm && npm run build:ts && npm run build:package-json",
     "check-fmt": "prettier --check . && cargo fmt -- --check"
   },
   "devDependencies": {

--- a/packages/wasm-utxo/test/address/utxolibCompat.ts
+++ b/packages/wasm-utxo/test/address/utxolibCompat.ts
@@ -1,9 +1,19 @@
 import * as path from "node:path";
 import * as fs from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import { dirname } from "node:path";
 
 import * as utxolib from "@bitgo/utxo-lib";
 import assert from "node:assert";
-import { utxolibCompat, address as addressNs, type CoinName, AddressFormat } from "../../js";
+import {
+  utxolibCompat,
+  address as addressNs,
+  type CoinName,
+  AddressFormat,
+} from "../../js/index.js";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
 
 type Triple<T> = [T, T, T];
 

--- a/packages/wasm-utxo/test/ast/formatNode.ts
+++ b/packages/wasm-utxo/test/ast/formatNode.ts
@@ -1,6 +1,6 @@
 import * as assert from "assert";
 
-import { formatNode } from "../../js/ast";
+import { formatNode } from "../../js/ast/index.js";
 
 describe("formatNode", function () {
   it("formats simple nodes", function () {

--- a/packages/wasm-utxo/test/descriptorUtil.ts
+++ b/packages/wasm-utxo/test/descriptorUtil.ts
@@ -1,7 +1,7 @@
 import * as assert from "node:assert";
 import * as fs from "fs/promises";
 import * as utxolib from "@bitgo/utxo-lib";
-import { DescriptorNode, MiniscriptNode, formatNode } from "../js/ast";
+import { DescriptorNode, MiniscriptNode, formatNode } from "../js/ast/index.js";
 
 async function assertEqualJSON(path: string, value: unknown): Promise<void> {
   try {

--- a/packages/wasm-utxo/test/fixedScript/address.ts
+++ b/packages/wasm-utxo/test/fixedScript/address.ts
@@ -2,7 +2,7 @@ import assert from "node:assert";
 
 import * as utxolib from "@bitgo/utxo-lib";
 
-import { AddressFormat, fixedScriptWallet } from "../../js";
+import { AddressFormat, fixedScriptWallet } from "../../js/index.js";
 
 type Triple<T> = [T, T, T];
 

--- a/packages/wasm-utxo/test/fixedScript/fixtureUtil.ts
+++ b/packages/wasm-utxo/test/fixedScript/fixtureUtil.ts
@@ -1,6 +1,11 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import { dirname } from "node:path";
 import * as utxolib from "@bitgo/utxo-lib";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
 
 export type SignatureState = "unsigned" | "halfsigned" | "fullsigned";
 

--- a/packages/wasm-utxo/test/fixedScript/parseTransactionWithWalletKeys.ts
+++ b/packages/wasm-utxo/test/fixedScript/parseTransactionWithWalletKeys.ts
@@ -1,8 +1,8 @@
 import assert from "node:assert";
 import * as utxolib from "@bitgo/utxo-lib";
-import { fixedScriptWallet } from "../../js";
-import { BitGoPsbt } from "../../js/fixedScriptWallet";
-import { loadPsbtFixture, loadWalletKeysFromFixture, getPsbtBuffer } from "./fixtureUtil";
+import { fixedScriptWallet } from "../../js/index.js";
+import { BitGoPsbt } from "../../js/fixedScriptWallet.js";
+import { loadPsbtFixture, loadWalletKeysFromFixture, getPsbtBuffer } from "./fixtureUtil.js";
 
 function getOtherWalletKeys(): utxolib.bitgo.RootWalletKeys {
   const otherWalletKeys = utxolib.testutil.getKeyTriple("too many secrets");

--- a/packages/wasm-utxo/test/fixedScript/verifySignature.ts
+++ b/packages/wasm-utxo/test/fixedScript/verifySignature.ts
@@ -1,13 +1,13 @@
 import assert from "node:assert";
 import * as utxolib from "@bitgo/utxo-lib";
-import { fixedScriptWallet } from "../../js";
-import { BitGoPsbt } from "../../js/fixedScriptWallet";
+import { fixedScriptWallet } from "../../js/index.js";
+import { BitGoPsbt } from "../../js/fixedScriptWallet.js";
 import {
   loadPsbtFixture,
   loadWalletKeysFromFixture,
   getPsbtBuffer,
   type Fixture,
-} from "./fixtureUtil";
+} from "./fixtureUtil.js";
 
 type SignatureStage = "unsigned" | "halfsigned" | "fullsigned";
 

--- a/packages/wasm-utxo/test/fixedScriptToDescriptor.ts
+++ b/packages/wasm-utxo/test/fixedScriptToDescriptor.ts
@@ -1,7 +1,7 @@
 import * as assert from "assert";
 import * as utxolib from "@bitgo/utxo-lib";
-import { Descriptor } from "../js";
-import { getDescriptorForScriptType } from "./descriptorUtil";
+import { Descriptor } from "../js/index.js";
+import { getDescriptorForScriptType } from "./descriptorUtil.js";
 
 const rootWalletKeys = new utxolib.bitgo.RootWalletKeys(utxolib.testutil.getKeyTriple("wasm"));
 const scriptTypes = ["p2sh", "p2shP2wsh", "p2wsh"] as const;

--- a/packages/wasm-utxo/test/opdrop.ts
+++ b/packages/wasm-utxo/test/opdrop.ts
@@ -1,8 +1,8 @@
 import * as assert from "assert";
 import * as utxolib from "@bitgo/utxo-lib";
-import { Descriptor } from "../js";
-import { finalizePsbt, updateInputWithDescriptor } from "./psbt.util";
-import { getFixture } from "./fixtures";
+import { Descriptor } from "../js/index.js";
+import { finalizePsbt, updateInputWithDescriptor } from "./psbt.util.js";
+import { getFixture } from "./fixtures.js";
 
 const rootWalletKeys = new utxolib.bitgo.RootWalletKeys(utxolib.testutil.getKeyTriple("wasm"));
 

--- a/packages/wasm-utxo/test/psbt.util.ts
+++ b/packages/wasm-utxo/test/psbt.util.ts
@@ -1,6 +1,6 @@
 import * as assert from "node:assert";
 import * as utxolib from "@bitgo/utxo-lib";
-import { Descriptor, Psbt } from "../js";
+import { Descriptor, Psbt } from "../js/index.js";
 
 function toAddress(descriptor: Descriptor, network: utxolib.Network) {
   utxolib.address.fromOutputScript(Buffer.from(descriptor.scriptPubkey()), network);

--- a/packages/wasm-utxo/test/psbtFixedScriptCompat.ts
+++ b/packages/wasm-utxo/test/psbtFixedScriptCompat.ts
@@ -1,10 +1,15 @@
 import * as utxolib from "@bitgo/utxo-lib";
 import * as assert from "node:assert";
-import { getPsbtFixtures, PsbtStage } from "./psbtFixedScriptCompatFixtures";
-import { Descriptor, Psbt } from "../js";
+import { getPsbtFixtures, PsbtStage } from "./psbtFixedScriptCompatFixtures.js";
+import { Descriptor, Psbt } from "../js/index.js";
 
-import { getDescriptorForScriptType } from "./descriptorUtil";
-import { assertEqualPsbt, toUtxoPsbt, toWrappedPsbt, updateInputWithDescriptor } from "./psbt.util";
+import { getDescriptorForScriptType } from "./descriptorUtil.js";
+import {
+  assertEqualPsbt,
+  toUtxoPsbt,
+  toWrappedPsbt,
+  updateInputWithDescriptor,
+} from "./psbt.util.js";
 import { getKey } from "@bitgo/utxo-lib/dist/src/testutil";
 
 const rootWalletKeys = new utxolib.bitgo.RootWalletKeys(utxolib.testutil.getKeyTriple("wasm"));

--- a/packages/wasm-utxo/test/psbtFromDescriptor.ts
+++ b/packages/wasm-utxo/test/psbtFromDescriptor.ts
@@ -2,10 +2,10 @@ import assert from "node:assert";
 import { BIP32Interface, ECPair, ECPairInterface } from "@bitgo/utxo-lib";
 import { getKey } from "@bitgo/utxo-lib/dist/src/testutil";
 
-import { DescriptorNode, formatNode } from "../js/ast";
-import { mockPsbtDefault } from "./psbtFromDescriptor.util";
-import { Descriptor } from "../js";
-import { toWrappedPsbt } from "./psbt.util";
+import { DescriptorNode, formatNode } from "../js/ast/index.js";
+import { mockPsbtDefault } from "./psbtFromDescriptor.util.js";
+import { Descriptor } from "../js/index.js";
+import { toWrappedPsbt } from "./psbt.util.js";
 
 function toKeyWithPath(k: BIP32Interface, path = "*"): string {
   return k.neutered().toBase58() + "/" + path;

--- a/packages/wasm-utxo/test/psbtFromDescriptor.util.ts
+++ b/packages/wasm-utxo/test/psbtFromDescriptor.util.ts
@@ -1,6 +1,6 @@
 import * as utxolib from "@bitgo/utxo-lib";
-import { toUtxoPsbt, toWrappedPsbt } from "./psbt.util";
-import { Descriptor } from "../js";
+import { toUtxoPsbt, toWrappedPsbt } from "./psbt.util.js";
+import { Descriptor } from "../js/index.js";
 
 export function createScriptPubKeyFromDescriptor(descriptor: Descriptor, index?: number): Buffer {
   if (index === undefined) {

--- a/packages/wasm-utxo/test/test.ts
+++ b/packages/wasm-utxo/test/test.ts
@@ -1,9 +1,14 @@
 import * as assert from "assert";
-import { Descriptor } from "../js";
-import { fixtures } from "./descriptorFixtures";
-import { assertEqualFixture } from "./descriptorUtil";
-import { fromDescriptor } from "../js/ast";
-import { formatNode } from "../js/ast";
+import { fileURLToPath } from "node:url";
+import { dirname } from "node:path";
+import { Descriptor } from "../js/index.js";
+import { fixtures } from "./descriptorFixtures.js";
+import { assertEqualFixture } from "./descriptorUtil.js";
+import { fromDescriptor } from "../js/ast/index.js";
+import { formatNode } from "../js/ast/index.js";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
 
 function removeChecksum(descriptor: string): string {
   const parts = descriptor.split("#");

--- a/packages/wasm-utxo/tsconfig.cjs.json
+++ b/packages/wasm-utxo/tsconfig.cjs.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "CommonJS",
+    "moduleResolution": "node",
+    "rootDir": "./js",
+    "outDir": "./dist/cjs"
+  }
+}

--- a/packages/wasm-utxo/tsconfig.json
+++ b/packages/wasm-utxo/tsconfig.json
@@ -1,14 +1,16 @@
 {
   "compilerOptions": {
-    "module": "CommonJS",
-    "target": "ESNext",
-    "moduleResolution": "node",
+    "module": "ES2022",
+    "target": "ES2022",
+    "moduleResolution": "bundler",
     "esModuleInterop": true,
     "allowJs": true,
     "skipLibCheck": true,
     "declaration": true,
-    "noEmit": true
+    "composite": true,
+    "rootDir": "./js",
+    "outDir": "./dist/esm"
   },
-  "include": ["./js/**/*.ts", "test/**/*.ts"],
-  "exclude": ["node_modules", "./js/wasm/**/*"]
+  "include": ["./js/**/*.ts"],
+  "exclude": ["node_modules", "./js/wasm/**/*", "test"]
 }


### PR DESCRIPTION

This PR adds ESM as the primary module format while maintaining CJS 
compatibility for the wasm-utxo package. It also enhances TypeScript 
configuration and improves the UI module by replacing utxolib dependencies.

## Changes

- Set "type": "module" in package.json with dual ESM/CJS output
- Configure proper exports field for module resolution
- Add .js extensions to imports for ESM compatibility
- Update build scripts for both ESM and CJS outputs
- Configure tests to work with ESM imports
- Add bundler compatibility tests for both formats
- Update mocha config for ESM testing
- Emit compiled code directly to dist directory for both formats
- Add composite flag for project references
- Replace utxolib in UI package with wasm-utxo address functions
- Update address generation to use fromOutputScriptWithCoin

Issue: esm-first.2