### PR TITLE
chore(wasm-utxo): fix vscode and compile settings

### DIFF
--- a/packages/wasm-utxo/.vscode/settings.json
+++ b/packages/wasm-utxo/.vscode/settings.json
@@ -1,0 +1,9 @@
+{
+  "makefile.configureOnOpen": false,
+  "mochaExplorer.files": "test/**/*.ts",
+  "mochaExplorer.logpanel": true,
+  "mochaExplorer.esmLoader": true,
+  "mochaExplorer.nodeArgv": ["--import=tsx/esm", "--experimental-wasm-modules"],
+  "rust-analyzer.check.command": "clippy",
+  "rust-analyzer.check.extraArgs": ["--", "-W", "clippy::all"]
+}

--- a/packages/wasm-utxo/Makefile
+++ b/packages/wasm-utxo/Makefile
@@ -38,12 +38,12 @@ endef
 js/wasm/:
 	$(call BUILD,$@,bundler)
 
-.PHONY: dist/esm/wasm/
-dist/esm/wasm/:
+.PHONY: dist/esm/js/wasm/
+dist/esm/js/wasm/:
 	$(call BUILD,$@,bundler)
 
-.PHONY: dist/cjs/wasm/
-dist/cjs/wasm/:
+.PHONY: dist/cjs/js/wasm/
+dist/cjs/js/wasm/:
 	$(call BUILD,$@,nodejs)
 
 .PHONY: lint

--- a/packages/wasm-utxo/bundler-test/test-cjs-import.cjs
+++ b/packages/wasm-utxo/bundler-test/test-cjs-import.cjs
@@ -8,7 +8,7 @@ console.log("Testing CommonJS require() compatibility...\n");
 // Use standard CommonJS require
 let wasmUtxo;
 try {
-  wasmUtxo = require("../dist/cjs/index.js");
+  wasmUtxo = require("../dist/cjs/js/index.js");
 } catch (error) {
   console.error("✗ require() failed:", error.message);
   process.exit(1);

--- a/packages/wasm-utxo/bundler-test/test-esm-import.mjs
+++ b/packages/wasm-utxo/bundler-test/test-esm-import.mjs
@@ -3,7 +3,7 @@
  * Run with: node --experimental-wasm-modules bundler-test/test-esm-import.mjs
  */
 
-import { Descriptor, Psbt, address, fixedScriptWallet } from "../dist/esm/index.js";
+import { Descriptor, Psbt, address, fixedScriptWallet } from "../dist/esm/js/index.js";
 
 console.log("Testing ESM import...\n");
 

--- a/packages/wasm-utxo/package.json
+++ b/packages/wasm-utxo/package.json
@@ -15,24 +15,24 @@
   "exports": {
     ".": {
       "import": {
-        "types": "./dist/esm/index.d.ts",
-        "default": "./dist/esm/index.js"
+        "types": "./dist/esm/js/index.d.ts",
+        "default": "./dist/esm/js/index.js"
       },
       "require": {
-        "types": "./dist/cjs/index.d.ts",
-        "default": "./dist/cjs/index.js"
+        "types": "./dist/cjs/js/index.d.ts",
+        "default": "./dist/cjs/js/index.js"
       }
     }
   },
-  "main": "./dist/cjs/index.js",
-  "module": "./dist/esm/index.js",
-  "types": "./dist/esm/index.d.ts",
+  "main": "./dist/cjs/js/index.js",
+  "module": "./dist/esm/js/index.js",
+  "types": "./dist/esm/js/index.d.ts",
   "sideEffects": [
-    "./dist/esm/wasm/wasm_utxo.js",
-    "./dist/cjs/wasm/wasm_utxo.js"
+    "./dist/esm/js/wasm/wasm_utxo.js",
+    "./dist/cjs/js/wasm/wasm_utxo.js"
   ],
   "scripts": {
-    "test": "npm run test:mocha && npm run test:wasm-pack",
+    "test": "npm run test:mocha && npm run test:wasm-pack && npm run test:imports",
     "test:mocha": "mocha --recursive test",
     "test:wasm-pack": "npm run test:wasm-pack-node && npm run test:wasm-pack-chrome",
     "test:wasm-pack-node": "wasm-pack test --node",
@@ -40,7 +40,7 @@
     "test:esm-import": "node --experimental-wasm-modules bundler-test/test-esm-import.mjs",
     "test:cjs-import": "node bundler-test/test-cjs-import.cjs",
     "test:imports": "npm run test:esm-import && npm run test:cjs-import",
-    "build:wasm": "make js/wasm/ && make dist/esm/wasm/ && make dist/cjs/wasm/",
+    "build:wasm": "make js/wasm/ && make dist/esm/js/wasm/ && make dist/cjs/js/wasm/",
     "build:ts-esm": "tsc",
     "build:ts-cjs": "tsc --project tsconfig.cjs.json",
     "build:ts": "npm run build:ts-esm && npm run build:ts-cjs",

--- a/packages/wasm-utxo/tsconfig.cjs.json
+++ b/packages/wasm-utxo/tsconfig.cjs.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "module": "CommonJS",
     "moduleResolution": "node",
-    "rootDir": "./js",
+    "rootDir": ".",
     "outDir": "./dist/cjs"
-  }
+  },
+  "exclude": ["test/**/*"]
 }

--- a/packages/wasm-utxo/tsconfig.json
+++ b/packages/wasm-utxo/tsconfig.json
@@ -8,9 +8,9 @@
     "skipLibCheck": true,
     "declaration": true,
     "composite": true,
-    "rootDir": "./js",
+    "rootDir": ".",
     "outDir": "./dist/esm"
   },
-  "include": ["./js/**/*.ts"],
-  "exclude": ["node_modules", "./js/wasm/**/*", "test"]
+  "include": ["./js/**/*.ts", "test/**/*.ts"],
+  "exclude": ["node_modules", "./js/wasm/**/*"]
 }


### PR DESCRIPTION
Configure mocha explorer, rust-analyzer, and makefile settings for
better developer experience.


A previous change excluded the `test/` dir from compilation. This change includes it again and moves around the `dist/` layout.

Issue: BTC-0