### PR TITLE
feat(wasm-utxo): add input script type detection

### DIFF
--- a/packages/wasm-utxo/js/fixedScriptWallet.ts
+++ b/packages/wasm-utxo/js/fixedScriptWallet.ts
@@ -56,11 +56,21 @@ type ReplayProtection =
 
 export type ScriptId = { chain: number; index: number };
 
+export type InputScriptType =
+  | "p2shP2pk"
+  | "p2sh"
+  | "p2shP2wsh"
+  | "p2wsh"
+  | "p2trLegacy"
+  | "p2trMusig2ScriptPath"
+  | "p2trMusig2KeyPath";
+
 export type ParsedInput = {
   address: string;
   script: Uint8Array;
   value: bigint;
   scriptId: ScriptId | null;
+  scriptType: InputScriptType;
 };
 
 export type ParsedOutput = {

--- a/packages/wasm-utxo/src/fixed_script_wallet/bitgo_psbt/mod.rs
+++ b/packages/wasm-utxo/src/fixed_script_wallet/bitgo_psbt/mod.rs
@@ -97,7 +97,7 @@ pub enum BitGoPsbt {
 }
 
 // Re-export types from submodules for convenience
-pub use psbt_wallet_input::{ParsedInput, ScriptId};
+pub use psbt_wallet_input::{InputScriptType, ParsedInput, ScriptId};
 pub use psbt_wallet_output::ParsedOutput;
 
 /// Parsed transaction with wallet information

--- a/packages/wasm-utxo/src/wasm/try_into_js_value.rs
+++ b/packages/wasm-utxo/src/wasm/try_into_js_value.rs
@@ -317,12 +317,29 @@ impl TryIntoJsValue for crate::fixed_script_wallet::bitgo_psbt::ScriptId {
     }
 }
 
+impl TryIntoJsValue for crate::fixed_script_wallet::bitgo_psbt::InputScriptType {
+    fn try_to_js_value(&self) -> Result<JsValue, WasmUtxoError> {
+        use crate::fixed_script_wallet::bitgo_psbt::InputScriptType;
+        let script_type = match self {
+            InputScriptType::P2shP2pk => "p2shP2pk",
+            InputScriptType::P2sh => "p2sh",
+            InputScriptType::P2shP2wsh => "p2shP2wsh",
+            InputScriptType::P2wsh => "p2wsh",
+            InputScriptType::P2trLegacy => "p2trLegacy",
+            InputScriptType::P2trMusig2ScriptPath => "p2trMusig2ScriptPath",
+            InputScriptType::P2trMusig2KeyPath => "p2trMusig2KeyPath",
+        };
+        Ok(JsValue::from_str(script_type))
+    }
+}
+
 impl TryIntoJsValue for crate::fixed_script_wallet::bitgo_psbt::ParsedInput {
     fn try_to_js_value(&self) -> Result<JsValue, WasmUtxoError> {
         js_obj!(
             "address" => self.address.clone(),
             "value" => self.value,
-            "scriptId" => self.script_id
+            "scriptId" => self.script_id,
+            "scriptType" => self.script_type
         )
     }
 }


### PR DESCRIPTION

Add InputScriptType enum to determine the script type of transaction inputs.
Implement detection logic based on script chain and PSBT metadata to
identify input types (p2sh, p2wsh, p2tr variants, etc). Include the
detected script type in ParsedInput to help with signature validation.

Issue: BTC-2786