### PR TITLE
feat(wasm-utxo): implement signing workflow

### DIFF
--- a/packages/wasm-utxo/js/fixedScriptWallet/BitGoPsbt.ts
+++ b/packages/wasm-utxo/js/fixedScriptWallet/BitGoPsbt.ts
@@ -266,7 +266,8 @@ export class BitGoPsbt {
    * // Send PSBT to counterparty
    *
    * // Phase 2: After receiving counterparty PSBT with their nonces
-   * psbt.combine(counterpartyPsbtBytes);
+   * const counterpartyPsbt = BitGoPsbt.fromBytes(counterpartyPsbtBytes, network);
+   * psbt.combineMusig2Nonces(counterpartyPsbt);
    * // Sign MuSig2 key path inputs
    * const parsed = psbt.parseTransactionWithWalletKeys(walletKeys, replayProtection);
    * for (let i = 0; i < parsed.inputs.length; i++) {
@@ -279,6 +280,29 @@ export class BitGoPsbt {
   generateMusig2Nonces(key: BIP32Arg, sessionId?: Uint8Array): void {
     const wasmKey = BIP32.from(key);
     this.wasm.generate_musig2_nonces(wasmKey.wasm, sessionId);
+  }
+
+  /**
+   * Combine/merge data from another PSBT into this one
+   *
+   * This method copies MuSig2 nonces and signatures (proprietary key-value pairs) from the
+   * source PSBT to this PSBT. This is useful for merging PSBTs during the nonce exchange
+   * and signature collection phases.
+   *
+   * @param sourcePsbt - The source PSBT containing data to merge
+   * @throws Error if networks don't match
+   *
+   * @example
+   * ```typescript
+   * // After receiving counterparty's PSBT with their nonces
+   * const counterpartyPsbt = BitGoPsbt.fromBytes(counterpartyPsbtBytes, network);
+   * psbt.combineMusig2Nonces(counterpartyPsbt);
+   * // Now can sign with all nonces present
+   * psbt.sign(0, userXpriv);
+   * ```
+   */
+  combineMusig2Nonces(sourcePsbt: BitGoPsbt): void {
+    this.wasm.combine_musig2_nonces(sourcePsbt.wasm);
   }
 
   /**

--- a/packages/wasm-utxo/src/fixed_script_wallet/bitgo_psbt/mod.rs
+++ b/packages/wasm-utxo/src/fixed_script_wallet/bitgo_psbt/mod.rs
@@ -426,6 +426,146 @@ impl BitGoPsbt {
             .map_err(|e| e.to_string())
     }
 
+    /// Sign a single input with a raw private key
+    ///
+    /// This method signs a specific input using the provided private key. It automatically
+    /// detects the input type and uses the appropriate signing method:
+    /// - Replay protection inputs (P2SH-P2PK): Signs with legacy P2SH sighash
+    /// - Regular inputs: Uses standard PSBT signing
+    /// - MuSig2 inputs: Returns error (requires FirstRound state, use sign_with_first_round)
+    ///
+    /// # Arguments
+    /// - `input_index`: The index of the input to sign
+    /// - `privkey`: The private key to sign with
+    ///
+    /// # Returns
+    /// - `Ok(())` if signing was successful
+    /// - `Err(String)` if signing fails or input type is not supported
+    pub fn sign_with_privkey(
+        &mut self,
+        input_index: usize,
+        privkey: &secp256k1::SecretKey,
+    ) -> Result<(), String> {
+        use miniscript::bitcoin::{
+            ecdsa::Signature as EcdsaSignature, hashes::Hash, sighash::SighashCache, PublicKey,
+        };
+
+        // Get network before mutable borrow
+        let network = self.network();
+        let is_testnet = network.is_testnet();
+
+        let psbt = self.psbt_mut();
+
+        // Check bounds
+        if input_index >= psbt.inputs.len() {
+            return Err(format!(
+                "Input index {} out of bounds (total inputs: {})",
+                input_index,
+                psbt.inputs.len()
+            ));
+        }
+
+        // Check if this is a MuSig2 input
+        if p2tr_musig2_input::Musig2Input::is_musig2_input(&psbt.inputs[input_index]) {
+            return Err(
+                "MuSig2 inputs cannot be signed with raw privkey. Use sign_with_first_round instead."
+                    .to_string(),
+            );
+        }
+
+        let secp = secp256k1::Secp256k1::new();
+
+        // Derive public key from private key
+        let public_key = PublicKey::from_slice(
+            &secp256k1::PublicKey::from_secret_key(&secp, privkey).serialize(),
+        )
+        .map_err(|e| format!("Failed to derive public key: {}", e))?;
+
+        // Check if this is a replay protection input (P2SH-P2PK)
+        if let Some(redeem_script) = &psbt.inputs[input_index].redeem_script.clone() {
+            // Try to extract pubkey from redeem script
+            if let Ok(redeem_pubkey) = Self::extract_pubkey_from_p2pk_redeem_script(redeem_script) {
+                // This is a replay protection input - verify the derived pubkey matches
+                if public_key != redeem_pubkey {
+                    return Err(
+                        "Public key mismatch: derived pubkey does not match redeem_script pubkey"
+                            .to_string(),
+                    );
+                }
+
+                // Sign the replay protection input with legacy P2SH sighash
+                let sighash_type = miniscript::bitcoin::sighash::EcdsaSighashType::All;
+                let cache = SighashCache::new(&psbt.unsigned_tx);
+                let sighash = cache
+                    .legacy_signature_hash(input_index, redeem_script, sighash_type.to_u32())
+                    .map_err(|e| format!("Failed to compute sighash: {}", e))?;
+
+                // Create ECDSA signature
+                let message = secp256k1::Message::from_digest(sighash.to_byte_array());
+                let signature = secp.sign_ecdsa(&message, privkey);
+                let ecdsa_sig = EcdsaSignature {
+                    signature,
+                    sighash_type,
+                };
+
+                // Add signature to partial_sigs
+                psbt.inputs[input_index]
+                    .partial_sigs
+                    .insert(public_key, ecdsa_sig);
+
+                return Ok(());
+            }
+        }
+
+        // For regular inputs (non-RP, non-MuSig2), use standard signing via miniscript
+        // This will handle legacy, SegWit, and Taproot script path inputs
+        match self {
+            BitGoPsbt::BitcoinLike(ref mut psbt, _network) => {
+                // Create a key provider that returns our single key
+                // Convert SecretKey to PrivateKey for the GetKey trait
+                // Note: The network parameter is only used for WIF serialization, not for signing
+                let bitcoin_network = if is_testnet {
+                    miniscript::bitcoin::Network::Testnet
+                } else {
+                    miniscript::bitcoin::Network::Bitcoin
+                };
+                let private_key = miniscript::bitcoin::PrivateKey::new(*privkey, bitcoin_network);
+                let key_map = std::collections::BTreeMap::from_iter([(public_key, private_key)]);
+
+                // Sign the PSBT
+                let result = psbt.sign(&key_map, &secp);
+
+                // Check if our specific input was signed
+                match result {
+                    Ok(signing_keys) => {
+                        if signing_keys.contains_key(&input_index) {
+                            Ok(())
+                        } else {
+                            Err(format!(
+                                "Input {} was not signed (no key found or already signed)",
+                                input_index
+                            ))
+                        }
+                    }
+                    Err((partial_success, errors)) => {
+                        // Check if there's an error for our specific input
+                        if let Some(error) = errors.get(&input_index) {
+                            Err(format!("Failed to sign input {}: {:?}", input_index, error))
+                        } else if partial_success.contains_key(&input_index) {
+                            // Input was signed successfully despite other errors
+                            Ok(())
+                        } else {
+                            Err(format!("Input {} was not signed", input_index))
+                        }
+                    }
+                }
+            }
+            BitGoPsbt::Zcash(_zcash_psbt, _network) => {
+                Err("Zcash signing not yet implemented".to_string())
+            }
+        }
+    }
+
     /// Sign the PSBT with the provided key.
     /// Wraps the underlying PSBT's sign method from miniscript::psbt::PsbtExt.
     ///

--- a/packages/wasm-utxo/src/wasm/bip32.rs
+++ b/packages/wasm-utxo/src/wasm/bip32.rs
@@ -334,4 +334,12 @@ impl WasmBIP32 {
     pub(crate) fn to_xpub(&self) -> Result<crate::bitcoin::bip32::Xpub, WasmUtxoError> {
         Ok(self.0.to_xpub())
     }
+
+    /// Convert to Xpriv (for internal Rust use, not exposed to JS)
+    pub(crate) fn to_xpriv(&self) -> Result<crate::bitcoin::bip32::Xpriv, WasmUtxoError> {
+        match &self.0 {
+            BIP32Key::Private(xpriv) => Ok(*xpriv),
+            BIP32Key::Public(_) => Err(WasmUtxoError::new("Cannot get xpriv from public key")),
+        }
+    }
 }

--- a/packages/wasm-utxo/src/wasm/ecpair.rs
+++ b/packages/wasm-utxo/src/wasm/ecpair.rs
@@ -41,6 +41,13 @@ impl WasmECPair {
     pub(crate) fn get_public_key(&self) -> PublicKey {
         self.key.public_key()
     }
+
+    /// Get the private key as a secp256k1::SecretKey (for internal Rust use)
+    pub(crate) fn get_private_key(&self) -> Result<SecretKey, WasmUtxoError> {
+        self.key
+            .secret_key()
+            .ok_or_else(|| WasmUtxoError::new("Cannot get private key from public-only ECPair"))
+    }
 }
 
 #[wasm_bindgen]

--- a/packages/wasm-utxo/src/wasm/fixed_script_wallet.rs
+++ b/packages/wasm-utxo/src/wasm/fixed_script_wallet.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsValue;
 
@@ -83,6 +84,9 @@ impl FixedScriptWalletNamespace {
 #[wasm_bindgen]
 pub struct BitGoPsbt {
     psbt: crate::fixed_script_wallet::bitgo_psbt::BitGoPsbt,
+    // Store FirstRound states per (input_index, xpub_string)
+    #[wasm_bindgen(skip)]
+    first_rounds: HashMap<(usize, String), musig2::FirstRound>,
 }
 
 #[wasm_bindgen]
@@ -95,7 +99,10 @@ impl BitGoPsbt {
             crate::fixed_script_wallet::bitgo_psbt::BitGoPsbt::deserialize(bytes, network)
                 .map_err(|e| WasmUtxoError::new(&format!("Failed to deserialize PSBT: {}", e)))?;
 
-        Ok(BitGoPsbt { psbt })
+        Ok(BitGoPsbt {
+            psbt,
+            first_rounds: HashMap::new(),
+        })
     }
 
     /// Get the unsigned transaction ID
@@ -260,6 +267,108 @@ impl BitGoPsbt {
         self.psbt
             .serialize()
             .map_err(|e| WasmUtxoError::new(&format!("Failed to serialize PSBT: {}", e)))
+    }
+
+    /// Generate and store MuSig2 nonces for all MuSig2 inputs
+    ///
+    /// This method generates nonces using the State-Machine API and stores them in the PSBT.
+    /// The nonces are stored as proprietary fields in the PSBT and will be included when serialized.
+    /// After ALL participants have generated their nonces, they can sign MuSig2 inputs using
+    /// sign_with_xpriv().
+    ///
+    /// # Arguments
+    /// * `xpriv` - The extended private key (xpriv) for signing
+    /// * `session_id_bytes` - Optional 32-byte session ID for nonce generation. **Only allowed on testnets**.
+    ///                        On mainnets, a secure random session ID is always generated automatically.
+    ///                        Must be unique per signing session.
+    ///
+    /// # Returns
+    /// Ok(()) if nonces were successfully generated and stored
+    ///
+    /// # Errors
+    /// Returns error if:
+    /// - Nonce generation fails
+    /// - session_id length is invalid
+    /// - Custom session_id is provided on a mainnet (security restriction)
+    ///
+    /// # Security
+    /// The session_id MUST be cryptographically random and unique for each signing session.
+    /// Never reuse a session_id with the same key! On mainnets, session_id is always randomly
+    /// generated for security. Custom session_id is only allowed on testnets for testing purposes.
+    pub fn generate_musig2_nonces(
+        &mut self,
+        xpriv: &WasmBIP32,
+        session_id_bytes: Option<Vec<u8>>,
+    ) -> Result<(), WasmUtxoError> {
+        // Extract Xpriv from WasmBIP32
+        let xpriv = xpriv.to_xpriv()?;
+
+        // Get the network from the PSBT to check if custom session_id is allowed
+        let network = self.psbt.network();
+
+        // Get or generate session ID
+        let session_id = match session_id_bytes {
+            Some(bytes) => {
+                // Only allow custom session_id on testnets for security
+                if !network.is_testnet() {
+                    return Err(WasmUtxoError::new(
+                        "Custom session_id is only allowed on testnets. On mainnets, session_id is always randomly generated for security."
+                    ));
+                }
+                if bytes.len() != 32 {
+                    return Err(WasmUtxoError::new(&format!(
+                        "Session ID must be 32 bytes, got {}",
+                        bytes.len()
+                    )));
+                }
+                let mut session_id = [0u8; 32];
+                session_id.copy_from_slice(&bytes);
+                session_id
+            }
+            None => {
+                // Generate secure random session ID
+                use getrandom::getrandom;
+                let mut session_id = [0u8; 32];
+                getrandom(&mut session_id).map_err(|e| {
+                    WasmUtxoError::new(&format!("Failed to generate random session ID: {}", e))
+                })?;
+                session_id
+            }
+        };
+
+        // Derive xpub from xpriv to use as key
+        let secp = miniscript::bitcoin::secp256k1::Secp256k1::new();
+        let xpub = miniscript::bitcoin::bip32::Xpub::from_priv(&secp, &xpriv);
+        let xpub_str = xpub.to_string();
+
+        // Iterate over all inputs and generate nonces for MuSig2 inputs
+        let input_count = self.psbt.psbt().unsigned_tx.input.len();
+        for input_index in 0..input_count {
+            // Check if this input is a MuSig2 input
+            let psbt = self.psbt.psbt();
+            if !crate::fixed_script_wallet::bitgo_psbt::p2tr_musig2_input::Musig2Input::is_musig2_input(&psbt.inputs[input_index]) {
+                continue;
+            }
+
+            // Generate nonce and get the FirstRound
+            // The nonce is automatically stored in the PSBT
+            let (first_round, _pub_nonce) = self
+                .psbt
+                .generate_nonce_first_round(input_index, &xpriv, session_id)
+                .map_err(|e| {
+                    WasmUtxoError::new(&format!(
+                        "Failed to generate nonce for input {}: {}",
+                        input_index, e
+                    ))
+                })?;
+
+            // Store the FirstRound for later use in signing
+            // Use (input_index, xpub) as key so multiple parties can store their FirstRounds
+            self.first_rounds
+                .insert((input_index, xpub_str.clone()), first_round);
+        }
+
+        Ok(())
     }
 
     /// Finalize all inputs in the PSBT

--- a/packages/wasm-utxo/src/wasm/fixed_script_wallet.rs
+++ b/packages/wasm-utxo/src/wasm/fixed_script_wallet.rs
@@ -504,6 +504,26 @@ impl BitGoPsbt {
             .map_err(|e| WasmUtxoError::new(&format!("Failed to sign input: {}", e)))
     }
 
+    /// Combine/merge data from another PSBT into this one
+    ///
+    /// This method copies MuSig2 nonces and signatures (proprietary key-value pairs) from the
+    /// source PSBT to this PSBT. This is useful for merging PSBTs during the nonce exchange
+    /// and signature collection phases.
+    ///
+    /// # Arguments
+    /// * `source_psbt` - The source PSBT containing data to merge
+    ///
+    /// # Returns
+    /// Ok(()) if data was successfully merged
+    ///
+    /// # Errors
+    /// Returns error if networks don't match
+    pub fn combine_musig2_nonces(&mut self, source_psbt: &BitGoPsbt) -> Result<(), WasmUtxoError> {
+        self.psbt
+            .combine_musig2_nonces(&source_psbt.psbt)
+            .map_err(|e| WasmUtxoError::new(&format!("Failed to combine PSBTs: {}", e)))
+    }
+
     /// Finalize all inputs in the PSBT
     ///
     /// This method attempts to finalize all inputs in the PSBT, computing the final

--- a/packages/wasm-utxo/src/wasm/replay_protection.rs
+++ b/packages/wasm-utxo/src/wasm/replay_protection.rs
@@ -14,6 +14,8 @@ pub struct WasmReplayProtection {
 impl WasmReplayProtection {
     /// Create from output scripts directly
     #[wasm_bindgen]
+    // Box<[T]> is required by wasm-bindgen for passing JavaScript arrays
+    #[allow(clippy::boxed_local)]
     pub fn from_output_scripts(output_scripts: Box<[js_sys::Uint8Array]>) -> WasmReplayProtection {
         let scripts = output_scripts
             .iter()
@@ -29,6 +31,8 @@ impl WasmReplayProtection {
 
     /// Create from addresses (requires network for decoding)
     #[wasm_bindgen]
+    // Box<[T]> is required by wasm-bindgen for passing JavaScript arrays
+    #[allow(clippy::boxed_local)]
     pub fn from_addresses(
         addresses: Box<[JsValue]>,
         network: &str,
@@ -68,6 +72,8 @@ impl WasmReplayProtection {
 
     /// Create from public keys (derives P2SH-P2PK output scripts)
     #[wasm_bindgen]
+    // Box<[T]> is required by wasm-bindgen for passing JavaScript arrays
+    #[allow(clippy::boxed_local)]
     pub fn from_public_keys(
         public_keys: Box<[js_sys::Uint8Array]>,
     ) -> Result<WasmReplayProtection, WasmUtxoError> {

--- a/packages/wasm-utxo/test/fixedScript/fixtureUtil.ts
+++ b/packages/wasm-utxo/test/fixedScript/fixtureUtil.ts
@@ -7,6 +7,8 @@ import type { IWalletKeys } from "../../js/fixedScriptWallet/RootWalletKeys.js";
 import { BIP32, type BIP32Interface } from "../../js/bip32.js";
 import { RootWalletKeys } from "../../js/fixedScriptWallet/RootWalletKeys.js";
 import { ECPair } from "../../js/ecpair.js";
+import { fixedScriptWallet } from "../../js/index.js";
+import type { BitGoPsbt, NetworkName } from "../../js/fixedScriptWallet/index.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -101,6 +103,16 @@ export type Fixture = {
  */
 export function getPsbtBuffer(fixture: Fixture): Buffer {
   return Buffer.from(fixture.psbtBase64, "base64");
+}
+
+/**
+ * Get BitGoPsbt from a fixture
+ * @param fixture - The test fixture
+ * @param networkName - The network name for deserializing the PSBT
+ * @returns A BitGoPsbt instance
+ */
+export function getBitGoPsbt(fixture: Fixture, networkName: NetworkName): BitGoPsbt {
+  return fixedScriptWallet.BitGoPsbt.fromBytes(getPsbtBuffer(fixture), networkName);
 }
 
 /**

--- a/packages/wasm-utxo/test/fixedScript/musig2Nonces.ts
+++ b/packages/wasm-utxo/test/fixedScript/musig2Nonces.ts
@@ -1,37 +1,89 @@
 import assert from "assert";
-import { BitGoPsbt } from "../../js/fixedScriptWallet/index.js";
 import { BIP32 } from "../../js/bip32.js";
-import {
-  loadPsbtFixture,
-  getBitGoPsbt,
-  type Fixture,
-} from "./fixtureUtil.js";
+import { loadPsbtFixture, getBitGoPsbt, type Fixture } from "./fixtureUtil.js";
 
 describe("MuSig2 nonce management", function () {
   describe("Bitcoin mainnet", function () {
     const networkName = "bitcoin";
     let fixture: Fixture;
-    let unsignedBitgoPsbt: BitGoPsbt;
     let userKey: BIP32;
+    let backupKey: BIP32;
+    let bitgoKey: BIP32;
 
     before(function () {
       fixture = loadPsbtFixture(networkName, "unsigned");
-      unsignedBitgoPsbt = getBitGoPsbt(fixture, networkName);
       userKey = BIP32.fromBase58(fixture.walletKeys[0]);
+      backupKey = BIP32.fromBase58(fixture.walletKeys[1]);
+      bitgoKey = BIP32.fromBase58(fixture.walletKeys[2]);
     });
 
     it("should generate nonces for MuSig2 inputs with auto-generated session ID", function () {
+      const unsignedBitgoPsbt = getBitGoPsbt(fixture, networkName);
       // Generate nonces with auto-generated session ID (no second parameter)
       assert.doesNotThrow(() => {
         unsignedBitgoPsbt.generateMusig2Nonces(userKey);
       });
-
       // Verify nonces were stored by serializing and deserializing
-      const serialized = unsignedBitgoPsbt.serialize();
-      assert.ok(serialized.length > getBitGoPsbt(fixture, networkName).serialize().length);
+      const serializedWithUserNonces = unsignedBitgoPsbt.serialize();
+      assert.ok(
+        serializedWithUserNonces.length > getBitGoPsbt(fixture, networkName).serialize().length,
+      );
+
+      assert.doesNotThrow(() => {
+        unsignedBitgoPsbt.generateMusig2Nonces(bitgoKey);
+      });
+
+      const serializedWithBitgoNonces = unsignedBitgoPsbt.serialize();
+      assert.ok(serializedWithBitgoNonces.length > serializedWithUserNonces.length);
+
+      assert.throws(() => {
+        unsignedBitgoPsbt.generateMusig2Nonces(backupKey);
+      }, "Should throw error when generating nonces for backup key");
+    });
+
+    it("implements combineMusig2Nonces", function () {
+      const unsignedBitgoPsbtWithUserNonces = getBitGoPsbt(fixture, networkName);
+      unsignedBitgoPsbtWithUserNonces.generateMusig2Nonces(userKey);
+
+      const unsignedBitgoPsbtWithBitgoNonces = getBitGoPsbt(fixture, networkName);
+      unsignedBitgoPsbtWithBitgoNonces.generateMusig2Nonces(bitgoKey);
+
+      const unsignedBitgoPsbtWithBothNonces = getBitGoPsbt(fixture, networkName);
+      unsignedBitgoPsbtWithBothNonces.combineMusig2Nonces(unsignedBitgoPsbtWithUserNonces);
+      unsignedBitgoPsbtWithBothNonces.combineMusig2Nonces(unsignedBitgoPsbtWithBitgoNonces);
+
+      {
+        const psbt = getBitGoPsbt(fixture, networkName);
+        psbt.combineMusig2Nonces(unsignedBitgoPsbtWithUserNonces);
+        assert.strictEqual(
+          psbt.serialize().length,
+          unsignedBitgoPsbtWithUserNonces.serialize().length,
+        );
+      }
+
+      {
+        const psbt = getBitGoPsbt(fixture, networkName);
+        psbt.combineMusig2Nonces(unsignedBitgoPsbtWithBitgoNonces);
+        assert.strictEqual(
+          psbt.serialize().length,
+          unsignedBitgoPsbtWithBitgoNonces.serialize().length,
+        );
+      }
+
+      {
+        const psbt = getBitGoPsbt(fixture, networkName);
+        psbt.combineMusig2Nonces(unsignedBitgoPsbtWithUserNonces);
+        psbt.combineMusig2Nonces(unsignedBitgoPsbtWithBitgoNonces);
+        assert.strictEqual(
+          psbt.serialize().length,
+          unsignedBitgoPsbtWithBothNonces.serialize().length,
+        );
+      }
     });
 
     it("should reject invalid session ID length", function () {
+      const unsignedBitgoPsbt = getBitGoPsbt(fixture, networkName);
+
       // Invalid session ID (wrong length)
       const invalidSessionId = new Uint8Array(16); // Should be 32 bytes
 
@@ -41,6 +93,7 @@ describe("MuSig2 nonce management", function () {
     });
 
     it("should reject custom session ID on mainnet (security)", function () {
+      const unsignedBitgoPsbt = getBitGoPsbt(fixture, "bitcoin");
       // Custom session ID should be rejected on mainnet for security
       const customSessionId = new Uint8Array(32).fill(1);
 

--- a/packages/wasm-utxo/test/fixedScript/musig2Nonces.ts
+++ b/packages/wasm-utxo/test/fixedScript/musig2Nonces.ts
@@ -1,0 +1,56 @@
+import assert from "assert";
+import { BitGoPsbt } from "../../js/fixedScriptWallet/index.js";
+import { BIP32 } from "../../js/bip32.js";
+import {
+  loadPsbtFixture,
+  getBitGoPsbt,
+  type Fixture,
+} from "./fixtureUtil.js";
+
+describe("MuSig2 nonce management", function () {
+  describe("Bitcoin mainnet", function () {
+    const networkName = "bitcoin";
+    let fixture: Fixture;
+    let unsignedBitgoPsbt: BitGoPsbt;
+    let userKey: BIP32;
+
+    before(function () {
+      fixture = loadPsbtFixture(networkName, "unsigned");
+      unsignedBitgoPsbt = getBitGoPsbt(fixture, networkName);
+      userKey = BIP32.fromBase58(fixture.walletKeys[0]);
+    });
+
+    it("should generate nonces for MuSig2 inputs with auto-generated session ID", function () {
+      // Generate nonces with auto-generated session ID (no second parameter)
+      assert.doesNotThrow(() => {
+        unsignedBitgoPsbt.generateMusig2Nonces(userKey);
+      });
+
+      // Verify nonces were stored by serializing and deserializing
+      const serialized = unsignedBitgoPsbt.serialize();
+      assert.ok(serialized.length > getBitGoPsbt(fixture, networkName).serialize().length);
+    });
+
+    it("should reject invalid session ID length", function () {
+      // Invalid session ID (wrong length)
+      const invalidSessionId = new Uint8Array(16); // Should be 32 bytes
+
+      assert.throws(() => {
+        unsignedBitgoPsbt.generateMusig2Nonces(userKey, invalidSessionId);
+      }, "Should throw error for invalid session ID length");
+    });
+
+    it("should reject custom session ID on mainnet (security)", function () {
+      // Custom session ID should be rejected on mainnet for security
+      const customSessionId = new Uint8Array(32).fill(1);
+
+      assert.throws(
+        () => {
+          unsignedBitgoPsbt.generateMusig2Nonces(userKey, customSessionId);
+        },
+        /Custom session_id is only allowed on testnets/,
+        "Should throw error when providing custom session_id on mainnet",
+      );
+    });
+  });
+});

--- a/packages/wasm-utxo/test/fixedScript/walletKeys.util.ts
+++ b/packages/wasm-utxo/test/fixedScript/walletKeys.util.ts
@@ -1,0 +1,26 @@
+import * as utxolib from "@bitgo/utxo-lib";
+import type { Triple } from "../../js/triple.js";
+
+/**
+ * Convert utxolib BIP32 keys to WASM wallet keys format (Triple<string>)
+ */
+export function toWasmWalletKeys(
+  keys: [utxolib.BIP32Interface, utxolib.BIP32Interface, utxolib.BIP32Interface],
+): Triple<string> {
+  return [
+    keys[0].neutered().toBase58(),
+    keys[1].neutered().toBase58(),
+    keys[2].neutered().toBase58(),
+  ];
+}
+
+/**
+ * Get standard replay protection configuration
+ */
+export function getStandardReplayProtection(): { outputScripts: Uint8Array[] } {
+  const replayProtectionScript = Buffer.from(
+    "a91420b37094d82a513451ff0ccd9db23aba05bc5ef387",
+    "hex",
+  );
+  return { outputScripts: [replayProtectionScript] };
+}


### PR DESCRIPTION

This PR adds complete signing support to the WASM-UTXO library with
three key components:

1. **MuSig2 Nonce Generation**
   - Add FirstRound HashMap storage to WASM BitGoPsbt struct
   - Add generate_musig2_nonces WASM method with security checks
   - Add generateMusig2Nonces() TypeScript method
   - Security: Custom session IDs only allowed on testnets

2. **MuSig2 Nonce Combination**
   - Implement combineMusig2Nonces method for nonce exchange
   - Enable proper nonce exchange between cosigners
   - Validate network compatibility and input count matching

3. **Single Input Signing**
   - Implement sign methods for individual inputs by index
   - Support wallet inputs (BIP32) via sign_with_xpriv
   - Support raw private keys (ECPair) via sign_with_privkey
   - Handle MuSig2 inputs with existing first round state
   - Support replay protection inputs with proper P2SH sighashing

The implementation includes comprehensive tests, documentation, and examples
showing the complete MuSig2 signing workflow.

Issue: BTC-2786