### PR TITLE
feat(wasm-utxo): implement BCH fork ID support and extend wallet capabilities

### DIFF
--- a/packages/wasm-utxo/Cargo.lock
+++ b/packages/wasm-utxo/Cargo.lock
@@ -157,8 +157,7 @@ checksum = "32637268377fc7b10a8c6d51de3e7fba1ce5dd371a96e342b34e6078db558e7f"
 [[package]]
 name = "bitcoin"
 version = "0.32.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e499f9fc0407f50fe98af744ab44fa67d409f76b6772e1689ec8485eb0c0f66"
+source = "git+https://github.com/BitGo/rust-bitcoin?tag=bitcoin-0.32.8-forkid#e1eb843a5f5f28ed7a229bcca59cff44719bbcc1"
 dependencies = [
  "base58ck",
  "bech32",
@@ -779,7 +778,7 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 [[package]]
 name = "miniscript"
 version = "13.0.0"
-source = "git+https://github.com/BitGo/rust-miniscript?tag=miniscript-13.0.0-opdrop#970feb88f5ceae6b1bf4253b77dbeaf0f2e2d7ce"
+source = "git+https://github.com/BitGo/rust-miniscript?tag=miniscript-13.0.0-opdrop-forkid#13eccd8bdb83af1a9b63118ceac962aed49906a5"
 dependencies = [
  "bech32",
  "bitcoin",

--- a/packages/wasm-utxo/Cargo.toml
+++ b/packages/wasm-utxo/Cargo.toml
@@ -16,7 +16,7 @@ all = "warn"
 [dependencies]
 wasm-bindgen = "0.2"
 js-sys = "0.3"
-miniscript = { git = "https://github.com/BitGo/rust-miniscript", tag = "miniscript-13.0.0-opdrop" }
+miniscript = { git = "https://github.com/BitGo/rust-miniscript", tag = "miniscript-13.0.0-opdrop-forkid" }
 bech32 = "0.11"
 musig2 = { version = "0.3.1", default-features = false, features = ["k256"] }
 getrandom = { version = "0.2", features = ["js"] }

--- a/packages/wasm-utxo/README.md
+++ b/packages/wasm-utxo/README.md
@@ -20,7 +20,7 @@ This project is under active development.
 | Descriptor Wallet: Address Support      | ✅ Complete | 🚫          | 🚫          | 🚫          | 🚫          | 🚫          | 🚫          |
 | Descriptor Wallet: Transaction Support  | ✅ Complete | 🚫          | 🚫          | 🚫          | 🚫          | 🚫          | 🚫          |
 | FixedScript Wallet: Address Generation  | ✅ Complete | ✅ Complete | ✅ Complete | ✅ Complete | ✅ Complete | ✅ Complete | ✅ Complete |
-| FixedScript Wallet: Transaction Support | ⏳ TODO     | ⏳ TODO     | ⏳ TODO     | ⏳ TODO     | ⏳ TODO     | ⏳ TODO     | ⏳ TODO     |
+| FixedScript Wallet: Transaction Support | ✅ Complete | ⏳ TODO     | ⏳ TODO     | ⏳ TODO     | ⏳ TODO     | ✅ Complete | ⏳ TODO     |
 
 ## Building
 

--- a/packages/wasm-utxo/README.md
+++ b/packages/wasm-utxo/README.md
@@ -20,7 +20,7 @@ This project is under active development.
 | Descriptor Wallet: Address Support      | ✅ Complete | 🚫          | 🚫          | 🚫          | 🚫          | 🚫          | 🚫          |
 | Descriptor Wallet: Transaction Support  | ✅ Complete | 🚫          | 🚫          | 🚫          | 🚫          | 🚫          | 🚫          |
 | FixedScript Wallet: Address Generation  | ✅ Complete | ✅ Complete | ✅ Complete | ✅ Complete | ✅ Complete | ✅ Complete | ✅ Complete |
-| FixedScript Wallet: Transaction Support | ✅ Complete | ⏳ TODO     | ⏳ TODO     | ⏳ TODO     | ⏳ TODO     | ✅ Complete | ⏳ TODO     |
+| FixedScript Wallet: Transaction Support | ✅ Complete | ✅ Complete | ✅ Complete | ⏳ TODO     | ⏳ TODO     | ✅ Complete | ⏳ TODO     |
 
 ## Building
 

--- a/packages/wasm-utxo/cli/Cargo.toml
+++ b/packages/wasm-utxo/cli/Cargo.toml
@@ -16,6 +16,6 @@ base64 = "0.21"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 num-bigint = "0.4"
-bitcoin = "0.32"
+bitcoin = { git = "https://github.com/BitGo/rust-bitcoin", tag = "bitcoin-0.32.8-forkid" }
 colored = "2.1"
 ptree = "0.5"

--- a/packages/wasm-utxo/test/fixedScript/finalizeExtract.ts
+++ b/packages/wasm-utxo/test/fixedScript/finalizeExtract.ts
@@ -7,20 +7,10 @@ import {
   getExtractedTransactionHex,
   type Fixture,
 } from "./fixtureUtil.js";
+import { getFixtureNetworks } from "./networkSupport.util.js";
 
 describe("finalize and extract transaction", function () {
-  const supportedNetworks = utxolib.getNetworkList().filter((network) => {
-    return (
-      utxolib.isMainnet(network) &&
-      network !== utxolib.networks.bitcoincash &&
-      network !== utxolib.networks.bitcoingold &&
-      network !== utxolib.networks.bitcoinsv &&
-      network !== utxolib.networks.ecash &&
-      network !== utxolib.networks.zcash
-    );
-  });
-
-  supportedNetworks.forEach((network) => {
+  getFixtureNetworks().forEach((network) => {
     const networkName = utxolib.getNetworkName(network);
 
     describe(`network: ${networkName}`, function () {

--- a/packages/wasm-utxo/test/fixedScript/networkSupport.util.ts
+++ b/packages/wasm-utxo/test/fixedScript/networkSupport.util.ts
@@ -1,0 +1,17 @@
+import * as utxolib from "@bitgo/utxo-lib";
+
+/**
+ * Get networks that have psbt fixtures
+ */
+export function getFixtureNetworks(): utxolib.Network[] {
+  return utxolib.getNetworkList().filter((network) => {
+    return (
+      // we only have fixtures for mainnet networks
+      utxolib.isMainnet(network) &&
+      // we don't have fixtures for bitcoinsv since it is not really supported any longer
+      network !== utxolib.networks.bitcoinsv &&
+      // we do have zcash fixtures but it is not fully implemented yet
+      network !== utxolib.networks.zcash
+    );
+  });
+}

--- a/packages/wasm-utxo/test/fixedScript/parseTransactionWithWalletKeys.ts
+++ b/packages/wasm-utxo/test/fixedScript/parseTransactionWithWalletKeys.ts
@@ -11,6 +11,7 @@ import {
   loadReplayProtectionKeyFromFixture,
   type Fixture,
 } from "./fixtureUtil.js";
+import { getFixtureNetworks } from "./networkSupport.util.js";
 
 function getExpectedInputScriptType(fixtureScriptType: string): InputScriptType {
   // Map fixture types to InputScriptType values
@@ -38,18 +39,7 @@ function getOtherWalletKeys(): utxolib.bitgo.RootWalletKeys {
 }
 
 describe("parseTransactionWithWalletKeys", function () {
-  const supportedNetworks = utxolib.getNetworkList().filter((network) => {
-    return (
-      utxolib.isMainnet(network) &&
-      network !== utxolib.networks.bitcoincash &&
-      network !== utxolib.networks.bitcoingold &&
-      network !== utxolib.networks.bitcoinsv &&
-      network !== utxolib.networks.ecash &&
-      network !== utxolib.networks.zcash
-    );
-  });
-
-  supportedNetworks.forEach((network) => {
+  getFixtureNetworks().forEach((network) => {
     const networkName = utxolib.getNetworkName(network);
 
     describe(`network: ${networkName}`, function () {

--- a/packages/wasm-utxo/test/fixedScript/signAndVerifySignature.ts
+++ b/packages/wasm-utxo/test/fixedScript/signAndVerifySignature.ts
@@ -14,6 +14,7 @@ import {
   type Fixture,
   loadReplayProtectionKeyFromFixture,
 } from "./fixtureUtil.js";
+import { getFixtureNetworks } from "./networkSupport.util.js";
 
 type SignatureStage = "unsigned" | "halfsigned" | "fullsigned";
 
@@ -279,18 +280,7 @@ function runTestsForFixture(
 }
 
 describe("verifySignature", function () {
-  const supportedNetworks = utxolib.getNetworkList().filter((network) => {
-    return (
-      utxolib.isMainnet(network) &&
-      network !== utxolib.networks.bitcoincash &&
-      network !== utxolib.networks.bitcoingold &&
-      network !== utxolib.networks.bitcoinsv &&
-      network !== utxolib.networks.ecash &&
-      network !== utxolib.networks.zcash
-    );
-  });
-
-  supportedNetworks.forEach((network) => {
+  getFixtureNetworks().forEach((network) => {
     const networkName = utxolib.getNetworkName(network);
 
     describe(`network: ${networkName}`, function () {


### PR DESCRIPTION

This PR adds Bitcoin Cash-style fork ID support for multiple networks (BCH, 
XEC, BSV, BTG) and extends the FixedScript wallet transaction capabilities 
to include Bitcoin Cash and Bitcoin Gold.

Key changes:
- Implement fork ID-aware signing for BCH (0), BTG (79), XEC (0), and BSV (0)
- Update miniscript dependency to use forkid-compatible version
- Modify PSBT functions to use appropriate sighash algorithms
- Add network support utilities for fixtures to improve test organization
- Update documentation to reflect newly supported networks in the feature 
  status matrix

Issue: BTC-2656