### PR TITLE
feat(wasm-utxo): add support for creating outputs with addresses

### DIFF
--- a/packages/wasm-utxo/src/fixed_script_wallet/bitgo_psbt/mod.rs
+++ b/packages/wasm-utxo/src/fixed_script_wallet/bitgo_psbt/mod.rs
@@ -726,6 +726,13 @@ impl BitGoPsbt {
         psbt.outputs.len() - 1
     }
 
+    pub fn add_output_with_address(&mut self, address: &str, value: u64) -> Result<usize, String> {
+        let script =
+            crate::address::networks::to_output_script_with_network(address, self.network())
+                .map_err(|e| e.to_string())?;
+        Ok(self.add_output(script, value))
+    }
+
     /// Add a wallet input with full PSBT metadata
     ///
     /// This is a higher-level method that adds an input and populates all required

--- a/packages/wasm-utxo/src/wasm/fixed_script_wallet/mod.rs
+++ b/packages/wasm-utxo/src/wasm/fixed_script_wallet/mod.rs
@@ -281,6 +281,22 @@ impl BitGoPsbt {
         Ok(self.psbt.add_output(script, value))
     }
 
+    /// Add an output to the PSBT by address
+    ///
+    /// # Arguments
+    /// * `address` - The destination address
+    /// * `value` - The value in satoshis
+    ///
+    /// # Returns
+    /// The index of the newly added output
+    pub fn add_output_with_address(
+        &mut self,
+        address: &str,
+        value: u64,
+    ) -> Result<usize, WasmUtxoError> {
+        Ok(self.psbt.add_output_with_address(address, value)?)
+    }
+
     /// Add a wallet input with full PSBT metadata
     ///
     /// This is a higher-level method that adds an input and populates all required


### PR DESCRIPTION
Added the ability to create transaction outputs using addresses instead of
raw scripts. This provides a more convenient API for users who don't want
to deal with script creation.

- Added `add_output_with_address` method in Rust
- Extended TypeScript `addOutput` method with overloads for:
  - Direct script/value pairs
  - Address/value pairs
  - options object

BTC-0