### PR TITLE
fix(wasm-bip32): mark package as private

### DIFF
--- a/packages/wasm-bip32/package.json
+++ b/packages/wasm-bip32/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@bitgo/wasm-bip32",
+  "private": true,
   "description": "Minimal WebAssembly BIP32/ECPair implementation with message signing",
   "version": "0.0.1",
   "type": "module",


### PR DESCRIPTION

Set wasm-bip32 package as private to work around publishing issues.

Issue: BTC-2915