### PR TITLE
feat(wasm-utxo): add string-based network parameter support

### DIFF
--- a/packages/wasm-utxo/js/fixedScriptWallet/address.ts
+++ b/packages/wasm-utxo/js/fixedScriptWallet/address.ts
@@ -1,19 +1,36 @@
 import { FixedScriptWalletNamespace } from "../wasm/wasm_utxo.js";
 import { type WalletKeysArg, RootWalletKeys } from "./RootWalletKeys.js";
 import type { UtxolibNetwork } from "../utxolibCompat.js";
+import type { UtxolibName } from "../utxolibCompat.js";
+import type { CoinName } from "../coinName.js";
 import { AddressFormat } from "../address.js";
+
+export type NetworkName = UtxolibName | CoinName;
 
 /**
  * Create the output script for a given wallet keys and chain and index
+ * @param keys - The wallet keys to use
+ * @param chain - The chain to use
+ * @param index - The index to use
+ * @param network - The network to use. Can be a network name string (e.g., "btc", "bitcoin", "testnet") or a UtxolibNetwork object
  */
 export function outputScript(
   keys: WalletKeysArg,
   chain: number,
   index: number,
-  network: UtxolibNetwork,
+  network: NetworkName | UtxolibNetwork,
 ): Uint8Array {
   const walletKeys = RootWalletKeys.from(keys);
-  return FixedScriptWalletNamespace.output_script(walletKeys.wasm, chain, index, network);
+  if (typeof network === "string") {
+    return FixedScriptWalletNamespace.output_script_with_network_str(
+      walletKeys.wasm,
+      chain,
+      index,
+      network,
+    );
+  } else {
+    return FixedScriptWalletNamespace.output_script(walletKeys.wasm, chain, index, network);
+  }
 }
 
 /**
@@ -22,7 +39,7 @@ export function outputScript(
  * @param keys - The wallet keys to use.
  * @param chain - The chain to use.
  * @param index - The index to use.
- * @param network - The network to use.
+ * @param network - The network to use. Can be a network name string (e.g., "btc", "bitcoin", "testnet") or a UtxolibNetwork object
  * @param addressFormat - The address format to use.
  *   Only relevant for Bitcoin Cash and eCash networks, where:
  *   - "default" means base58check,
@@ -32,9 +49,25 @@ export function address(
   keys: WalletKeysArg,
   chain: number,
   index: number,
-  network: UtxolibNetwork,
+  network: NetworkName | UtxolibNetwork,
   addressFormat?: AddressFormat,
 ): string {
   const walletKeys = RootWalletKeys.from(keys);
-  return FixedScriptWalletNamespace.address(walletKeys.wasm, chain, index, network, addressFormat);
+  if (typeof network === "string") {
+    return FixedScriptWalletNamespace.address_with_network_str(
+      walletKeys.wasm,
+      chain,
+      index,
+      network,
+      addressFormat,
+    );
+  } else {
+    return FixedScriptWalletNamespace.address(
+      walletKeys.wasm,
+      chain,
+      index,
+      network,
+      addressFormat,
+    );
+  }
 }

--- a/packages/wasm-utxo/src/wasm/try_from_js_value.rs
+++ b/packages/wasm-utxo/src/wasm/try_from_js_value.rs
@@ -173,3 +173,20 @@ impl TryFromJsValue for crate::inscriptions::TapLeafScript {
         })
     }
 }
+
+impl TryFromJsValue for crate::networks::Network {
+    fn try_from_js_value(value: &JsValue) -> Result<Self, WasmUtxoError> {
+        let network_str = value
+            .as_string()
+            .ok_or_else(|| WasmUtxoError::new("Expected a string for network parameter"))?;
+
+        crate::networks::Network::from_utxolib_name(&network_str)
+            .or_else(|| crate::networks::Network::from_coin_name(&network_str))
+            .ok_or_else(|| {
+                WasmUtxoError::new(&format!(
+                    "Unknown network '{}'. Expected a utxolib name (e.g., 'bitcoin', 'testnet') or coin name (e.g., 'btc', 'tbtc')",
+                    network_str
+                ))
+            })
+    }
+}


### PR DESCRIPTION

Add option to provide network as a string parameter for address
and outputScript functions. This makes the API more convenient
by allowing users to pass network names (e.g. "btc", "bitcoin",
"testnet") instead of requiring a network object.

- Implement string-based network parameter handler functions
- Add TypeScript wrapper to handle both string and object parameters
- Document the pattern in wasm-bindgen.md for future reference

BTC-2912