### PR TITLE
feat(wasm-solana): add instruction decoders

### DIFF
--- a/packages/wasm-solana/js/index.ts
+++ b/packages/wasm-solana/js/index.ts
@@ -7,11 +7,24 @@ void wasm;
 export * as keypair from "./keypair.js";
 export * as pubkey from "./pubkey.js";
 export * as transaction from "./transaction.js";
+export * as instructions from "./instructions.js";
 
 // Top-level class exports for convenience
 export { Keypair } from "./keypair.js";
 export { Pubkey } from "./pubkey.js";
 export { Transaction } from "./transaction.js";
 
+// Instruction decoder exports
+export { SystemInstruction, StakeInstruction, ComputeBudgetInstruction } from "./instructions.js";
+
 // Type exports
 export type { AccountMeta, Instruction } from "./transaction.js";
+export type {
+  SystemInstructionType,
+  DecodedSystemInstruction,
+  StakeInstructionType,
+  StakeAuthorize,
+  DecodedStakeInstruction,
+  ComputeBudgetInstructionType,
+  DecodedComputeBudgetInstruction,
+} from "./instructions.js";

--- a/packages/wasm-solana/js/instructions.ts
+++ b/packages/wasm-solana/js/instructions.ts
@@ -1,0 +1,184 @@
+import {
+  SystemInstructionDecoder as WasmSystemDecoder,
+  StakeInstructionDecoder as WasmStakeDecoder,
+  ComputeBudgetInstructionDecoder as WasmComputeBudgetDecoder,
+} from "./wasm/wasm_solana.js";
+
+// =============================================================================
+// System Program Types (only types used by BitGo)
+// =============================================================================
+
+export type SystemInstructionType =
+  | "CreateAccount"
+  | "Assign"
+  | "Transfer"
+  | "AdvanceNonceAccount"
+  | "InitializeNonceAccount"
+  | "Allocate";
+
+export interface CreateAccountInstruction {
+  type: "CreateAccount";
+  lamports: bigint;
+  space: bigint;
+  owner: string;
+}
+
+export interface AssignInstruction {
+  type: "Assign";
+  owner: string;
+}
+
+export interface TransferInstruction {
+  type: "Transfer";
+  lamports: bigint;
+}
+
+export interface AdvanceNonceAccountInstruction {
+  type: "AdvanceNonceAccount";
+}
+
+export interface InitializeNonceAccountInstruction {
+  type: "InitializeNonceAccount";
+  authorized: string;
+}
+
+export interface AllocateInstruction {
+  type: "Allocate";
+  space: bigint;
+}
+
+export type DecodedSystemInstruction =
+  | CreateAccountInstruction
+  | AssignInstruction
+  | TransferInstruction
+  | AdvanceNonceAccountInstruction
+  | InitializeNonceAccountInstruction
+  | AllocateInstruction;
+
+// =============================================================================
+// Stake Program Types (only types used by BitGo)
+// =============================================================================
+
+export type StakeInstructionType =
+  | "Initialize"
+  | "Authorize"
+  | "DelegateStake"
+  | "Split"
+  | "Withdraw"
+  | "Deactivate";
+
+export type StakeAuthorize = "Staker" | "Withdrawer";
+
+export interface Lockup {
+  unixTimestamp: bigint;
+  epoch: bigint;
+  custodian: string;
+}
+
+export interface InitializeStakeInstruction {
+  type: "Initialize";
+  staker: string;
+  withdrawer: string;
+  lockup?: Lockup;
+}
+
+export interface AuthorizeStakeInstruction {
+  type: "Authorize";
+  newAuthority: string;
+  stakeAuthorize: StakeAuthorize;
+}
+
+export interface DelegateStakeInstruction {
+  type: "DelegateStake";
+}
+
+export interface SplitStakeInstruction {
+  type: "Split";
+  lamports: bigint;
+}
+
+export interface WithdrawStakeInstruction {
+  type: "Withdraw";
+  lamports: bigint;
+}
+
+export interface DeactivateStakeInstruction {
+  type: "Deactivate";
+}
+
+export type DecodedStakeInstruction =
+  | InitializeStakeInstruction
+  | AuthorizeStakeInstruction
+  | DelegateStakeInstruction
+  | SplitStakeInstruction
+  | WithdrawStakeInstruction
+  | DeactivateStakeInstruction;
+
+// =============================================================================
+// ComputeBudget Program Types (only types used by BitGo)
+// =============================================================================
+
+export type ComputeBudgetInstructionType = "SetComputeUnitLimit" | "SetComputeUnitPrice";
+
+export interface SetComputeUnitLimitInstruction {
+  type: "SetComputeUnitLimit";
+  units: number;
+}
+
+export interface SetComputeUnitPriceInstruction {
+  type: "SetComputeUnitPrice";
+  microLamports: bigint;
+}
+
+export type DecodedComputeBudgetInstruction =
+  | SetComputeUnitLimitInstruction
+  | SetComputeUnitPriceInstruction;
+
+// =============================================================================
+// Decoder Classes
+// =============================================================================
+
+/**
+ * System Program instruction decoder
+ */
+export class SystemInstruction {
+  static readonly PROGRAM_ID = WasmSystemDecoder.program_id;
+
+  static isSystemProgram(programId: string): boolean {
+    return WasmSystemDecoder.is_system_program(programId);
+  }
+
+  static decode(data: Uint8Array): DecodedSystemInstruction {
+    return WasmSystemDecoder.decode(data) as DecodedSystemInstruction;
+  }
+}
+
+/**
+ * Stake Program instruction decoder
+ */
+export class StakeInstruction {
+  static readonly PROGRAM_ID = WasmStakeDecoder.program_id;
+
+  static isStakeProgram(programId: string): boolean {
+    return WasmStakeDecoder.is_stake_program(programId);
+  }
+
+  static decode(data: Uint8Array): DecodedStakeInstruction {
+    return WasmStakeDecoder.decode(data) as DecodedStakeInstruction;
+  }
+}
+
+/**
+ * ComputeBudget Program instruction decoder
+ */
+export class ComputeBudgetInstruction {
+  static readonly PROGRAM_ID = WasmComputeBudgetDecoder.program_id;
+
+  static isComputeBudgetProgram(programId: string): boolean {
+    return WasmComputeBudgetDecoder.is_compute_budget_program(programId);
+  }
+
+  static decode(data: Uint8Array): DecodedComputeBudgetInstruction {
+    return WasmComputeBudgetDecoder.decode(data) as DecodedComputeBudgetInstruction;
+  }
+}

--- a/packages/wasm-solana/src/instructions/compute_budget.rs
+++ b/packages/wasm-solana/src/instructions/compute_budget.rs
@@ -1,0 +1,307 @@
+//! ComputeBudget Program instruction decoder.
+//!
+//! The ComputeBudget Program controls transaction compute limits and priority fees:
+//! - Set compute unit limit
+//! - Set compute unit price (priority fee)
+//! - Request heap frame size
+//!
+//! # Wire Format
+//!
+//! ComputeBudget instructions use a single-byte discriminator:
+//! - 0: Deprecated (RequestUnitsDeprecated)
+//! - 1: RequestHeapFrame
+//! - 2: SetComputeUnitLimit
+//! - 3: SetComputeUnitPrice
+//! - 4: SetLoadedAccountsDataSizeLimit
+
+use crate::error::WasmSolanaError;
+
+/// ComputeBudget Program ID
+pub const COMPUTE_BUDGET_PROGRAM_ID: &str = "ComputeBudget111111111111111111111111111111";
+
+/// ComputeBudget instruction types.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ComputeBudgetInstructionType {
+    /// Deprecated instruction.
+    RequestUnitsDeprecated,
+    /// Request a specific heap frame size.
+    RequestHeapFrame,
+    /// Set the compute unit limit for the transaction.
+    SetComputeUnitLimit,
+    /// Set the compute unit price (priority fee).
+    SetComputeUnitPrice,
+    /// Set the maximum loaded accounts data size.
+    SetLoadedAccountsDataSizeLimit,
+}
+
+impl ComputeBudgetInstructionType {
+    /// Get string representation.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::RequestUnitsDeprecated => "RequestUnitsDeprecated",
+            Self::RequestHeapFrame => "RequestHeapFrame",
+            Self::SetComputeUnitLimit => "SetComputeUnitLimit",
+            Self::SetComputeUnitPrice => "SetComputeUnitPrice",
+            Self::SetLoadedAccountsDataSizeLimit => "SetLoadedAccountsDataSizeLimit",
+        }
+    }
+}
+
+/// Decoded ComputeBudget instruction.
+#[derive(Debug, Clone)]
+pub enum ComputeBudgetInstruction {
+    /// Deprecated: Request units (replaced by SetComputeUnitLimit).
+    RequestUnitsDeprecated {
+        /// Compute units requested.
+        units: u32,
+        /// Additional fee in lamports.
+        additional_fee: u32,
+    },
+
+    /// Request a specific heap frame size.
+    /// Accounts: none
+    RequestHeapFrame {
+        /// Heap size in bytes (must be multiple of 1024).
+        bytes: u32,
+    },
+
+    /// Set the compute unit limit for the transaction.
+    /// Accounts: none
+    SetComputeUnitLimit {
+        /// Maximum compute units.
+        units: u32,
+    },
+
+    /// Set the compute unit price (priority fee per compute unit).
+    /// Accounts: none
+    SetComputeUnitPrice {
+        /// Price in micro-lamports per compute unit.
+        micro_lamports: u64,
+    },
+
+    /// Set the maximum loaded accounts data size limit.
+    /// Accounts: none
+    SetLoadedAccountsDataSizeLimit {
+        /// Maximum bytes of account data that can be loaded.
+        bytes: u32,
+    },
+}
+
+impl ComputeBudgetInstruction {
+    /// Check if the given program ID is the ComputeBudget Program.
+    pub fn is_compute_budget_program(program_id: &str) -> bool {
+        program_id == COMPUTE_BUDGET_PROGRAM_ID
+    }
+
+    /// Decode a ComputeBudget Program instruction from raw data.
+    pub fn decode(data: &[u8]) -> Result<Self, WasmSolanaError> {
+        if data.is_empty() {
+            return Err(WasmSolanaError::new(
+                "ComputeBudget instruction empty: need at least 1 byte",
+            ));
+        }
+
+        let discriminator = data[0];
+        let data = &data[1..];
+
+        match discriminator {
+            0 => Self::decode_request_units_deprecated(data),
+            1 => Self::decode_request_heap_frame(data),
+            2 => Self::decode_set_compute_unit_limit(data),
+            3 => Self::decode_set_compute_unit_price(data),
+            4 => Self::decode_set_loaded_accounts_data_size_limit(data),
+            _ => Err(WasmSolanaError::new(&format!(
+                "Unknown ComputeBudget instruction discriminator: {}",
+                discriminator
+            ))),
+        }
+    }
+
+    /// Get the instruction type.
+    pub fn instruction_type(&self) -> ComputeBudgetInstructionType {
+        match self {
+            Self::RequestUnitsDeprecated { .. } => {
+                ComputeBudgetInstructionType::RequestUnitsDeprecated
+            }
+            Self::RequestHeapFrame { .. } => ComputeBudgetInstructionType::RequestHeapFrame,
+            Self::SetComputeUnitLimit { .. } => ComputeBudgetInstructionType::SetComputeUnitLimit,
+            Self::SetComputeUnitPrice { .. } => ComputeBudgetInstructionType::SetComputeUnitPrice,
+            Self::SetLoadedAccountsDataSizeLimit { .. } => {
+                ComputeBudgetInstructionType::SetLoadedAccountsDataSizeLimit
+            }
+        }
+    }
+
+    /// Get the compute unit limit if this is a SetComputeUnitLimit instruction.
+    pub fn compute_unit_limit(&self) -> Option<u32> {
+        match self {
+            Self::SetComputeUnitLimit { units } => Some(*units),
+            _ => None,
+        }
+    }
+
+    /// Get the compute unit price in micro-lamports if this is a SetComputeUnitPrice instruction.
+    pub fn compute_unit_price(&self) -> Option<u64> {
+        match self {
+            Self::SetComputeUnitPrice { micro_lamports } => Some(*micro_lamports),
+            _ => None,
+        }
+    }
+
+    // Private decode helpers
+
+    fn decode_request_units_deprecated(data: &[u8]) -> Result<Self, WasmSolanaError> {
+        // RequestUnitsDeprecated: units(u32) + additional_fee(u32)
+        if data.len() < 8 {
+            return Err(WasmSolanaError::new(
+                "RequestUnitsDeprecated instruction too short",
+            ));
+        }
+
+        let units = u32::from_le_bytes(data[0..4].try_into().unwrap());
+        let additional_fee = u32::from_le_bytes(data[4..8].try_into().unwrap());
+
+        Ok(Self::RequestUnitsDeprecated {
+            units,
+            additional_fee,
+        })
+    }
+
+    fn decode_request_heap_frame(data: &[u8]) -> Result<Self, WasmSolanaError> {
+        // RequestHeapFrame: bytes(u32)
+        if data.len() < 4 {
+            return Err(WasmSolanaError::new(
+                "RequestHeapFrame instruction too short",
+            ));
+        }
+
+        let bytes = u32::from_le_bytes(data[0..4].try_into().unwrap());
+
+        Ok(Self::RequestHeapFrame { bytes })
+    }
+
+    fn decode_set_compute_unit_limit(data: &[u8]) -> Result<Self, WasmSolanaError> {
+        // SetComputeUnitLimit: units(u32)
+        if data.len() < 4 {
+            return Err(WasmSolanaError::new(
+                "SetComputeUnitLimit instruction too short",
+            ));
+        }
+
+        let units = u32::from_le_bytes(data[0..4].try_into().unwrap());
+
+        Ok(Self::SetComputeUnitLimit { units })
+    }
+
+    fn decode_set_compute_unit_price(data: &[u8]) -> Result<Self, WasmSolanaError> {
+        // SetComputeUnitPrice: micro_lamports(u64)
+        if data.len() < 8 {
+            return Err(WasmSolanaError::new(
+                "SetComputeUnitPrice instruction too short",
+            ));
+        }
+
+        let micro_lamports = u64::from_le_bytes(data[0..8].try_into().unwrap());
+
+        Ok(Self::SetComputeUnitPrice { micro_lamports })
+    }
+
+    fn decode_set_loaded_accounts_data_size_limit(data: &[u8]) -> Result<Self, WasmSolanaError> {
+        // SetLoadedAccountsDataSizeLimit: bytes(u32)
+        if data.len() < 4 {
+            return Err(WasmSolanaError::new(
+                "SetLoadedAccountsDataSizeLimit instruction too short",
+            ));
+        }
+
+        let bytes = u32::from_le_bytes(data[0..4].try_into().unwrap());
+
+        Ok(Self::SetLoadedAccountsDataSizeLimit { bytes })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_decode_set_compute_unit_limit() {
+        let data = [
+            2, // discriminator = 2 (SetComputeUnitLimit)
+            64, 66, 15, 0, // units = 1000000
+        ];
+
+        let instr = ComputeBudgetInstruction::decode(&data).unwrap();
+        match instr {
+            ComputeBudgetInstruction::SetComputeUnitLimit { units } => {
+                assert_eq!(units, 1000000);
+            }
+            _ => panic!("Expected SetComputeUnitLimit instruction"),
+        }
+    }
+
+    #[test]
+    fn test_decode_set_compute_unit_price() {
+        let data = [
+            3, // discriminator = 3 (SetComputeUnitPrice)
+            232, 3, 0, 0, 0, 0, 0, 0, // micro_lamports = 1000
+        ];
+
+        let instr = ComputeBudgetInstruction::decode(&data).unwrap();
+        match instr {
+            ComputeBudgetInstruction::SetComputeUnitPrice { micro_lamports } => {
+                assert_eq!(micro_lamports, 1000);
+            }
+            _ => panic!("Expected SetComputeUnitPrice instruction"),
+        }
+    }
+
+    #[test]
+    fn test_decode_request_heap_frame() {
+        let data = [
+            1, // discriminator = 1 (RequestHeapFrame)
+            0, 0, 4, 0, // bytes = 262144 (256KB)
+        ];
+
+        let instr = ComputeBudgetInstruction::decode(&data).unwrap();
+        match instr {
+            ComputeBudgetInstruction::RequestHeapFrame { bytes } => {
+                assert_eq!(bytes, 262144);
+            }
+            _ => panic!("Expected RequestHeapFrame instruction"),
+        }
+    }
+
+    #[test]
+    fn test_is_compute_budget_program() {
+        assert!(ComputeBudgetInstruction::is_compute_budget_program(
+            COMPUTE_BUDGET_PROGRAM_ID
+        ));
+        assert!(!ComputeBudgetInstruction::is_compute_budget_program(
+            "11111111111111111111111111111111"
+        ));
+    }
+
+    #[test]
+    fn test_instruction_type() {
+        let limit = ComputeBudgetInstruction::SetComputeUnitLimit { units: 1000 };
+        assert_eq!(
+            limit.instruction_type(),
+            ComputeBudgetInstructionType::SetComputeUnitLimit
+        );
+        assert_eq!(limit.instruction_type().as_str(), "SetComputeUnitLimit");
+    }
+
+    #[test]
+    fn test_helper_methods() {
+        let limit = ComputeBudgetInstruction::SetComputeUnitLimit { units: 500000 };
+        assert_eq!(limit.compute_unit_limit(), Some(500000));
+        assert_eq!(limit.compute_unit_price(), None);
+
+        let price = ComputeBudgetInstruction::SetComputeUnitPrice {
+            micro_lamports: 1000,
+        };
+        assert_eq!(price.compute_unit_limit(), None);
+        assert_eq!(price.compute_unit_price(), Some(1000));
+    }
+}

--- a/packages/wasm-solana/src/instructions/mod.rs
+++ b/packages/wasm-solana/src/instructions/mod.rs
@@ -1,0 +1,14 @@
+//! Solana instruction decoders.
+//!
+//! This module provides decoders for common Solana program instructions:
+//! - System Program (transfers, account creation, nonce operations)
+//! - Stake Program (staking operations)
+//! - ComputeBudget (priority fees, compute limits)
+
+pub mod compute_budget;
+pub mod stake;
+pub mod system;
+
+pub use compute_budget::{ComputeBudgetInstruction, ComputeBudgetInstructionType};
+pub use stake::{StakeAuthorize, StakeInstruction, StakeInstructionType};
+pub use system::{SystemInstruction, SystemInstructionType};

--- a/packages/wasm-solana/src/instructions/stake.rs
+++ b/packages/wasm-solana/src/instructions/stake.rs
@@ -1,0 +1,621 @@
+//! Stake Program instruction decoder.
+//!
+//! The Stake Program handles Solana staking operations:
+//! - Creating and initializing stake accounts
+//! - Delegating stake to validators
+//! - Deactivating and withdrawing stake
+//!
+//! # Wire Format
+//!
+//! Stake instructions start with a 4-byte little-endian discriminator:
+//! - 0: Initialize
+//! - 1: Authorize
+//! - 2: DelegateStake
+//! - 3: Split
+//! - 4: Withdraw
+//! - 5: Deactivate
+//! - 6: SetLockup
+//! - 7: Merge
+//! - 8: AuthorizeWithSeed
+//! - 9: InitializeChecked
+//! - 10: AuthorizeChecked
+//! - 11: AuthorizeCheckedWithSeed
+//! - 12: SetLockupChecked
+
+use crate::error::WasmSolanaError;
+use crate::Pubkey;
+
+/// Stake Program ID
+pub const STAKE_PROGRAM_ID: &str = "Stake11111111111111111111111111111111111111";
+
+/// Authorization types for stake accounts.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StakeAuthorize {
+    /// Authority to delegate/activate stake.
+    Staker,
+    /// Authority to withdraw stake.
+    Withdrawer,
+}
+
+impl StakeAuthorize {
+    /// Get string representation.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Staker => "Staker",
+            Self::Withdrawer => "Withdrawer",
+        }
+    }
+}
+
+/// Stake instruction types.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StakeInstructionType {
+    Initialize,
+    Authorize,
+    DelegateStake,
+    Split,
+    Withdraw,
+    Deactivate,
+    SetLockup,
+    Merge,
+    AuthorizeWithSeed,
+    InitializeChecked,
+    AuthorizeChecked,
+    AuthorizeCheckedWithSeed,
+    SetLockupChecked,
+}
+
+impl StakeInstructionType {
+    /// Get string representation.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Initialize => "Initialize",
+            Self::Authorize => "Authorize",
+            Self::DelegateStake => "DelegateStake",
+            Self::Split => "Split",
+            Self::Withdraw => "Withdraw",
+            Self::Deactivate => "Deactivate",
+            Self::SetLockup => "SetLockup",
+            Self::Merge => "Merge",
+            Self::AuthorizeWithSeed => "AuthorizeWithSeed",
+            Self::InitializeChecked => "InitializeChecked",
+            Self::AuthorizeChecked => "AuthorizeChecked",
+            Self::AuthorizeCheckedWithSeed => "AuthorizeCheckedWithSeed",
+            Self::SetLockupChecked => "SetLockupChecked",
+        }
+    }
+}
+
+/// Lockup configuration for stake accounts.
+#[derive(Debug, Clone)]
+pub struct Lockup {
+    /// Unix timestamp until which the stake is locked.
+    pub unix_timestamp: i64,
+    /// Epoch until which the stake is locked.
+    pub epoch: u64,
+    /// Custodian who can modify the lockup.
+    pub custodian: Pubkey,
+}
+
+/// Decoded Stake Program instruction.
+#[derive(Debug, Clone)]
+pub enum StakeInstruction {
+    /// Initialize a stake account.
+    /// Accounts: [stake_account, rent_sysvar]
+    Initialize {
+        /// The staker authority.
+        staker: Pubkey,
+        /// The withdrawer authority.
+        withdrawer: Pubkey,
+        /// Optional lockup configuration.
+        lockup: Option<Lockup>,
+    },
+
+    /// Authorize a new key for the stake account.
+    /// Accounts: [stake_account, clock_sysvar, authority, (optional) lockup_authority]
+    Authorize {
+        /// The new authority pubkey.
+        new_authority: Pubkey,
+        /// The type of authority to change.
+        stake_authorize: StakeAuthorize,
+    },
+
+    /// Delegate stake to a validator.
+    /// Accounts: [stake_account, vote_account, clock_sysvar, stake_history_sysvar, config_account, stake_authority]
+    DelegateStake,
+
+    /// Split stake into a new stake account.
+    /// Accounts: [stake_account, new_stake_account, stake_authority]
+    Split {
+        /// Lamports to move to new stake account.
+        lamports: u64,
+    },
+
+    /// Withdraw from a stake account.
+    /// Accounts: [stake_account, to_account, clock_sysvar, stake_history_sysvar, withdraw_authority, (optional) lockup_authority]
+    Withdraw {
+        /// Lamports to withdraw.
+        lamports: u64,
+    },
+
+    /// Deactivate a stake account.
+    /// Accounts: [stake_account, clock_sysvar, stake_authority]
+    Deactivate,
+
+    /// Set lockup parameters.
+    /// Accounts: [stake_account, lockup_authority]
+    SetLockup {
+        /// Unix timestamp (None to leave unchanged).
+        unix_timestamp: Option<i64>,
+        /// Epoch (None to leave unchanged).
+        epoch: Option<u64>,
+        /// Custodian (None to leave unchanged).
+        custodian: Option<Pubkey>,
+    },
+
+    /// Merge two stake accounts.
+    /// Accounts: [destination_stake, source_stake, clock_sysvar, stake_history_sysvar, stake_authority]
+    Merge,
+
+    /// Authorize with seed.
+    /// Accounts: [stake_account, authority_base, clock_sysvar]
+    AuthorizeWithSeed {
+        /// New authority pubkey.
+        new_authority: Pubkey,
+        /// Type of authority.
+        stake_authorize: StakeAuthorize,
+        /// Seed for deriving authority.
+        authority_seed: String,
+        /// Owner for deriving authority.
+        authority_owner: Pubkey,
+    },
+
+    /// Initialize with checked authorities (must be signers).
+    /// Accounts: [stake_account, rent_sysvar, staker, withdrawer]
+    InitializeChecked,
+
+    /// Authorize with checked new authority (must be signer).
+    /// Accounts: [stake_account, clock_sysvar, authority, new_authority]
+    AuthorizeChecked {
+        /// Type of authority.
+        stake_authorize: StakeAuthorize,
+    },
+
+    /// Authorize with seed and checked new authority.
+    /// Accounts: [stake_account, authority_base, clock_sysvar, new_authority]
+    AuthorizeCheckedWithSeed {
+        /// Type of authority.
+        stake_authorize: StakeAuthorize,
+        /// Seed for deriving authority.
+        authority_seed: String,
+        /// Owner for deriving authority.
+        authority_owner: Pubkey,
+    },
+
+    /// Set lockup with checked custodian.
+    /// Accounts: [stake_account, lockup_authority, (optional) new_lockup_authority]
+    SetLockupChecked {
+        /// Unix timestamp (None to leave unchanged).
+        unix_timestamp: Option<i64>,
+        /// Epoch (None to leave unchanged).
+        epoch: Option<u64>,
+    },
+}
+
+impl StakeInstruction {
+    /// Check if the given program ID is the Stake Program.
+    pub fn is_stake_program(program_id: &str) -> bool {
+        program_id == STAKE_PROGRAM_ID
+    }
+
+    /// Decode a Stake Program instruction from raw data.
+    pub fn decode(data: &[u8]) -> Result<Self, WasmSolanaError> {
+        if data.len() < 4 {
+            return Err(WasmSolanaError::new(
+                "Stake instruction too short: need at least 4 bytes",
+            ));
+        }
+
+        let discriminator = u32::from_le_bytes([data[0], data[1], data[2], data[3]]);
+        let data = &data[4..];
+
+        match discriminator {
+            0 => Self::decode_initialize(data),
+            1 => Self::decode_authorize(data),
+            2 => Ok(StakeInstruction::DelegateStake),
+            3 => Self::decode_split(data),
+            4 => Self::decode_withdraw(data),
+            5 => Ok(StakeInstruction::Deactivate),
+            6 => Self::decode_set_lockup(data),
+            7 => Ok(StakeInstruction::Merge),
+            8 => Self::decode_authorize_with_seed(data),
+            9 => Ok(StakeInstruction::InitializeChecked),
+            10 => Self::decode_authorize_checked(data),
+            11 => Self::decode_authorize_checked_with_seed(data),
+            12 => Self::decode_set_lockup_checked(data),
+            _ => Err(WasmSolanaError::new(&format!(
+                "Unknown Stake instruction discriminator: {}",
+                discriminator
+            ))),
+        }
+    }
+
+    /// Get the instruction type.
+    pub fn instruction_type(&self) -> StakeInstructionType {
+        match self {
+            Self::Initialize { .. } => StakeInstructionType::Initialize,
+            Self::Authorize { .. } => StakeInstructionType::Authorize,
+            Self::DelegateStake => StakeInstructionType::DelegateStake,
+            Self::Split { .. } => StakeInstructionType::Split,
+            Self::Withdraw { .. } => StakeInstructionType::Withdraw,
+            Self::Deactivate => StakeInstructionType::Deactivate,
+            Self::SetLockup { .. } => StakeInstructionType::SetLockup,
+            Self::Merge => StakeInstructionType::Merge,
+            Self::AuthorizeWithSeed { .. } => StakeInstructionType::AuthorizeWithSeed,
+            Self::InitializeChecked => StakeInstructionType::InitializeChecked,
+            Self::AuthorizeChecked { .. } => StakeInstructionType::AuthorizeChecked,
+            Self::AuthorizeCheckedWithSeed { .. } => StakeInstructionType::AuthorizeCheckedWithSeed,
+            Self::SetLockupChecked { .. } => StakeInstructionType::SetLockupChecked,
+        }
+    }
+
+    // Private decode helpers
+
+    fn decode_initialize(data: &[u8]) -> Result<Self, WasmSolanaError> {
+        // Initialize: staker(Pubkey) + withdrawer(Pubkey) + lockup(i64 + u64 + Pubkey)
+        // Lockup: unix_timestamp(i64) + epoch(u64) + custodian(Pubkey)
+        if data.len() < 64 {
+            return Err(WasmSolanaError::new("Initialize instruction too short"));
+        }
+
+        let staker = Pubkey::try_from(&data[0..32])
+            .map_err(|_| WasmSolanaError::new("Invalid staker pubkey"))?;
+        let withdrawer = Pubkey::try_from(&data[32..64])
+            .map_err(|_| WasmSolanaError::new("Invalid withdrawer pubkey"))?;
+
+        // Lockup is optional but usually present (48 bytes: i64 + u64 + Pubkey)
+        let lockup = if data.len() >= 112 {
+            let unix_timestamp = i64::from_le_bytes(data[64..72].try_into().unwrap());
+            let epoch = u64::from_le_bytes(data[72..80].try_into().unwrap());
+            let custodian = Pubkey::try_from(&data[80..112])
+                .map_err(|_| WasmSolanaError::new("Invalid custodian pubkey"))?;
+
+            // Check if lockup is meaningful (not all zeros)
+            if unix_timestamp != 0 || epoch != 0 || custodian.to_string() != STAKE_PROGRAM_ID {
+                Some(Lockup {
+                    unix_timestamp,
+                    epoch,
+                    custodian,
+                })
+            } else {
+                None
+            }
+        } else {
+            None
+        };
+
+        Ok(Self::Initialize {
+            staker,
+            withdrawer,
+            lockup,
+        })
+    }
+
+    fn decode_authorize(data: &[u8]) -> Result<Self, WasmSolanaError> {
+        // Authorize: new_authority(Pubkey) + stake_authorize(u32)
+        if data.len() < 36 {
+            return Err(WasmSolanaError::new("Authorize instruction too short"));
+        }
+
+        let new_authority = Pubkey::try_from(&data[0..32])
+            .map_err(|_| WasmSolanaError::new("Invalid new_authority pubkey"))?;
+
+        let stake_authorize = match u32::from_le_bytes(data[32..36].try_into().unwrap()) {
+            0 => StakeAuthorize::Staker,
+            1 => StakeAuthorize::Withdrawer,
+            n => {
+                return Err(WasmSolanaError::new(&format!(
+                    "Invalid stake authorize type: {}",
+                    n
+                )))
+            }
+        };
+
+        Ok(Self::Authorize {
+            new_authority,
+            stake_authorize,
+        })
+    }
+
+    fn decode_split(data: &[u8]) -> Result<Self, WasmSolanaError> {
+        // Split: lamports(u64)
+        if data.len() < 8 {
+            return Err(WasmSolanaError::new("Split instruction too short"));
+        }
+
+        let lamports = u64::from_le_bytes(data[0..8].try_into().unwrap());
+
+        Ok(Self::Split { lamports })
+    }
+
+    fn decode_withdraw(data: &[u8]) -> Result<Self, WasmSolanaError> {
+        // Withdraw: lamports(u64)
+        if data.len() < 8 {
+            return Err(WasmSolanaError::new("Withdraw instruction too short"));
+        }
+
+        let lamports = u64::from_le_bytes(data[0..8].try_into().unwrap());
+
+        Ok(Self::Withdraw { lamports })
+    }
+
+    fn decode_set_lockup(data: &[u8]) -> Result<Self, WasmSolanaError> {
+        // SetLockup uses COption format: present(u8) + value
+        let mut offset = 0;
+
+        // unix_timestamp: Option<i64>
+        let unix_timestamp = if data.get(offset).copied() == Some(1) {
+            offset += 1;
+            if data.len() < offset + 8 {
+                return Err(WasmSolanaError::new("SetLockup: truncated unix_timestamp"));
+            }
+            let val = i64::from_le_bytes(data[offset..offset + 8].try_into().unwrap());
+            offset += 8;
+            Some(val)
+        } else {
+            offset += 1;
+            None
+        };
+
+        // epoch: Option<u64>
+        let epoch = if data.get(offset).copied() == Some(1) {
+            offset += 1;
+            if data.len() < offset + 8 {
+                return Err(WasmSolanaError::new("SetLockup: truncated epoch"));
+            }
+            let val = u64::from_le_bytes(data[offset..offset + 8].try_into().unwrap());
+            offset += 8;
+            Some(val)
+        } else {
+            offset += 1;
+            None
+        };
+
+        // custodian: Option<Pubkey>
+        let custodian = if data.get(offset).copied() == Some(1) {
+            offset += 1;
+            if data.len() < offset + 32 {
+                return Err(WasmSolanaError::new("SetLockup: truncated custodian"));
+            }
+            Some(
+                Pubkey::try_from(&data[offset..offset + 32])
+                    .map_err(|_| WasmSolanaError::new("Invalid custodian pubkey"))?,
+            )
+        } else {
+            None
+        };
+
+        Ok(Self::SetLockup {
+            unix_timestamp,
+            epoch,
+            custodian,
+        })
+    }
+
+    fn decode_authorize_with_seed(data: &[u8]) -> Result<Self, WasmSolanaError> {
+        // AuthorizeWithSeed: new_authority(Pubkey) + stake_authorize(u32) + seed_len(u64) + seed(bytes) + authority_owner(Pubkey)
+        if data.len() < 36 {
+            return Err(WasmSolanaError::new(
+                "AuthorizeWithSeed instruction too short",
+            ));
+        }
+
+        let new_authority = Pubkey::try_from(&data[0..32])
+            .map_err(|_| WasmSolanaError::new("Invalid new_authority pubkey"))?;
+
+        let stake_authorize = match u32::from_le_bytes(data[32..36].try_into().unwrap()) {
+            0 => StakeAuthorize::Staker,
+            1 => StakeAuthorize::Withdrawer,
+            n => {
+                return Err(WasmSolanaError::new(&format!(
+                    "Invalid stake authorize type: {}",
+                    n
+                )))
+            }
+        };
+
+        if data.len() < 44 {
+            return Err(WasmSolanaError::new(
+                "AuthorizeWithSeed: missing seed length",
+            ));
+        }
+
+        let seed_len = u64::from_le_bytes(data[36..44].try_into().unwrap()) as usize;
+        if data.len() < 44 + seed_len + 32 {
+            return Err(WasmSolanaError::new("AuthorizeWithSeed: truncated"));
+        }
+
+        let authority_seed = String::from_utf8(data[44..44 + seed_len].to_vec())
+            .map_err(|_| WasmSolanaError::new("Invalid UTF-8 seed"))?;
+
+        let offset = 44 + seed_len;
+        let authority_owner = Pubkey::try_from(&data[offset..offset + 32])
+            .map_err(|_| WasmSolanaError::new("Invalid authority_owner pubkey"))?;
+
+        Ok(Self::AuthorizeWithSeed {
+            new_authority,
+            stake_authorize,
+            authority_seed,
+            authority_owner,
+        })
+    }
+
+    fn decode_authorize_checked(data: &[u8]) -> Result<Self, WasmSolanaError> {
+        // AuthorizeChecked: stake_authorize(u32)
+        if data.len() < 4 {
+            return Err(WasmSolanaError::new(
+                "AuthorizeChecked instruction too short",
+            ));
+        }
+
+        let stake_authorize = match u32::from_le_bytes(data[0..4].try_into().unwrap()) {
+            0 => StakeAuthorize::Staker,
+            1 => StakeAuthorize::Withdrawer,
+            n => {
+                return Err(WasmSolanaError::new(&format!(
+                    "Invalid stake authorize type: {}",
+                    n
+                )))
+            }
+        };
+
+        Ok(Self::AuthorizeChecked { stake_authorize })
+    }
+
+    fn decode_authorize_checked_with_seed(data: &[u8]) -> Result<Self, WasmSolanaError> {
+        // AuthorizeCheckedWithSeed: stake_authorize(u32) + seed_len(u64) + seed(bytes) + authority_owner(Pubkey)
+        if data.len() < 12 {
+            return Err(WasmSolanaError::new(
+                "AuthorizeCheckedWithSeed instruction too short",
+            ));
+        }
+
+        let stake_authorize = match u32::from_le_bytes(data[0..4].try_into().unwrap()) {
+            0 => StakeAuthorize::Staker,
+            1 => StakeAuthorize::Withdrawer,
+            n => {
+                return Err(WasmSolanaError::new(&format!(
+                    "Invalid stake authorize type: {}",
+                    n
+                )))
+            }
+        };
+
+        let seed_len = u64::from_le_bytes(data[4..12].try_into().unwrap()) as usize;
+        if data.len() < 12 + seed_len + 32 {
+            return Err(WasmSolanaError::new("AuthorizeCheckedWithSeed: truncated"));
+        }
+
+        let authority_seed = String::from_utf8(data[12..12 + seed_len].to_vec())
+            .map_err(|_| WasmSolanaError::new("Invalid UTF-8 seed"))?;
+
+        let offset = 12 + seed_len;
+        let authority_owner = Pubkey::try_from(&data[offset..offset + 32])
+            .map_err(|_| WasmSolanaError::new("Invalid authority_owner pubkey"))?;
+
+        Ok(Self::AuthorizeCheckedWithSeed {
+            stake_authorize,
+            authority_seed,
+            authority_owner,
+        })
+    }
+
+    fn decode_set_lockup_checked(data: &[u8]) -> Result<Self, WasmSolanaError> {
+        // SetLockupChecked: same as SetLockup but custodian comes from accounts
+        let mut offset = 0;
+
+        // unix_timestamp: Option<i64>
+        let unix_timestamp = if data.get(offset).copied() == Some(1) {
+            offset += 1;
+            if data.len() < offset + 8 {
+                return Err(WasmSolanaError::new(
+                    "SetLockupChecked: truncated unix_timestamp",
+                ));
+            }
+            let val = i64::from_le_bytes(data[offset..offset + 8].try_into().unwrap());
+            offset += 8;
+            Some(val)
+        } else {
+            offset += 1;
+            None
+        };
+
+        // epoch: Option<u64>
+        let epoch = if data.get(offset).copied() == Some(1) {
+            offset += 1;
+            if data.len() < offset + 8 {
+                return Err(WasmSolanaError::new("SetLockupChecked: truncated epoch"));
+            }
+            let val = u64::from_le_bytes(data[offset..offset + 8].try_into().unwrap());
+            Some(val)
+        } else {
+            None
+        };
+
+        Ok(Self::SetLockupChecked {
+            unix_timestamp,
+            epoch,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_decode_delegate_stake() {
+        let data = [2, 0, 0, 0]; // discriminator = 2 (DelegateStake)
+
+        let instr = StakeInstruction::decode(&data).unwrap();
+        assert!(matches!(instr, StakeInstruction::DelegateStake));
+    }
+
+    #[test]
+    fn test_decode_deactivate() {
+        let data = [5, 0, 0, 0]; // discriminator = 5 (Deactivate)
+
+        let instr = StakeInstruction::decode(&data).unwrap();
+        assert!(matches!(instr, StakeInstruction::Deactivate));
+    }
+
+    #[test]
+    fn test_decode_withdraw() {
+        let data = [
+            4, 0, 0, 0, // discriminator = 4 (Withdraw)
+            0, 0, 0, 0, 1, 0, 0, 0, // lamports = 4294967296 (2^32)
+        ];
+
+        let instr = StakeInstruction::decode(&data).unwrap();
+        match instr {
+            StakeInstruction::Withdraw { lamports } => {
+                assert_eq!(lamports, 4294967296);
+            }
+            _ => panic!("Expected Withdraw instruction"),
+        }
+    }
+
+    #[test]
+    fn test_decode_split() {
+        let data = [
+            3, 0, 0, 0, // discriminator = 3 (Split)
+            128, 150, 152, 0, 0, 0, 0, 0, // lamports = 10000000
+        ];
+
+        let instr = StakeInstruction::decode(&data).unwrap();
+        match instr {
+            StakeInstruction::Split { lamports } => {
+                assert_eq!(lamports, 10000000);
+            }
+            _ => panic!("Expected Split instruction"),
+        }
+    }
+
+    #[test]
+    fn test_is_stake_program() {
+        assert!(StakeInstruction::is_stake_program(STAKE_PROGRAM_ID));
+        assert!(!StakeInstruction::is_stake_program(
+            "11111111111111111111111111111111"
+        ));
+    }
+
+    #[test]
+    fn test_instruction_type() {
+        let deactivate = StakeInstruction::Deactivate;
+        assert_eq!(
+            deactivate.instruction_type(),
+            StakeInstructionType::Deactivate
+        );
+        assert_eq!(deactivate.instruction_type().as_str(), "Deactivate");
+    }
+}

--- a/packages/wasm-solana/src/instructions/system.rs
+++ b/packages/wasm-solana/src/instructions/system.rs
@@ -1,0 +1,518 @@
+//! System Program instruction decoder.
+//!
+//! The System Program is responsible for:
+//! - Creating new accounts
+//! - Allocating account data
+//! - Assigning accounts to programs
+//! - Transferring lamports
+//! - Nonce account operations
+//!
+//! # Wire Format
+//!
+//! System instructions start with a 4-byte little-endian discriminator:
+//! - 0: CreateAccount
+//! - 1: Assign
+//! - 2: Transfer
+//! - 3: CreateAccountWithSeed
+//! - 4: AdvanceNonceAccount
+//! - 5: WithdrawNonceAccount
+//! - 6: InitializeNonceAccount
+//! - 7: AuthorizeNonceAccount
+//! - 8: Allocate
+//! - 9: AllocateWithSeed
+//! - 10: AssignWithSeed
+//! - 11: TransferWithSeed
+//! - 12: UpgradeNonceAccount
+
+use crate::error::WasmSolanaError;
+use crate::Pubkey;
+
+/// System Program ID (all zeros, represented as base58 "11111111111111111111111111111111")
+pub const SYSTEM_PROGRAM_ID: &str = "11111111111111111111111111111111";
+
+/// System instruction types.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SystemInstructionType {
+    CreateAccount,
+    Assign,
+    Transfer,
+    CreateAccountWithSeed,
+    AdvanceNonceAccount,
+    WithdrawNonceAccount,
+    InitializeNonceAccount,
+    AuthorizeNonceAccount,
+    Allocate,
+    AllocateWithSeed,
+    AssignWithSeed,
+    TransferWithSeed,
+    UpgradeNonceAccount,
+}
+
+impl SystemInstructionType {
+    /// Get the string representation of this instruction type.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::CreateAccount => "CreateAccount",
+            Self::Assign => "Assign",
+            Self::Transfer => "Transfer",
+            Self::CreateAccountWithSeed => "CreateAccountWithSeed",
+            Self::AdvanceNonceAccount => "AdvanceNonceAccount",
+            Self::WithdrawNonceAccount => "WithdrawNonceAccount",
+            Self::InitializeNonceAccount => "InitializeNonceAccount",
+            Self::AuthorizeNonceAccount => "AuthorizeNonceAccount",
+            Self::Allocate => "Allocate",
+            Self::AllocateWithSeed => "AllocateWithSeed",
+            Self::AssignWithSeed => "AssignWithSeed",
+            Self::TransferWithSeed => "TransferWithSeed",
+            Self::UpgradeNonceAccount => "UpgradeNonceAccount",
+        }
+    }
+}
+
+/// Decoded System Program instruction.
+#[derive(Debug, Clone)]
+pub enum SystemInstruction {
+    /// Create a new account.
+    /// Accounts: [funding_account, new_account]
+    CreateAccount {
+        /// Number of lamports to transfer to the new account.
+        lamports: u64,
+        /// Number of bytes of memory to allocate.
+        space: u64,
+        /// Address of the program to assign as the owner.
+        owner: Pubkey,
+    },
+
+    /// Assign account to a program.
+    /// Accounts: [assigned_account]
+    Assign {
+        /// Owner program account.
+        owner: Pubkey,
+    },
+
+    /// Transfer lamports.
+    /// Accounts: [from, to]
+    Transfer {
+        /// Number of lamports to transfer.
+        lamports: u64,
+    },
+
+    /// Create a new account at an address derived from seed.
+    /// Accounts: [funding_account, created_account, base_account (optional)]
+    CreateAccountWithSeed {
+        /// Base public key.
+        base: Pubkey,
+        /// Seed string.
+        seed: String,
+        /// Number of lamports to transfer.
+        lamports: u64,
+        /// Number of bytes to allocate.
+        space: u64,
+        /// Owner program.
+        owner: Pubkey,
+    },
+
+    /// Advance the nonce in a nonce account.
+    /// Accounts: [nonce_account, recent_blockhashes_sysvar, nonce_authority]
+    AdvanceNonceAccount,
+
+    /// Withdraw funds from a nonce account.
+    /// Accounts: [nonce_account, to_account, recent_blockhashes_sysvar, rent_sysvar, nonce_authority]
+    WithdrawNonceAccount {
+        /// Lamports to withdraw.
+        lamports: u64,
+    },
+
+    /// Initialize a nonce account.
+    /// Accounts: [nonce_account, recent_blockhashes_sysvar, rent_sysvar]
+    InitializeNonceAccount {
+        /// The entity authorized to execute nonce instructions.
+        authorized: Pubkey,
+    },
+
+    /// Authorize a new entity to execute nonce instructions.
+    /// Accounts: [nonce_account, nonce_authority]
+    AuthorizeNonceAccount {
+        /// New authorized entity.
+        authorized: Pubkey,
+    },
+
+    /// Allocate space for an account without funding.
+    /// Accounts: [new_account]
+    Allocate {
+        /// Number of bytes to allocate.
+        space: u64,
+    },
+
+    /// Allocate space for an account with seed.
+    /// Accounts: [allocated_account, base_account]
+    AllocateWithSeed {
+        /// Base public key.
+        base: Pubkey,
+        /// Seed string.
+        seed: String,
+        /// Number of bytes to allocate.
+        space: u64,
+        /// Owner program.
+        owner: Pubkey,
+    },
+
+    /// Assign account to a program with seed.
+    /// Accounts: [assigned_account, base_account]
+    AssignWithSeed {
+        /// Base public key.
+        base: Pubkey,
+        /// Seed string.
+        seed: String,
+        /// Owner program.
+        owner: Pubkey,
+    },
+
+    /// Transfer lamports from a derived address.
+    /// Accounts: [from_account, base_account, to_account]
+    TransferWithSeed {
+        /// Lamports to transfer.
+        lamports: u64,
+        /// Seed for derived address.
+        from_seed: String,
+        /// Owner of derived address.
+        from_owner: Pubkey,
+    },
+
+    /// Upgrade a nonce account.
+    /// Accounts: [nonce_account]
+    UpgradeNonceAccount,
+}
+
+impl SystemInstruction {
+    /// Check if the given program ID is the System Program.
+    pub fn is_system_program(program_id: &str) -> bool {
+        program_id == SYSTEM_PROGRAM_ID
+    }
+
+    /// Decode a System Program instruction from raw data.
+    ///
+    /// # Arguments
+    ///
+    /// * `data` - Raw instruction data bytes
+    ///
+    /// # Returns
+    ///
+    /// The decoded instruction or an error if the data is invalid.
+    pub fn decode(data: &[u8]) -> Result<Self, WasmSolanaError> {
+        if data.len() < 4 {
+            return Err(WasmSolanaError::new(
+                "System instruction too short: need at least 4 bytes",
+            ));
+        }
+
+        let discriminator = u32::from_le_bytes([data[0], data[1], data[2], data[3]]);
+        let data = &data[4..];
+
+        match discriminator {
+            0 => Self::decode_create_account(data),
+            1 => Self::decode_assign(data),
+            2 => Self::decode_transfer(data),
+            3 => Self::decode_create_account_with_seed(data),
+            4 => Ok(SystemInstruction::AdvanceNonceAccount),
+            5 => Self::decode_withdraw_nonce(data),
+            6 => Self::decode_initialize_nonce(data),
+            7 => Self::decode_authorize_nonce(data),
+            8 => Self::decode_allocate(data),
+            9 => Self::decode_allocate_with_seed(data),
+            10 => Self::decode_assign_with_seed(data),
+            11 => Self::decode_transfer_with_seed(data),
+            12 => Ok(SystemInstruction::UpgradeNonceAccount),
+            _ => Err(WasmSolanaError::new(&format!(
+                "Unknown System instruction discriminator: {}",
+                discriminator
+            ))),
+        }
+    }
+
+    /// Get the instruction type.
+    pub fn instruction_type(&self) -> SystemInstructionType {
+        match self {
+            Self::CreateAccount { .. } => SystemInstructionType::CreateAccount,
+            Self::Assign { .. } => SystemInstructionType::Assign,
+            Self::Transfer { .. } => SystemInstructionType::Transfer,
+            Self::CreateAccountWithSeed { .. } => SystemInstructionType::CreateAccountWithSeed,
+            Self::AdvanceNonceAccount => SystemInstructionType::AdvanceNonceAccount,
+            Self::WithdrawNonceAccount { .. } => SystemInstructionType::WithdrawNonceAccount,
+            Self::InitializeNonceAccount { .. } => SystemInstructionType::InitializeNonceAccount,
+            Self::AuthorizeNonceAccount { .. } => SystemInstructionType::AuthorizeNonceAccount,
+            Self::Allocate { .. } => SystemInstructionType::Allocate,
+            Self::AllocateWithSeed { .. } => SystemInstructionType::AllocateWithSeed,
+            Self::AssignWithSeed { .. } => SystemInstructionType::AssignWithSeed,
+            Self::TransferWithSeed { .. } => SystemInstructionType::TransferWithSeed,
+            Self::UpgradeNonceAccount => SystemInstructionType::UpgradeNonceAccount,
+        }
+    }
+
+    // Private decode helpers
+
+    fn decode_create_account(data: &[u8]) -> Result<Self, WasmSolanaError> {
+        // CreateAccount: lamports(u64) + space(u64) + owner(Pubkey)
+        if data.len() < 48 {
+            return Err(WasmSolanaError::new("CreateAccount instruction too short"));
+        }
+
+        let lamports = u64::from_le_bytes(data[0..8].try_into().unwrap());
+        let space = u64::from_le_bytes(data[8..16].try_into().unwrap());
+        let owner = Pubkey::try_from(&data[16..48])
+            .map_err(|_| WasmSolanaError::new("Invalid owner pubkey in CreateAccount"))?;
+
+        Ok(Self::CreateAccount {
+            lamports,
+            space,
+            owner,
+        })
+    }
+
+    fn decode_assign(data: &[u8]) -> Result<Self, WasmSolanaError> {
+        // Assign: owner(Pubkey)
+        if data.len() < 32 {
+            return Err(WasmSolanaError::new("Assign instruction too short"));
+        }
+
+        let owner = Pubkey::try_from(&data[0..32])
+            .map_err(|_| WasmSolanaError::new("Invalid owner pubkey in Assign"))?;
+
+        Ok(Self::Assign { owner })
+    }
+
+    fn decode_transfer(data: &[u8]) -> Result<Self, WasmSolanaError> {
+        // Transfer: lamports(u64)
+        if data.len() < 8 {
+            return Err(WasmSolanaError::new("Transfer instruction too short"));
+        }
+
+        let lamports = u64::from_le_bytes(data[0..8].try_into().unwrap());
+
+        Ok(Self::Transfer { lamports })
+    }
+
+    fn decode_create_account_with_seed(data: &[u8]) -> Result<Self, WasmSolanaError> {
+        // CreateAccountWithSeed: base(Pubkey) + seed_len(u64) + seed(bytes) + lamports(u64) + space(u64) + owner(Pubkey)
+        if data.len() < 32 {
+            return Err(WasmSolanaError::new(
+                "CreateAccountWithSeed instruction too short",
+            ));
+        }
+
+        let base = Pubkey::try_from(&data[0..32])
+            .map_err(|_| WasmSolanaError::new("Invalid base pubkey"))?;
+
+        let seed_len = u64::from_le_bytes(data[32..40].try_into().unwrap()) as usize;
+        if data.len() < 40 + seed_len + 48 {
+            return Err(WasmSolanaError::new(
+                "CreateAccountWithSeed instruction too short for seed",
+            ));
+        }
+
+        let seed = String::from_utf8(data[40..40 + seed_len].to_vec())
+            .map_err(|_| WasmSolanaError::new("Invalid UTF-8 seed"))?;
+
+        let offset = 40 + seed_len;
+        let lamports = u64::from_le_bytes(data[offset..offset + 8].try_into().unwrap());
+        let space = u64::from_le_bytes(data[offset + 8..offset + 16].try_into().unwrap());
+        let owner = Pubkey::try_from(&data[offset + 16..offset + 48])
+            .map_err(|_| WasmSolanaError::new("Invalid owner pubkey"))?;
+
+        Ok(Self::CreateAccountWithSeed {
+            base,
+            seed,
+            lamports,
+            space,
+            owner,
+        })
+    }
+
+    fn decode_withdraw_nonce(data: &[u8]) -> Result<Self, WasmSolanaError> {
+        // WithdrawNonceAccount: lamports(u64)
+        if data.len() < 8 {
+            return Err(WasmSolanaError::new(
+                "WithdrawNonceAccount instruction too short",
+            ));
+        }
+
+        let lamports = u64::from_le_bytes(data[0..8].try_into().unwrap());
+
+        Ok(Self::WithdrawNonceAccount { lamports })
+    }
+
+    fn decode_initialize_nonce(data: &[u8]) -> Result<Self, WasmSolanaError> {
+        // InitializeNonceAccount: authorized(Pubkey)
+        if data.len() < 32 {
+            return Err(WasmSolanaError::new(
+                "InitializeNonceAccount instruction too short",
+            ));
+        }
+
+        let authorized = Pubkey::try_from(&data[0..32])
+            .map_err(|_| WasmSolanaError::new("Invalid authorized pubkey"))?;
+
+        Ok(Self::InitializeNonceAccount { authorized })
+    }
+
+    fn decode_authorize_nonce(data: &[u8]) -> Result<Self, WasmSolanaError> {
+        // AuthorizeNonceAccount: authorized(Pubkey)
+        if data.len() < 32 {
+            return Err(WasmSolanaError::new(
+                "AuthorizeNonceAccount instruction too short",
+            ));
+        }
+
+        let authorized = Pubkey::try_from(&data[0..32])
+            .map_err(|_| WasmSolanaError::new("Invalid authorized pubkey"))?;
+
+        Ok(Self::AuthorizeNonceAccount { authorized })
+    }
+
+    fn decode_allocate(data: &[u8]) -> Result<Self, WasmSolanaError> {
+        // Allocate: space(u64)
+        if data.len() < 8 {
+            return Err(WasmSolanaError::new("Allocate instruction too short"));
+        }
+
+        let space = u64::from_le_bytes(data[0..8].try_into().unwrap());
+
+        Ok(Self::Allocate { space })
+    }
+
+    fn decode_allocate_with_seed(data: &[u8]) -> Result<Self, WasmSolanaError> {
+        // AllocateWithSeed: base(Pubkey) + seed_len(u64) + seed(bytes) + space(u64) + owner(Pubkey)
+        if data.len() < 32 {
+            return Err(WasmSolanaError::new(
+                "AllocateWithSeed instruction too short",
+            ));
+        }
+
+        let base = Pubkey::try_from(&data[0..32])
+            .map_err(|_| WasmSolanaError::new("Invalid base pubkey"))?;
+
+        let seed_len = u64::from_le_bytes(data[32..40].try_into().unwrap()) as usize;
+        if data.len() < 40 + seed_len + 40 {
+            return Err(WasmSolanaError::new(
+                "AllocateWithSeed instruction too short for seed",
+            ));
+        }
+
+        let seed = String::from_utf8(data[40..40 + seed_len].to_vec())
+            .map_err(|_| WasmSolanaError::new("Invalid UTF-8 seed"))?;
+
+        let offset = 40 + seed_len;
+        let space = u64::from_le_bytes(data[offset..offset + 8].try_into().unwrap());
+        let owner = Pubkey::try_from(&data[offset + 8..offset + 40])
+            .map_err(|_| WasmSolanaError::new("Invalid owner pubkey"))?;
+
+        Ok(Self::AllocateWithSeed {
+            base,
+            seed,
+            space,
+            owner,
+        })
+    }
+
+    fn decode_assign_with_seed(data: &[u8]) -> Result<Self, WasmSolanaError> {
+        // AssignWithSeed: base(Pubkey) + seed_len(u64) + seed(bytes) + owner(Pubkey)
+        if data.len() < 32 {
+            return Err(WasmSolanaError::new("AssignWithSeed instruction too short"));
+        }
+
+        let base = Pubkey::try_from(&data[0..32])
+            .map_err(|_| WasmSolanaError::new("Invalid base pubkey"))?;
+
+        let seed_len = u64::from_le_bytes(data[32..40].try_into().unwrap()) as usize;
+        if data.len() < 40 + seed_len + 32 {
+            return Err(WasmSolanaError::new(
+                "AssignWithSeed instruction too short for seed",
+            ));
+        }
+
+        let seed = String::from_utf8(data[40..40 + seed_len].to_vec())
+            .map_err(|_| WasmSolanaError::new("Invalid UTF-8 seed"))?;
+
+        let offset = 40 + seed_len;
+        let owner = Pubkey::try_from(&data[offset..offset + 32])
+            .map_err(|_| WasmSolanaError::new("Invalid owner pubkey"))?;
+
+        Ok(Self::AssignWithSeed { base, seed, owner })
+    }
+
+    fn decode_transfer_with_seed(data: &[u8]) -> Result<Self, WasmSolanaError> {
+        // TransferWithSeed: lamports(u64) + seed_len(u64) + seed(bytes) + from_owner(Pubkey)
+        if data.len() < 16 {
+            return Err(WasmSolanaError::new(
+                "TransferWithSeed instruction too short",
+            ));
+        }
+
+        let lamports = u64::from_le_bytes(data[0..8].try_into().unwrap());
+        let seed_len = u64::from_le_bytes(data[8..16].try_into().unwrap()) as usize;
+
+        if data.len() < 16 + seed_len + 32 {
+            return Err(WasmSolanaError::new(
+                "TransferWithSeed instruction too short for seed",
+            ));
+        }
+
+        let from_seed = String::from_utf8(data[16..16 + seed_len].to_vec())
+            .map_err(|_| WasmSolanaError::new("Invalid UTF-8 seed"))?;
+
+        let offset = 16 + seed_len;
+        let from_owner = Pubkey::try_from(&data[offset..offset + 32])
+            .map_err(|_| WasmSolanaError::new("Invalid from_owner pubkey"))?;
+
+        Ok(Self::TransferWithSeed {
+            lamports,
+            from_seed,
+            from_owner,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_decode_transfer() {
+        // Transfer 100000 lamports (discriminator 2 + u64 lamports)
+        let data = [
+            2, 0, 0, 0, // discriminator = 2 (Transfer)
+            160, 134, 1, 0, 0, 0, 0, 0, // lamports = 100000
+        ];
+
+        let instr = SystemInstruction::decode(&data).unwrap();
+        match instr {
+            SystemInstruction::Transfer { lamports } => {
+                assert_eq!(lamports, 100000);
+            }
+            _ => panic!("Expected Transfer instruction"),
+        }
+    }
+
+    #[test]
+    fn test_decode_advance_nonce() {
+        let data = [4, 0, 0, 0]; // discriminator = 4 (AdvanceNonceAccount)
+
+        let instr = SystemInstruction::decode(&data).unwrap();
+        assert!(matches!(instr, SystemInstruction::AdvanceNonceAccount));
+    }
+
+    #[test]
+    fn test_is_system_program() {
+        assert!(SystemInstruction::is_system_program(SYSTEM_PROGRAM_ID));
+        assert!(!SystemInstruction::is_system_program(
+            "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        ));
+    }
+
+    #[test]
+    fn test_instruction_type() {
+        let transfer = SystemInstruction::Transfer { lamports: 100 };
+        assert_eq!(transfer.instruction_type(), SystemInstructionType::Transfer);
+        assert_eq!(transfer.instruction_type().as_str(), "Transfer");
+    }
+}

--- a/packages/wasm-solana/src/lib.rs
+++ b/packages/wasm-solana/src/lib.rs
@@ -24,6 +24,7 @@
 //! ```
 
 mod error;
+pub mod instructions;
 pub mod keypair;
 pub mod pubkey;
 pub mod transaction;
@@ -34,6 +35,12 @@ pub use error::WasmSolanaError;
 pub use keypair::{Keypair, KeypairExt};
 pub use pubkey::{Pubkey, PubkeyExt};
 pub use transaction::{Transaction, TransactionExt};
+
+// Re-export instruction types
+pub use instructions::{
+    ComputeBudgetInstruction, ComputeBudgetInstructionType, StakeAuthorize, StakeInstruction,
+    StakeInstructionType, SystemInstruction, SystemInstructionType,
+};
 
 // Re-export WASM types
 pub use wasm::{WasmKeypair, WasmPubkey, WasmTransaction};

--- a/packages/wasm-solana/src/wasm/instructions.rs
+++ b/packages/wasm-solana/src/wasm/instructions.rs
@@ -1,0 +1,344 @@
+//! WASM bindings for instruction decoders.
+//!
+//! Provides JavaScript-friendly interfaces for decoding Solana program instructions.
+
+use crate::error::WasmSolanaError;
+use crate::instructions::{
+    compute_budget::{ComputeBudgetInstruction, COMPUTE_BUDGET_PROGRAM_ID},
+    stake::{StakeInstruction, STAKE_PROGRAM_ID},
+    system::{SystemInstruction, SYSTEM_PROGRAM_ID},
+};
+use wasm_bindgen::prelude::*;
+
+// =============================================================================
+// System Instruction WASM Bindings
+// =============================================================================
+
+/// WASM namespace for System Program instruction decoding.
+#[wasm_bindgen]
+pub struct SystemInstructionDecoder;
+
+#[wasm_bindgen]
+impl SystemInstructionDecoder {
+    /// The System Program ID as a base58 string.
+    #[wasm_bindgen(getter)]
+    pub fn program_id() -> String {
+        SYSTEM_PROGRAM_ID.to_string()
+    }
+
+    /// Check if the given program ID is the System Program.
+    #[wasm_bindgen]
+    pub fn is_system_program(program_id: &str) -> bool {
+        SystemInstruction::is_system_program(program_id)
+    }
+
+    /// Decode a System instruction from raw bytes.
+    ///
+    /// Returns a JS object with:
+    /// - `type`: string (e.g., "Transfer", "CreateAccount")
+    /// - Additional fields depending on the instruction type
+    #[wasm_bindgen]
+    pub fn decode(data: &[u8]) -> Result<js_sys::Object, WasmSolanaError> {
+        let instr = SystemInstruction::decode(data)?;
+        let obj = js_sys::Object::new();
+
+        // Set the instruction type
+        let type_str = instr.instruction_type().as_str();
+        js_sys::Reflect::set(&obj, &"type".into(), &type_str.into())
+            .map_err(|_| WasmSolanaError::new("Failed to set type"))?;
+
+        // Set instruction-specific fields
+        match instr {
+            SystemInstruction::CreateAccount {
+                lamports,
+                space,
+                owner,
+            } => {
+                set_u64(&obj, "lamports", lamports)?;
+                set_u64(&obj, "space", space)?;
+                set_string(&obj, "owner", &owner.to_string())?;
+            }
+            SystemInstruction::Assign { owner } => {
+                set_string(&obj, "owner", &owner.to_string())?;
+            }
+            SystemInstruction::Transfer { lamports } => {
+                set_u64(&obj, "lamports", lamports)?;
+            }
+            SystemInstruction::CreateAccountWithSeed {
+                base,
+                seed,
+                lamports,
+                space,
+                owner,
+            } => {
+                set_string(&obj, "base", &base.to_string())?;
+                set_string(&obj, "seed", &seed)?;
+                set_u64(&obj, "lamports", lamports)?;
+                set_u64(&obj, "space", space)?;
+                set_string(&obj, "owner", &owner.to_string())?;
+            }
+            SystemInstruction::AdvanceNonceAccount => {}
+            SystemInstruction::WithdrawNonceAccount { lamports } => {
+                set_u64(&obj, "lamports", lamports)?;
+            }
+            SystemInstruction::InitializeNonceAccount { authorized } => {
+                set_string(&obj, "authorized", &authorized.to_string())?;
+            }
+            SystemInstruction::AuthorizeNonceAccount { authorized } => {
+                set_string(&obj, "authorized", &authorized.to_string())?;
+            }
+            SystemInstruction::Allocate { space } => {
+                set_u64(&obj, "space", space)?;
+            }
+            SystemInstruction::AllocateWithSeed {
+                base,
+                seed,
+                space,
+                owner,
+            } => {
+                set_string(&obj, "base", &base.to_string())?;
+                set_string(&obj, "seed", &seed)?;
+                set_u64(&obj, "space", space)?;
+                set_string(&obj, "owner", &owner.to_string())?;
+            }
+            SystemInstruction::AssignWithSeed { base, seed, owner } => {
+                set_string(&obj, "base", &base.to_string())?;
+                set_string(&obj, "seed", &seed)?;
+                set_string(&obj, "owner", &owner.to_string())?;
+            }
+            SystemInstruction::TransferWithSeed {
+                lamports,
+                from_seed,
+                from_owner,
+            } => {
+                set_u64(&obj, "lamports", lamports)?;
+                set_string(&obj, "fromSeed", &from_seed)?;
+                set_string(&obj, "fromOwner", &from_owner.to_string())?;
+            }
+            SystemInstruction::UpgradeNonceAccount => {}
+        }
+
+        Ok(obj)
+    }
+}
+
+// =============================================================================
+// Stake Instruction WASM Bindings
+// =============================================================================
+
+/// WASM namespace for Stake Program instruction decoding.
+#[wasm_bindgen]
+pub struct StakeInstructionDecoder;
+
+#[wasm_bindgen]
+impl StakeInstructionDecoder {
+    /// The Stake Program ID as a base58 string.
+    #[wasm_bindgen(getter)]
+    pub fn program_id() -> String {
+        STAKE_PROGRAM_ID.to_string()
+    }
+
+    /// Check if the given program ID is the Stake Program.
+    #[wasm_bindgen]
+    pub fn is_stake_program(program_id: &str) -> bool {
+        StakeInstruction::is_stake_program(program_id)
+    }
+
+    /// Decode a Stake instruction from raw bytes.
+    ///
+    /// Returns a JS object with:
+    /// - `type`: string (e.g., "DelegateStake", "Deactivate")
+    /// - Additional fields depending on the instruction type
+    #[wasm_bindgen]
+    pub fn decode(data: &[u8]) -> Result<js_sys::Object, WasmSolanaError> {
+        let instr = StakeInstruction::decode(data)?;
+        let obj = js_sys::Object::new();
+
+        // Set the instruction type
+        let type_str = instr.instruction_type().as_str();
+        js_sys::Reflect::set(&obj, &"type".into(), &type_str.into())
+            .map_err(|_| WasmSolanaError::new("Failed to set type"))?;
+
+        // Set instruction-specific fields
+        match instr {
+            StakeInstruction::Initialize {
+                staker,
+                withdrawer,
+                lockup,
+            } => {
+                set_string(&obj, "staker", &staker.to_string())?;
+                set_string(&obj, "withdrawer", &withdrawer.to_string())?;
+                if let Some(lockup) = lockup {
+                    let lockup_obj = js_sys::Object::new();
+                    set_i64(&lockup_obj, "unixTimestamp", lockup.unix_timestamp)?;
+                    set_u64(&lockup_obj, "epoch", lockup.epoch)?;
+                    set_string(&lockup_obj, "custodian", &lockup.custodian.to_string())?;
+                    js_sys::Reflect::set(&obj, &"lockup".into(), &lockup_obj)
+                        .map_err(|_| WasmSolanaError::new("Failed to set lockup"))?;
+                }
+            }
+            StakeInstruction::Authorize {
+                new_authority,
+                stake_authorize,
+            } => {
+                set_string(&obj, "newAuthority", &new_authority.to_string())?;
+                set_string(&obj, "stakeAuthorize", stake_authorize.as_str())?;
+            }
+            StakeInstruction::DelegateStake => {}
+            StakeInstruction::Split { lamports } => {
+                set_u64(&obj, "lamports", lamports)?;
+            }
+            StakeInstruction::Withdraw { lamports } => {
+                set_u64(&obj, "lamports", lamports)?;
+            }
+            StakeInstruction::Deactivate => {}
+            StakeInstruction::SetLockup {
+                unix_timestamp,
+                epoch,
+                custodian,
+            } => {
+                if let Some(ts) = unix_timestamp {
+                    set_i64(&obj, "unixTimestamp", ts)?;
+                }
+                if let Some(e) = epoch {
+                    set_u64(&obj, "epoch", e)?;
+                }
+                if let Some(c) = custodian {
+                    set_string(&obj, "custodian", &c.to_string())?;
+                }
+            }
+            StakeInstruction::Merge => {}
+            StakeInstruction::AuthorizeWithSeed {
+                new_authority,
+                stake_authorize,
+                authority_seed,
+                authority_owner,
+            } => {
+                set_string(&obj, "newAuthority", &new_authority.to_string())?;
+                set_string(&obj, "stakeAuthorize", stake_authorize.as_str())?;
+                set_string(&obj, "authoritySeed", &authority_seed)?;
+                set_string(&obj, "authorityOwner", &authority_owner.to_string())?;
+            }
+            StakeInstruction::InitializeChecked => {}
+            StakeInstruction::AuthorizeChecked { stake_authorize } => {
+                set_string(&obj, "stakeAuthorize", stake_authorize.as_str())?;
+            }
+            StakeInstruction::AuthorizeCheckedWithSeed {
+                stake_authorize,
+                authority_seed,
+                authority_owner,
+            } => {
+                set_string(&obj, "stakeAuthorize", stake_authorize.as_str())?;
+                set_string(&obj, "authoritySeed", &authority_seed)?;
+                set_string(&obj, "authorityOwner", &authority_owner.to_string())?;
+            }
+            StakeInstruction::SetLockupChecked {
+                unix_timestamp,
+                epoch,
+            } => {
+                if let Some(ts) = unix_timestamp {
+                    set_i64(&obj, "unixTimestamp", ts)?;
+                }
+                if let Some(e) = epoch {
+                    set_u64(&obj, "epoch", e)?;
+                }
+            }
+        }
+
+        Ok(obj)
+    }
+}
+
+// =============================================================================
+// ComputeBudget Instruction WASM Bindings
+// =============================================================================
+
+/// WASM namespace for ComputeBudget Program instruction decoding.
+#[wasm_bindgen]
+pub struct ComputeBudgetInstructionDecoder;
+
+#[wasm_bindgen]
+impl ComputeBudgetInstructionDecoder {
+    /// The ComputeBudget Program ID as a base58 string.
+    #[wasm_bindgen(getter)]
+    pub fn program_id() -> String {
+        COMPUTE_BUDGET_PROGRAM_ID.to_string()
+    }
+
+    /// Check if the given program ID is the ComputeBudget Program.
+    #[wasm_bindgen]
+    pub fn is_compute_budget_program(program_id: &str) -> bool {
+        ComputeBudgetInstruction::is_compute_budget_program(program_id)
+    }
+
+    /// Decode a ComputeBudget instruction from raw bytes.
+    ///
+    /// Returns a JS object with:
+    /// - `type`: string (e.g., "SetComputeUnitLimit", "SetComputeUnitPrice")
+    /// - Additional fields depending on the instruction type
+    #[wasm_bindgen]
+    pub fn decode(data: &[u8]) -> Result<js_sys::Object, WasmSolanaError> {
+        let instr = ComputeBudgetInstruction::decode(data)?;
+        let obj = js_sys::Object::new();
+
+        // Set the instruction type
+        let type_str = instr.instruction_type().as_str();
+        js_sys::Reflect::set(&obj, &"type".into(), &type_str.into())
+            .map_err(|_| WasmSolanaError::new("Failed to set type"))?;
+
+        // Set instruction-specific fields
+        match instr {
+            ComputeBudgetInstruction::RequestUnitsDeprecated {
+                units,
+                additional_fee,
+            } => {
+                set_u32(&obj, "units", units)?;
+                set_u32(&obj, "additionalFee", additional_fee)?;
+            }
+            ComputeBudgetInstruction::RequestHeapFrame { bytes } => {
+                set_u32(&obj, "bytes", bytes)?;
+            }
+            ComputeBudgetInstruction::SetComputeUnitLimit { units } => {
+                set_u32(&obj, "units", units)?;
+            }
+            ComputeBudgetInstruction::SetComputeUnitPrice { micro_lamports } => {
+                set_u64(&obj, "microLamports", micro_lamports)?;
+            }
+            ComputeBudgetInstruction::SetLoadedAccountsDataSizeLimit { bytes } => {
+                set_u32(&obj, "bytes", bytes)?;
+            }
+        }
+
+        Ok(obj)
+    }
+}
+
+// =============================================================================
+// Helper Functions
+// =============================================================================
+
+fn set_string(obj: &js_sys::Object, key: &str, value: &str) -> Result<(), WasmSolanaError> {
+    js_sys::Reflect::set(obj, &key.into(), &value.into())
+        .map_err(|_| WasmSolanaError::new(&format!("Failed to set {}", key)))?;
+    Ok(())
+}
+
+fn set_u32(obj: &js_sys::Object, key: &str, value: u32) -> Result<(), WasmSolanaError> {
+    js_sys::Reflect::set(obj, &key.into(), &JsValue::from(value))
+        .map_err(|_| WasmSolanaError::new(&format!("Failed to set {}", key)))?;
+    Ok(())
+}
+
+fn set_u64(obj: &js_sys::Object, key: &str, value: u64) -> Result<(), WasmSolanaError> {
+    // Use BigInt for u64 to preserve precision
+    js_sys::Reflect::set(obj, &key.into(), &js_sys::BigInt::from(value).into())
+        .map_err(|_| WasmSolanaError::new(&format!("Failed to set {}", key)))?;
+    Ok(())
+}
+
+fn set_i64(obj: &js_sys::Object, key: &str, value: i64) -> Result<(), WasmSolanaError> {
+    // Use BigInt for i64 to preserve precision
+    js_sys::Reflect::set(obj, &key.into(), &js_sys::BigInt::from(value).into())
+        .map_err(|_| WasmSolanaError::new(&format!("Failed to set {}", key)))?;
+    Ok(())
+}

--- a/packages/wasm-solana/src/wasm/mod.rs
+++ b/packages/wasm-solana/src/wasm/mod.rs
@@ -1,7 +1,11 @@
+mod instructions;
 mod keypair;
 mod pubkey;
 mod transaction;
 
+pub use instructions::{
+    ComputeBudgetInstructionDecoder, StakeInstructionDecoder, SystemInstructionDecoder,
+};
 pub use keypair::WasmKeypair;
 pub use pubkey::WasmPubkey;
 pub use transaction::WasmTransaction;

--- a/packages/wasm-solana/test/instructions.ts
+++ b/packages/wasm-solana/test/instructions.ts
@@ -1,0 +1,362 @@
+import * as assert from "assert";
+import {
+  SystemInstruction,
+  StakeInstruction,
+  ComputeBudgetInstruction,
+  Transaction,
+} from "../js/index.js";
+
+describe("SystemInstruction", () => {
+  describe("program ID", () => {
+    it("should have correct program ID", () => {
+      assert.strictEqual(SystemInstruction.PROGRAM_ID, "11111111111111111111111111111111");
+    });
+
+    it("should identify System program", () => {
+      assert.strictEqual(
+        SystemInstruction.isSystemProgram("11111111111111111111111111111111"),
+        true,
+      );
+      assert.strictEqual(
+        SystemInstruction.isSystemProgram("TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"),
+        false,
+      );
+    });
+  });
+
+  describe("decode", () => {
+    it("should decode Transfer instruction", () => {
+      // Transfer 100000 lamports
+      const data = new Uint8Array([
+        2,
+        0,
+        0,
+        0, // discriminator = 2 (Transfer)
+        160,
+        134,
+        1,
+        0,
+        0,
+        0,
+        0,
+        0, // lamports = 100000
+      ]);
+
+      const decoded = SystemInstruction.decode(data);
+      assert.strictEqual(decoded.type, "Transfer");
+      if (decoded.type === "Transfer") {
+        assert.strictEqual(decoded.lamports, 100000n);
+      }
+    });
+
+    it("should decode AdvanceNonceAccount instruction", () => {
+      const data = new Uint8Array([4, 0, 0, 0]); // discriminator = 4
+
+      const decoded = SystemInstruction.decode(data);
+      assert.strictEqual(decoded.type, "AdvanceNonceAccount");
+    });
+
+    it("should decode CreateAccount instruction", () => {
+      // CreateAccount with 1 SOL (1000000000 lamports), 165 bytes space
+      const owner = new Uint8Array(32).fill(1); // dummy owner
+      const data = new Uint8Array([
+        0,
+        0,
+        0,
+        0, // discriminator = 0 (CreateAccount)
+        0,
+        202,
+        154,
+        59,
+        0,
+        0,
+        0,
+        0, // lamports = 1000000000
+        165,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0, // space = 165
+        ...owner, // owner pubkey
+      ]);
+
+      const decoded = SystemInstruction.decode(data);
+      assert.strictEqual(decoded.type, "CreateAccount");
+      if (decoded.type === "CreateAccount") {
+        assert.strictEqual(decoded.lamports, 1000000000n);
+        assert.strictEqual(decoded.space, 165n);
+        assert.ok(decoded.owner.length > 0);
+      }
+    });
+
+    it("should decode Allocate instruction", () => {
+      const data = new Uint8Array([
+        8,
+        0,
+        0,
+        0, // discriminator = 8 (Allocate)
+        0,
+        16,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0, // space = 4096
+      ]);
+
+      const decoded = SystemInstruction.decode(data);
+      assert.strictEqual(decoded.type, "Allocate");
+      if (decoded.type === "Allocate") {
+        assert.strictEqual(decoded.space, 4096n);
+      }
+    });
+
+    it("should throw on invalid data", () => {
+      const data = new Uint8Array([255, 255, 255, 255]); // invalid discriminator
+      assert.throws(() => SystemInstruction.decode(data), /Unknown System instruction/);
+    });
+
+    it("should throw on truncated data", () => {
+      const data = new Uint8Array([2, 0]); // Transfer but too short
+      assert.throws(() => SystemInstruction.decode(data));
+    });
+  });
+});
+
+describe("StakeInstruction", () => {
+  describe("program ID", () => {
+    it("should have correct program ID", () => {
+      assert.strictEqual(
+        StakeInstruction.PROGRAM_ID,
+        "Stake11111111111111111111111111111111111111",
+      );
+    });
+
+    it("should identify Stake program", () => {
+      assert.strictEqual(
+        StakeInstruction.isStakeProgram("Stake11111111111111111111111111111111111111"),
+        true,
+      );
+      assert.strictEqual(
+        StakeInstruction.isStakeProgram("11111111111111111111111111111111"),
+        false,
+      );
+    });
+  });
+
+  describe("decode", () => {
+    it("should decode DelegateStake instruction", () => {
+      const data = new Uint8Array([2, 0, 0, 0]); // discriminator = 2
+
+      const decoded = StakeInstruction.decode(data);
+      assert.strictEqual(decoded.type, "DelegateStake");
+    });
+
+    it("should decode Deactivate instruction", () => {
+      const data = new Uint8Array([5, 0, 0, 0]); // discriminator = 5
+
+      const decoded = StakeInstruction.decode(data);
+      assert.strictEqual(decoded.type, "Deactivate");
+    });
+
+    it("should decode Withdraw instruction", () => {
+      const data = new Uint8Array([
+        4,
+        0,
+        0,
+        0, // discriminator = 4 (Withdraw)
+        0,
+        0,
+        0,
+        0,
+        1,
+        0,
+        0,
+        0, // lamports = 4294967296
+      ]);
+
+      const decoded = StakeInstruction.decode(data);
+      assert.strictEqual(decoded.type, "Withdraw");
+      if (decoded.type === "Withdraw") {
+        assert.strictEqual(decoded.lamports, 4294967296n);
+      }
+    });
+
+    it("should decode Split instruction", () => {
+      const data = new Uint8Array([
+        3,
+        0,
+        0,
+        0, // discriminator = 3 (Split)
+        128,
+        150,
+        152,
+        0,
+        0,
+        0,
+        0,
+        0, // lamports = 10000000
+      ]);
+
+      const decoded = StakeInstruction.decode(data);
+      assert.strictEqual(decoded.type, "Split");
+      if (decoded.type === "Split") {
+        assert.strictEqual(decoded.lamports, 10000000n);
+      }
+    });
+
+    it("should decode Merge instruction", () => {
+      const data = new Uint8Array([7, 0, 0, 0]); // discriminator = 7
+
+      const decoded = StakeInstruction.decode(data);
+      assert.strictEqual(decoded.type, "Merge");
+    });
+
+    it("should decode Authorize instruction", () => {
+      const newAuthority = new Uint8Array(32).fill(2);
+      const data = new Uint8Array([
+        1,
+        0,
+        0,
+        0, // discriminator = 1 (Authorize)
+        ...newAuthority, // new authority pubkey
+        0,
+        0,
+        0,
+        0, // stake_authorize = 0 (Staker)
+      ]);
+
+      const decoded = StakeInstruction.decode(data);
+      assert.strictEqual(decoded.type, "Authorize");
+      if (decoded.type === "Authorize") {
+        assert.strictEqual(decoded.stakeAuthorize, "Staker");
+        assert.ok(decoded.newAuthority.length > 0);
+      }
+    });
+
+    it("should throw on invalid discriminator", () => {
+      const data = new Uint8Array([255, 255, 255, 255]);
+      assert.throws(() => StakeInstruction.decode(data), /Unknown Stake instruction/);
+    });
+  });
+});
+
+describe("ComputeBudgetInstruction", () => {
+  describe("program ID", () => {
+    it("should have correct program ID", () => {
+      assert.strictEqual(
+        ComputeBudgetInstruction.PROGRAM_ID,
+        "ComputeBudget111111111111111111111111111111",
+      );
+    });
+
+    it("should identify ComputeBudget program", () => {
+      assert.strictEqual(
+        ComputeBudgetInstruction.isComputeBudgetProgram(
+          "ComputeBudget111111111111111111111111111111",
+        ),
+        true,
+      );
+      assert.strictEqual(
+        ComputeBudgetInstruction.isComputeBudgetProgram("11111111111111111111111111111111"),
+        false,
+      );
+    });
+  });
+
+  describe("decode", () => {
+    it("should decode SetComputeUnitLimit instruction", () => {
+      const data = new Uint8Array([
+        2, // discriminator = 2 (SetComputeUnitLimit)
+        64,
+        66,
+        15,
+        0, // units = 1000000
+      ]);
+
+      const decoded = ComputeBudgetInstruction.decode(data);
+      assert.strictEqual(decoded.type, "SetComputeUnitLimit");
+      if (decoded.type === "SetComputeUnitLimit") {
+        assert.strictEqual(decoded.units, 1000000);
+      }
+    });
+
+    it("should decode SetComputeUnitPrice instruction", () => {
+      const data = new Uint8Array([
+        3, // discriminator = 3 (SetComputeUnitPrice)
+        232,
+        3,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0, // micro_lamports = 1000
+      ]);
+
+      const decoded = ComputeBudgetInstruction.decode(data);
+      assert.strictEqual(decoded.type, "SetComputeUnitPrice");
+      if (decoded.type === "SetComputeUnitPrice") {
+        assert.strictEqual(decoded.microLamports, 1000n);
+      }
+    });
+
+    it("should throw on invalid discriminator", () => {
+      const data = new Uint8Array([255]);
+      assert.throws(
+        () => ComputeBudgetInstruction.decode(data),
+        /Unknown ComputeBudget instruction/,
+      );
+    });
+
+    it("should throw on empty data", () => {
+      const data = new Uint8Array([]);
+      assert.throws(() => ComputeBudgetInstruction.decode(data));
+    });
+  });
+});
+
+describe("Integration: Transaction + Instruction Decoding", () => {
+  // Real SOL transfer transaction
+  const TEST_TX_BASE64 =
+    "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAEDFVMqpim7tqEi2XL8R6KKkP0DYJvY3eiRXLlL1P9EjYgXKQC+k0FKnqyC4AZGJR7OhJXfpPP3NHOhS8t/6G7bLAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/1c7Oaj3RbyLIjU0/ZPpsmVfVUWAzc8g36fK5g6A0JoBAgIAAQwCAAAAoIYBAAAAAAA=";
+
+  it("should decode Transfer instruction from real transaction", () => {
+    const tx = Transaction.fromBase64(TEST_TX_BASE64);
+    const instr = tx.instructionAt(0);
+
+    assert.ok(instr);
+    assert.strictEqual(instr.programId, "11111111111111111111111111111111");
+    assert.ok(SystemInstruction.isSystemProgram(instr.programId));
+
+    const decoded = SystemInstruction.decode(instr.data);
+    assert.strictEqual(decoded.type, "Transfer");
+    if (decoded.type === "Transfer") {
+      assert.strictEqual(decoded.lamports, 100000n);
+    }
+  });
+
+  it("should handle transaction with multiple instruction types", () => {
+    const tx = Transaction.fromBase64(TEST_TX_BASE64);
+
+    for (let i = 0; i < tx.numInstructions; i++) {
+      const instr = tx.instructionAt(i);
+      if (!instr) continue;
+
+      if (SystemInstruction.isSystemProgram(instr.programId)) {
+        const decoded = SystemInstruction.decode(instr.data);
+        assert.ok(decoded.type);
+      } else if (StakeInstruction.isStakeProgram(instr.programId)) {
+        const decoded = StakeInstruction.decode(instr.data);
+        assert.ok(decoded.type);
+      } else if (ComputeBudgetInstruction.isComputeBudgetProgram(instr.programId)) {
+        const decoded = ComputeBudgetInstruction.decode(instr.data);
+        assert.ok(decoded.type);
+      }
+    }
+  });
+});


### PR DESCRIPTION
Add WASM bindings for decoding Solana program instructions:

System Program:
- Transfer, CreateAccount, AdvanceNonceAccount
- WithdrawNonceAccount, InitializeNonceAccount, AuthorizeNonceAccount
- Allocate, Assign, and seed-based variants

Stake Program:
- Initialize, Authorize, DelegateStake
- Split, Withdraw, Deactivate, Merge
- SetLockup, AuthorizeWithSeed, and checked variants

ComputeBudget Program:
- SetComputeUnitLimit, SetComputeUnitPrice
- RequestHeapFrame, SetLoadedAccountsDataSizeLimit

Implementation Details:
- Manual wire format parsing (no external Solana instruction crates)
- Uses existing solana-pubkey for address parsing
- TypeScript wrappers provide strongly-typed discriminated unions

Replaces in BitGoJS (sdk-coin-sol):
- @solana/web3.js SystemInstruction.decodeInstructionType()
- @solana/web3.js StakeInstruction.decodeInstructionType()
- @solana/web3.js ComputeBudgetInstruction.decodeInstructionType()
- Manual instruction data parsing in utils.ts getInstructionType()
- Manual instruction data parsing in instructionParamsFactory.ts

Ticket: BTC-2930