### PR TITLE
feat: add Solana transaction parser component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3021,7 +3021,6 @@
       "integrity": "sha512-/g2d4sW9nUDJOMz3mabVQvOGhVa4e/BN/Um7yca9Bb2XTzPPnfTWHWQg+IsEYO7M3Vx+EXvaM/I2pJWIMun1bg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^4.0.0",
         "@octokit/graphql": "^7.1.0",
@@ -3400,7 +3399,6 @@
       "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.3",
@@ -3631,7 +3629,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4732,7 +4729,6 @@
       "integrity": "sha512-lJi3PfxVmo0AkEY93ecfN+r8SofEqZNGByvHAI3GBLrvt1Cw6H5k1IM02nSzu0RfUafr2EvFSw0wAsZgubNplQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.47.0",
         "@typescript-eslint/types": "8.47.0",
@@ -5208,7 +5204,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5271,7 +5266,6 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -5923,7 +5917,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001646",
         "electron-to-chromium": "^1.5.4",
@@ -8076,7 +8069,6 @@
       "integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -8919,8 +8911,7 @@
     "node_modules/fp-ts": {
       "version": "2.16.9",
       "resolved": "https://registry.npmjs.org/fp-ts/-/fp-ts-2.16.9.tgz",
-      "integrity": "sha512-+I2+FnVB+tVaxcYyQkHUq7ZdKScaBlX53A41mxQtpIccsfyv8PzdzP7fzp2AY832T4aoK6UZ5WRX/ebGd8uZuQ==",
-      "peer": true
+      "integrity": "sha512-+I2+FnVB+tVaxcYyQkHUq7ZdKScaBlX53A41mxQtpIccsfyv8PzdzP7fzp2AY832T4aoK6UZ5WRX/ebGd8uZuQ=="
     },
     "node_modules/fresh": {
       "version": "0.5.2",
@@ -10362,7 +10353,6 @@
       "version": "2.2.21",
       "resolved": "https://registry.npmjs.org/io-ts/-/io-ts-2.2.21.tgz",
       "integrity": "sha512-zz2Z69v9ZIC3mMLYWIeoUcwWD6f+O7yP92FMVVaXEOSZH1jnVBmET/urd/uoarD1WGBY4rCj8TAyMPzsGNzMFQ==",
-      "peer": true,
       "peerDependencies": {
         "fp-ts": "^2.5.0"
       }
@@ -11861,7 +11851,6 @@
       "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -12628,7 +12617,6 @@
       "version": "2.3.13",
       "resolved": "https://registry.npmjs.org/monocle-ts/-/monocle-ts-2.3.13.tgz",
       "integrity": "sha512-D5Ygd3oulEoAm3KuGO0eeJIrhFf1jlQIoEVV2DYsZUMz42j4tGxgct97Aq68+F8w4w4geEnwFa8HayTS/7lpKQ==",
-      "peer": true,
       "peerDependencies": {
         "fp-ts": "^2.5.0"
       }
@@ -12932,7 +12920,6 @@
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/newtype-ts/-/newtype-ts-0.3.5.tgz",
       "integrity": "sha512-v83UEQMlVR75yf1OUdoSFssjitxzjZlqBAjiGQ4WJaML8Jdc68LJ+BaSAXUmKY4bNzp7hygkKLYTsDi14PxI2g==",
-      "peer": true,
       "peerDependencies": {
         "fp-ts": "^2.0.0",
         "monocle-ts": "^2.0.0"
@@ -15357,7 +15344,6 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -15509,7 +15495,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@napi-rs/wasm-runtime": "0.2.4",
         "@yarnpkg/lockfile": "^1.1.0",
@@ -16816,7 +16801,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.7",
         "picocolors": "^1.0.1",
@@ -17943,7 +17927,6 @@
       "integrity": "sha512-6qGjWccl5yoyugHt3jTgztJ9Y0JVzyH8/Voc/D8PlLat9pwxQYXz7W1Dpnq5h0/G5GCYGUaDSlYcyk3AMh5A6g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@semantic-release/commit-analyzer": "^13.0.1",
         "@semantic-release/error": "^4.0.0",
@@ -20063,7 +20046,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -20246,8 +20228,7 @@
       "version": "2.6.3",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
       "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/tsx": {
       "version": "4.20.6",
@@ -20400,7 +20381,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -20769,7 +20749,6 @@
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.94.0.tgz",
       "integrity": "sha512-KcsGn50VT+06JH/iunZJedYGUJS5FGjow8wb9c0v5n1Om8O1g4L6LjtfxwlXIATopoQu+vOXXa7gYisWxCoPyg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@types/estree": "^1.0.5",
         "@webassemblyjs/ast": "^1.12.1",
@@ -20816,7 +20795,6 @@
       "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-5.1.4.tgz",
       "integrity": "sha512-pIDJHIEI9LR0yxHXQ+Qh95k2EvXpWzZ5l+d+jIo+RdSm9MiHfzazIxwwni/p7+x4eJZuvG1AJwgC4TNQ7NRgsg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@discoveryjs/json-ext": "^0.5.0",
         "@webpack-cli/configtest": "^2.1.1",
@@ -20900,7 +20878,6 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -21013,7 +20990,6 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -21610,6 +21586,7 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
+        "@bitgo/wasm-solana": "*",
         "@bitgo/wasm-utxo": "*",
         "fp-ts": "^2.16.8",
         "io-ts": "^2.2.21",

--- a/packages/webui/package.json
+++ b/packages/webui/package.json
@@ -22,6 +22,7 @@
     "deploy": "gh-pages -d dist"
   },
   "dependencies": {
+    "@bitgo/wasm-solana": "*",
     "@bitgo/wasm-utxo": "*",
     "fp-ts": "^2.16.8",
     "io-ts": "^2.2.21",

--- a/packages/webui/src/index.ts
+++ b/packages/webui/src/index.ts
@@ -9,6 +9,7 @@ import { initRouter, type Route } from "./lib/router";
 
 // Import demo components (registers them as custom elements)
 import "./wasm-utxo/addresses";
+import "./wasm-solana/transaction";
 
 // Common styles used across components
 export const commonStyles = `
@@ -136,6 +137,20 @@ class HomePage extends BaseComponent {
               ),
             ),
           ),
+          h(
+            "li",
+            {},
+            h(
+              "a",
+              { class: "demo-link", href: "#/wasm-solana/transaction" },
+              h("div", { class: "demo-title" }, "Solana Transaction Parser"),
+              h(
+                "div",
+                { class: "demo-desc" },
+                "Parse and decode Solana transaction instructions from base64",
+              ),
+            ),
+          ),
         ),
       ),
     );
@@ -148,6 +163,7 @@ defineComponent("home-page", HomePage);
 const routes: Route[] = [
   { path: "/", component: "home-page" },
   { path: "/wasm-utxo/addresses", component: "address-converter" },
+  { path: "/wasm-solana/transaction", component: "solana-transaction-parser" },
 ];
 
 // Initialize router when DOM is ready

--- a/packages/webui/src/wasm-solana/transaction/index.ts
+++ b/packages/webui/src/wasm-solana/transaction/index.ts
@@ -1,0 +1,609 @@
+/**
+ * Solana Transaction Parser Demo
+ *
+ * Parses Solana transactions and displays decoded instruction data.
+ * Accepts base64-encoded transaction bytes.
+ */
+
+import { BaseComponent, defineComponent, h, css, fragment, type Child } from "../../lib/html";
+import { setParams } from "../../lib/router";
+import { commonStyles } from "../../index";
+import {
+  parseTransaction,
+  type ParsedTransaction,
+  type InstructionParams,
+} from "@bitgo/wasm-solana";
+
+/**
+ * Decode base64 to Uint8Array
+ */
+function base64ToBytes(base64: string): Uint8Array {
+  const binaryString = atob(base64);
+  const bytes = new Uint8Array(binaryString.length);
+  for (let i = 0; i < binaryString.length; i++) {
+    bytes[i] = binaryString.charCodeAt(i);
+  }
+  return bytes;
+}
+
+/**
+ * Copy text to clipboard and show feedback.
+ */
+async function copyToClipboard(text: string, button: HTMLElement): Promise<void> {
+  try {
+    await navigator.clipboard.writeText(text);
+    const original = button.textContent;
+    button.textContent = "Copied!";
+    setTimeout(() => {
+      button.textContent = original;
+    }, 1500);
+  } catch (e) {
+    console.error("Failed to copy:", e);
+  }
+}
+
+/**
+ * Format instruction type for display
+ */
+function formatInstructionType(type: string): string {
+  // Add spaces before capital letters for readability
+  return type.replace(/([A-Z])/g, " $1").trim();
+}
+
+/**
+ * Get instruction type color
+ */
+function getTypeColor(type: string): string {
+  const colors: Record<string, string> = {
+    Transfer: "var(--green)",
+    NonceAdvance: "var(--purple)",
+    Memo: "var(--yellow)",
+    TokenTransfer: "var(--sky-blue)",
+    CreateAccount: "var(--teal)",
+    StakingActivate: "var(--orange)",
+    StakingDeactivate: "var(--orange)",
+    StakingWithdraw: "var(--orange)",
+    StakingDelegate: "var(--orange)",
+    StakingAuthorize: "var(--orange)",
+    SetComputeUnitLimit: "var(--lavender)",
+    SetPriorityFee: "var(--lavender)",
+    CreateAssociatedTokenAccount: "var(--teal)",
+    CloseAssociatedTokenAccount: "var(--red)",
+    Unknown: "var(--muted)",
+  };
+  return colors[type] || "var(--fg)";
+}
+
+/**
+ * Solana Transaction Parser Web Component
+ */
+class SolanaTransactionParser extends BaseComponent {
+  private debounceTimer: number | null = null;
+
+  render() {
+    return fragment(
+      css(`
+        ${commonStyles}
+
+        .parser {
+          max-width: 1000px;
+        }
+
+        .input-section {
+          margin-bottom: 2rem;
+        }
+
+        .input-row {
+          display: flex;
+          gap: 0.5rem;
+        }
+
+        textarea {
+          flex: 1;
+          font-family: inherit;
+          font-size: 0.875rem;
+          padding: 0.75rem 1rem;
+          background: var(--surface, #161b22);
+          border: 1px solid var(--border, #30363d);
+          border-radius: 6px;
+          color: var(--fg, #c9d1d9);
+          resize: vertical;
+          min-height: 80px;
+        }
+
+        textarea:focus {
+          outline: none;
+          border-color: var(--accent, #58a6ff);
+        }
+
+        textarea::placeholder {
+          color: var(--muted, #8b949e);
+        }
+
+        .btn {
+          padding: 0.75rem 1rem;
+          font-family: inherit;
+          font-size: 0.875rem;
+          background: var(--surface, #161b22);
+          border: 1px solid var(--border, #30363d);
+          border-radius: 6px;
+          color: var(--fg, #c9d1d9);
+          cursor: pointer;
+          transition: border-color 0.15s, background 0.15s;
+          white-space: nowrap;
+        }
+
+        .btn:hover {
+          border-color: var(--accent, #58a6ff);
+          background: var(--surface-hover, #1c2128);
+        }
+
+        .error-message {
+          padding: 1rem;
+          background: rgba(248, 81, 73, 0.1);
+          border: 1px solid rgba(248, 81, 73, 0.4);
+          border-radius: 6px;
+          color: #f85149;
+          margin-bottom: 2rem;
+        }
+
+        .tx-info {
+          margin-bottom: 2rem;
+          padding: 1rem;
+          background: var(--surface, #161b22);
+          border: 1px solid var(--border, #30363d);
+          border-radius: 6px;
+        }
+
+        .tx-info-grid {
+          display: grid;
+          grid-template-columns: 140px 1fr;
+          gap: 0.5rem 1rem;
+        }
+
+        .tx-info-label {
+          font-size: 0.8125rem;
+          color: var(--muted, #8b949e);
+        }
+
+        .tx-info-value {
+          font-size: 0.8125rem;
+          word-break: break-all;
+          color: var(--fg, #c9d1d9);
+        }
+
+        .tx-info-value.mono {
+          font-family: var(--mono);
+        }
+
+        .instructions-section h2 {
+          font-size: 1rem;
+          margin-bottom: 1rem;
+          color: var(--muted, #8b949e);
+        }
+
+        .instruction-card {
+          margin-bottom: 1rem;
+          padding: 1rem;
+          background: var(--surface, #161b22);
+          border: 1px solid var(--border, #30363d);
+          border-radius: 6px;
+        }
+
+        .instruction-header {
+          display: flex;
+          align-items: center;
+          gap: 0.75rem;
+          margin-bottom: 0.75rem;
+        }
+
+        .instruction-index {
+          font-size: 0.75rem;
+          padding: 0.125rem 0.5rem;
+          background: var(--border, #30363d);
+          border-radius: 4px;
+          color: var(--muted, #8b949e);
+        }
+
+        .instruction-type {
+          font-weight: 500;
+          font-size: 0.9375rem;
+        }
+
+        .instruction-params {
+          display: grid;
+          grid-template-columns: 140px 1fr;
+          gap: 0.25rem 1rem;
+          font-size: 0.8125rem;
+        }
+
+        .param-name {
+          color: var(--muted, #8b949e);
+        }
+
+        .param-value {
+          word-break: break-all;
+          color: var(--fg, #c9d1d9);
+        }
+
+        .copy-btn {
+          padding: 0.25rem 0.5rem;
+          font-size: 0.75rem;
+          background: transparent;
+          border: 1px solid var(--border, #30363d);
+          border-radius: 4px;
+          color: var(--muted, #8b949e);
+          cursor: pointer;
+          transition: all 0.15s;
+          margin-left: 0.5rem;
+        }
+
+        .copy-btn:hover {
+          border-color: var(--accent, #58a6ff);
+          color: var(--accent, #58a6ff);
+        }
+
+        .empty-state {
+          text-align: center;
+          padding: 3rem 1rem;
+          color: var(--muted, #8b949e);
+        }
+
+        .empty-state p {
+          margin: 0;
+        }
+
+        .durable-nonce-badge {
+          font-size: 0.75rem;
+          padding: 0.125rem 0.5rem;
+          background: var(--purple);
+          color: var(--bg);
+          border-radius: 4px;
+        }
+
+        .account-keys-section {
+          margin-bottom: 2rem;
+        }
+
+        .account-keys-section h2 {
+          font-size: 1rem;
+          margin-bottom: 1rem;
+          color: var(--muted, #8b949e);
+        }
+
+        .account-keys-list {
+          padding: 1rem;
+          background: var(--surface, #161b22);
+          border: 1px solid var(--border, #30363d);
+          border-radius: 6px;
+        }
+
+        .account-key-item {
+          display: flex;
+          align-items: center;
+          gap: 0.75rem;
+          padding: 0.375rem 0;
+          font-size: 0.8125rem;
+        }
+
+        .account-key-item:not(:last-child) {
+          border-bottom: 1px solid var(--border, #30363d);
+        }
+
+        .account-key-index {
+          font-size: 0.75rem;
+          padding: 0.125rem 0.5rem;
+          background: var(--border, #30363d);
+          border-radius: 4px;
+          color: var(--muted, #8b949e);
+          min-width: 2rem;
+          text-align: center;
+        }
+
+        .account-key-address {
+          font-family: var(--mono);
+          word-break: break-all;
+          color: var(--fg, #c9d1d9);
+        }
+
+        .account-key-item.fee-payer .account-key-address {
+          color: var(--green);
+        }
+
+        .account-key-badge {
+          font-size: 0.625rem;
+          padding: 0.125rem 0.375rem;
+          border-radius: 3px;
+          text-transform: uppercase;
+          font-weight: 500;
+        }
+
+        .account-key-badge.fee-payer {
+          background: var(--green);
+          color: var(--bg);
+        }
+
+        @media (max-width: 768px) {
+          .tx-info-grid,
+          .instruction-params {
+            grid-template-columns: 1fr;
+            gap: 0.125rem;
+          }
+
+          .tx-info-label,
+          .param-name {
+            font-weight: 500;
+          }
+        }
+      `),
+      h(
+        "div",
+        { class: "parser" },
+        h(
+          "nav",
+          { class: "breadcrumb" },
+          h("a", { href: "#/" }, "Home"),
+          " / ",
+          h("span", {}, "Solana Transaction Parser"),
+        ),
+        h("h1", {}, "Solana Transaction Parser"),
+        h(
+          "section",
+          { class: "input-section" },
+          h(
+            "div",
+            { class: "input-row" },
+            h("textarea", {
+              id: "tx-input",
+              placeholder: "Paste a base64-encoded Solana transaction...",
+              rows: "3",
+              oninput: (e: Event) => this.handleInput(e),
+            }),
+            h(
+              "button",
+              {
+                class: "btn",
+                onclick: () => this.share(),
+              },
+              "Share",
+            ),
+            h(
+              "button",
+              {
+                class: "btn",
+                onclick: () => this.clear(),
+              },
+              "Clear",
+            ),
+          ),
+        ),
+        h("div", { id: "error-message" }),
+        h("div", { id: "tx-info" }),
+        h("div", { id: "account-keys" }),
+        h(
+          "div",
+          { id: "results" },
+          h(
+            "div",
+            { class: "empty-state" },
+            h("p", {}, "Enter a base64-encoded Solana transaction above to parse it"),
+          ),
+        ),
+      ),
+    );
+  }
+
+  onParamsChange(params: URLSearchParams): void {
+    const data = params.get("data");
+    const input = this.$<HTMLTextAreaElement>("#tx-input");
+
+    if (input && data) {
+      // URL decode the data parameter
+      const decoded = decodeURIComponent(data);
+      input.value = decoded;
+      this.parse(decoded);
+    } else if (input && !data) {
+      input.value = "";
+      this.showEmpty();
+    }
+  }
+
+  private handleInput(e: Event): void {
+    const value = (e.target as HTMLTextAreaElement).value.trim();
+
+    // Debounce URL updates
+    if (this.debounceTimer) {
+      clearTimeout(this.debounceTimer);
+    }
+
+    this.debounceTimer = window.setTimeout(() => {
+      setParams({ data: value ? encodeURIComponent(value) : "" });
+    }, 300);
+
+    // Update results immediately
+    if (value) {
+      this.parse(value);
+    } else {
+      this.showEmpty();
+    }
+  }
+
+  private parse(txData: string): void {
+    const errorEl = this.$("#error-message");
+    const txInfoEl = this.$("#tx-info");
+    const accountKeysEl = this.$("#account-keys");
+    const resultsEl = this.$("#results");
+
+    if (!errorEl || !txInfoEl || !accountKeysEl || !resultsEl) return;
+
+    // Clear previous state
+    errorEl.innerHTML = "";
+    txInfoEl.innerHTML = "";
+    accountKeysEl.innerHTML = "";
+
+    try {
+      // Parse the transaction
+      const bytes = base64ToBytes(txData);
+      const parsed = parseTransaction(bytes);
+
+      // Render transaction info
+      txInfoEl.replaceChildren(this.renderTxInfo(parsed));
+
+      // Render account keys
+      accountKeysEl.replaceChildren(this.renderAccountKeys(parsed));
+
+      // Render instructions
+      resultsEl.replaceChildren(
+        h(
+          "section",
+          { class: "instructions-section" },
+          h("h2", {}, `Instructions (${parsed.instructionsData.length})`),
+          ...parsed.instructionsData.map((instr, idx) => this.renderInstruction(instr, idx)),
+        ),
+      );
+    } catch (e) {
+      errorEl.replaceChildren(
+        h("div", { class: "error-message" }, `Failed to parse transaction: ${String(e)}`),
+      );
+      resultsEl.replaceChildren(
+        h(
+          "div",
+          { class: "empty-state" },
+          h("p", {}, "Enter a valid Solana transaction to see parsed data"),
+        ),
+      );
+    }
+  }
+
+  private renderTxInfo(parsed: ParsedTransaction): HTMLElement {
+    const children: Child[] = [
+      h("span", { class: "tx-info-label" }, "Fee Payer"),
+      h("span", { class: "tx-info-value mono" }, parsed.feePayer),
+      h("span", { class: "tx-info-label" }, "Blockhash/Nonce"),
+      h("span", { class: "tx-info-value mono" }, parsed.nonce),
+      h("span", { class: "tx-info-label" }, "Signatures"),
+      h("span", { class: "tx-info-value" }, String(parsed.numSignatures)),
+    ];
+
+    if (parsed.durableNonce) {
+      children.push(
+        h("span", { class: "tx-info-label" }, "Durable Nonce"),
+        h("span", { class: "tx-info-value" }, h("span", { class: "durable-nonce-badge" }, "Yes")),
+        h("span", { class: "tx-info-label" }, "Nonce Account"),
+        h("span", { class: "tx-info-value mono" }, parsed.durableNonce.walletNonceAddress),
+        h("span", { class: "tx-info-label" }, "Nonce Authority"),
+        h("span", { class: "tx-info-value mono" }, parsed.durableNonce.authWalletAddress),
+      );
+    }
+
+    return h("div", { class: "tx-info" }, h("div", { class: "tx-info-grid" }, ...children));
+  }
+
+  private renderAccountKeys(parsed: ParsedTransaction): HTMLElement {
+    const feePayer = parsed.feePayer;
+
+    return h(
+      "section",
+      { class: "account-keys-section" },
+      h("h2", {}, `Account Keys (${parsed.accountKeys.length})`),
+      h(
+        "div",
+        { class: "account-keys-list" },
+        ...parsed.accountKeys.map((key, idx) => {
+          const isFeePayer = key === feePayer;
+          return h(
+            "div",
+            { class: `account-key-item${isFeePayer ? " fee-payer" : ""}` },
+            h("span", { class: "account-key-index" }, String(idx)),
+            h("span", { class: "account-key-address" }, key),
+            isFeePayer ? h("span", { class: "account-key-badge fee-payer" }, "Fee Payer") : null,
+          );
+        }),
+      ),
+    );
+  }
+
+  private renderInstruction(instr: InstructionParams, index: number): HTMLElement {
+    const type = instr.type;
+    const typeColor = getTypeColor(type);
+
+    // Extract params (everything except 'type')
+    const params = Object.entries(instr).filter(([key]) => key !== "type");
+
+    return h(
+      "div",
+      { class: "instruction-card" },
+      h(
+        "div",
+        { class: "instruction-header" },
+        h("span", { class: "instruction-index" }, `#${index}`),
+        h(
+          "span",
+          { class: "instruction-type", style: `color: ${typeColor}` },
+          formatInstructionType(type),
+        ),
+      ),
+      params.length > 0
+        ? h(
+            "div",
+            { class: "instruction-params" },
+            ...params.flatMap(([key, value]) => [
+              h("span", { class: "param-name" }, key),
+              h("span", { class: "param-value" }, this.formatParamValue(value)),
+            ]),
+          )
+        : null,
+    );
+  }
+
+  private formatParamValue(value: unknown): string {
+    if (typeof value === "string") {
+      return value;
+    }
+    if (typeof value === "number" || typeof value === "bigint") {
+      return String(value);
+    }
+    if (Array.isArray(value)) {
+      return JSON.stringify(value);
+    }
+    if (value && typeof value === "object") {
+      return JSON.stringify(value);
+    }
+    return String(value);
+  }
+
+  private showEmpty(): void {
+    const errorEl = this.$("#error-message");
+    const txInfoEl = this.$("#tx-info");
+    const accountKeysEl = this.$("#account-keys");
+    const resultsEl = this.$("#results");
+
+    if (errorEl) errorEl.innerHTML = "";
+    if (txInfoEl) txInfoEl.innerHTML = "";
+    if (accountKeysEl) accountKeysEl.innerHTML = "";
+    if (resultsEl) {
+      resultsEl.replaceChildren(
+        h(
+          "div",
+          { class: "empty-state" },
+          h("p", {}, "Enter a base64-encoded Solana transaction above to parse it"),
+        ),
+      );
+    }
+  }
+
+  private share(): void {
+    copyToClipboard(location.href, this.$(".btn")!);
+  }
+
+  private clear(): void {
+    const input = this.$<HTMLTextAreaElement>("#tx-input");
+    if (input) {
+      input.value = "";
+      setParams({ data: "" });
+      this.showEmpty();
+    }
+  }
+}
+
+defineComponent("solana-transaction-parser", SolanaTransactionParser);

--- a/packages/webui/tsconfig.json
+++ b/packages/webui/tsconfig.json
@@ -21,6 +21,9 @@
   "references": [
     {
       "path": "../wasm-utxo"
+    },
+    {
+      "path": "../wasm-solana"
     }
   ]
 }

--- a/packages/webui/webpack.config.js
+++ b/packages/webui/webpack.config.js
@@ -7,7 +7,12 @@ module.exports = {
     rules: [
       {
         test: /\.ts$/,
-        use: "ts-loader",
+        use: {
+          loader: "ts-loader",
+          options: {
+            projectReferences: true,
+          },
+        },
         exclude: /node_modules/,
       },
       {


### PR DESCRIPTION
Add interactive UI for parsing and inspecting Solana transactions:
- Accepts base64-encoded transactions (standard Solana wire format)
- Shows fee payer, blockhash, and signature count
- Detects and displays durable nonce information
- Decodes known instruction types with color-coded display
- Supports URL param sharing for easy transaction sharing

Issue: BTC-2929

Ticket: BTC-2929

<img width="1148" height="792" alt="Screenshot 2026-01-15 at 4 34 59 PM" src="https://github.com/user-attachments/assets/04087054-18d6-4354-9fd4-9d5a2a48fc60" />
