### PR TITLE
feat: add GitHub Pages deployment workflow

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -7,6 +7,10 @@ on:
         description: "Upload build artifacts"
         type: boolean
         default: false
+      upload-webui-artifact:
+        description: "Upload webui build artifact for pages deployment"
+        type: boolean
+        default: false
 
 env:
   RUST_TOOLCHAIN: nightly-2025-10-23
@@ -89,6 +93,12 @@ jobs:
             packages/wasm-solana/dist/
             packages/wasm-solana/js/wasm/
           retention-days: 1
+
+      - name: Upload webui artifact
+        if: inputs.upload-webui-artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: packages/webui/dist
 
   test:
     name: "Test ${{ matrix.package }}"

--- a/.github/workflows/deploy-pages.yaml
+++ b/.github/workflows/deploy-pages.yaml
@@ -1,0 +1,37 @@
+name: "Deploy to GitHub Pages"
+
+on:
+  push:
+    branches:
+      - gh-pages
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    uses: ./.github/workflows/build-and-test.yaml
+    with:
+      upload-webui-artifact: true
+
+  deploy:
+    name: "Deploy"
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION

Add a new workflow to automatically deploy webui to GitHub Pages
when pushing to the gh-pages branch. The workflow utilizes the existing
build-and-test workflow with a new flag to upload the webui artifact.

Issue: BTC-0