### PR TITLE
feat: remove private flag from wasm-bip32 and wasm-solana

### DIFF
--- a/packages/wasm-bip32/package.json
+++ b/packages/wasm-bip32/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@bitgo/wasm-bip32",
-  "private": true,
   "description": "Minimal WebAssembly BIP32/ECPair implementation with message signing",
   "version": "0.0.1",
   "type": "module",

--- a/packages/wasm-solana/package.json
+++ b/packages/wasm-solana/package.json
@@ -2,7 +2,6 @@
   "name": "@bitgo/wasm-solana",
   "description": "WebAssembly wrapper for Solana cryptographic operations",
   "version": "0.0.1",
-  "private": true,
   "type": "module",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Enable publishing of the BIP32 and Solana WASM packages to the registry

Ticket: BTC-0