### PR TITLE
feat(wasm-utxo): redesign PSBT signing API for clarity and performance

### DIFF
--- a/packages/wasm-utxo/.gitignore
+++ b/packages/wasm-utxo/.gitignore
@@ -8,3 +8,5 @@ js/*.js
 js/*.d.ts
 js/wasm
 .vscode
+.cursor
+test/benchmark/results/

--- a/packages/wasm-utxo/.mocharc.json
+++ b/packages/wasm-utxo/.mocharc.json
@@ -1,5 +1,6 @@
 {
   "extensions": ["ts", "tsx", "js", "jsx"],
   "spec": ["test/**/*.ts"],
+  "ignore": ["test/benchmark/**"],
   "node-option": ["import=tsx/esm", "experimental-wasm-modules"]
 }

--- a/packages/wasm-utxo/js/bip32.ts
+++ b/packages/wasm-utxo/js/bip32.ts
@@ -224,3 +224,21 @@ export class BIP32 implements BIP32Interface {
     return this._wasm;
   }
 }
+
+/**
+ * Type guard to check if a value is a BIP32Arg
+ *
+ * @param key - The value to check
+ * @returns true if the value is a BIP32Arg (string, BIP32, WasmBIP32, or BIP32Interface)
+ */
+export function isBIP32Arg(key: unknown): key is BIP32Arg {
+  return (
+    typeof key === "string" ||
+    key instanceof BIP32 ||
+    key instanceof WasmBIP32 ||
+    (typeof key === "object" &&
+      key !== null &&
+      "derive" in key &&
+      typeof (key as BIP32Interface).derive === "function")
+  );
+}

--- a/packages/wasm-utxo/package.json
+++ b/packages/wasm-utxo/package.json
@@ -35,6 +35,7 @@
   "scripts": {
     "test": "npm run test:mocha && npm run test:wasm-pack && npm run test:imports",
     "test:mocha": "mocha --recursive test",
+    "test:benchmark": "mocha test/benchmark/signing.ts --timeout 600000",
     "test:wasm-pack": "npm run test:wasm-pack-node && npm run test:wasm-pack-chrome",
     "test:wasm-pack-node": "./scripts/wasm-pack-test.sh --node",
     "test:wasm-pack-chrome": "./scripts/wasm-pack-test.sh --headless --chrome",

--- a/packages/wasm-utxo/test/benchmark/signing.ts
+++ b/packages/wasm-utxo/test/benchmark/signing.ts
@@ -1,0 +1,341 @@
+/**
+ * Signing Performance Benchmark
+ *
+ * Benchmarks PSBT signing performance for different script types and input counts.
+ * Tests both bulk signing (sign(key)) and per-input signing (signInput(i, key)).
+ *
+ * Script types tested:
+ * - p2sh (chain 0/1)
+ * - p2shP2wsh (chain 10/11)
+ * - p2wsh (chain 20/21)
+ * - p2tr script path (chain 30/31) - "p2trLegacy"
+ * - p2trMusig2 keypath (chain 40/41)
+ *
+ * Run: npx mocha test/benchmark/signing.ts --timeout 300000
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import { BIP32 } from "../../js/bip32.js";
+import { BitGoPsbt, RootWalletKeys, type NetworkName } from "../../js/fixedScriptWallet/index.js";
+import type { IWalletKeys } from "../../js/fixedScriptWallet/RootWalletKeys.js";
+import type { BIP32Interface } from "../../js/bip32.js";
+import type { SignPath } from "../../js/fixedScriptWallet/BitGoPsbt.js";
+
+type Triple<T> = [T, T, T];
+
+// Script type configuration
+type ScriptTypeConfig = {
+  name: string;
+  chain: number; // external chain
+  needsSignPath: boolean;
+  signPath?: SignPath;
+  isMuSig2KeyPath?: boolean;
+};
+
+const SCRIPT_TYPES: ScriptTypeConfig[] = [
+  { name: "p2sh", chain: 0, needsSignPath: false },
+  { name: "p2shP2wsh", chain: 10, needsSignPath: false },
+  { name: "p2wsh", chain: 20, needsSignPath: false },
+  {
+    name: "p2trLegacy",
+    chain: 30,
+    needsSignPath: true,
+    signPath: { signer: "user", cosigner: "bitgo" },
+  },
+  {
+    name: "p2trMusig2KeyPath",
+    chain: 40,
+    needsSignPath: true,
+    signPath: { signer: "user", cosigner: "bitgo" },
+    isMuSig2KeyPath: true,
+  },
+];
+
+const INPUT_COUNTS = [200, 500, 1000];
+
+// Fixed test wallet keys (deterministic for reproducibility)
+const TEST_SEED = Buffer.alloc(32, 0x42);
+
+function createTestWalletKeys(): { keys: RootWalletKeys; xprivs: Triple<BIP32> } {
+  // Create three deterministic keys from seeds
+  const seeds = [
+    Buffer.alloc(32, 0x01), // user
+    Buffer.alloc(32, 0x02), // backup
+    Buffer.alloc(32, 0x03), // bitgo
+  ];
+
+  const xprivs = seeds.map((seed) => BIP32.fromSeed(seed)) as Triple<BIP32>;
+  const xpubs = xprivs.map((k) => k.neutered()) as unknown as Triple<BIP32Interface>;
+
+  const walletKeysLike: IWalletKeys = {
+    triple: xpubs,
+    derivationPrefixes: ["0/0", "0/0", "0/0"],
+  };
+
+  return {
+    keys: RootWalletKeys.from(walletKeysLike),
+    xprivs,
+  };
+}
+
+function createPsbtWithInputs(
+  inputCount: number,
+  scriptType: ScriptTypeConfig,
+  walletKeys: RootWalletKeys,
+): BitGoPsbt {
+  const network: NetworkName = "bitcoin";
+
+  const psbt = BitGoPsbt.createEmpty(network, walletKeys, {
+    version: 2,
+    lockTime: 0,
+  });
+
+  // Add inputs
+  for (let i = 0; i < inputCount; i++) {
+    // Create a unique txid for each input (32 bytes hex = 64 chars)
+    const txidBytes = Buffer.alloc(32);
+    txidBytes.writeUInt32BE(i, 0);
+    const txid = txidBytes.toString("hex");
+
+    const inputOptions = {
+      txid,
+      vout: 0,
+      value: BigInt(100000), // 0.001 BTC per input
+      sequence: 0xfffffffe,
+    };
+
+    const walletOptions: {
+      scriptId: { chain: number; index: number };
+      signPath?: SignPath;
+    } = {
+      scriptId: { chain: scriptType.chain, index: i },
+    };
+
+    if (scriptType.needsSignPath && scriptType.signPath) {
+      walletOptions.signPath = scriptType.signPath;
+    }
+
+    psbt.addWalletInput(inputOptions, walletKeys, walletOptions);
+  }
+
+  // Add a single output (change)
+  const changeChain = scriptType.chain + 1; // internal chain
+  psbt.addWalletOutput(walletKeys, {
+    chain: changeChain,
+    index: 0,
+    value: BigInt(inputCount * 100000 - 10000), // total minus fee
+  });
+
+  return psbt;
+}
+
+type BenchmarkResult = {
+  scriptType: string;
+  inputCount: number;
+  bulkSignMs: number;
+  perInputSignMs: number;
+  bulkSignPerInputMs: number;
+  perInputSignPerInputMs: number;
+};
+
+async function benchmarkBulkSign(
+  psbt: BitGoPsbt,
+  walletKeys: RootWalletKeys,
+  xprivs: Triple<BIP32>,
+  scriptType: ScriptTypeConfig,
+): Promise<number> {
+  // Clone PSBT for this benchmark
+  const testPsbt = BitGoPsbt.fromBytes(psbt.serialize(), "bitcoin");
+
+  // For MuSig2, generate nonces first (not timed)
+  if (scriptType.isMuSig2KeyPath) {
+    testPsbt.generateMusig2Nonces(xprivs[0]); // user
+    testPsbt.generateMusig2Nonces(xprivs[2]); // bitgo
+  }
+
+  const start = performance.now();
+
+  // Sign with user key
+  testPsbt.sign(xprivs[0]);
+
+  // For MuSig2 keypath, we need to sign individual inputs after bulk
+  if (scriptType.isMuSig2KeyPath) {
+    const parsed = testPsbt.parseTransactionWithWalletKeys(walletKeys, { publicKeys: [] });
+    for (let i = 0; i < parsed.inputs.length; i++) {
+      if (parsed.inputs[i].scriptType === "p2trMusig2KeyPath") {
+        testPsbt.signInput(i, xprivs[0]);
+      }
+    }
+  }
+
+  // Sign with bitgo key (second signer for 2-of-3)
+  testPsbt.sign(xprivs[2]);
+
+  if (scriptType.isMuSig2KeyPath) {
+    const parsed = testPsbt.parseTransactionWithWalletKeys(walletKeys, { publicKeys: [] });
+    for (let i = 0; i < parsed.inputs.length; i++) {
+      if (parsed.inputs[i].scriptType === "p2trMusig2KeyPath") {
+        testPsbt.signInput(i, xprivs[2]);
+      }
+    }
+  }
+
+  const end = performance.now();
+  return end - start;
+}
+
+async function benchmarkPerInputSign(
+  psbt: BitGoPsbt,
+  walletKeys: RootWalletKeys,
+  xprivs: Triple<BIP32>,
+  scriptType: ScriptTypeConfig,
+): Promise<number> {
+  // Clone PSBT for this benchmark
+  const testPsbt = BitGoPsbt.fromBytes(psbt.serialize(), "bitcoin");
+
+  const parsed = testPsbt.parseTransactionWithWalletKeys(walletKeys, { publicKeys: [] });
+
+  // For MuSig2, generate nonces first (not timed)
+  if (scriptType.isMuSig2KeyPath) {
+    testPsbt.generateMusig2Nonces(xprivs[0]); // user
+    testPsbt.generateMusig2Nonces(xprivs[2]); // bitgo
+  }
+
+  const start = performance.now();
+
+  // Sign each input individually with user key
+  for (let i = 0; i < parsed.inputs.length; i++) {
+    testPsbt.signInput(i, xprivs[0]);
+  }
+
+  // Sign each input individually with bitgo key
+  for (let i = 0; i < parsed.inputs.length; i++) {
+    testPsbt.signInput(i, xprivs[2]);
+  }
+
+  const end = performance.now();
+  return end - start;
+}
+
+async function runBenchmark(
+  scriptType: ScriptTypeConfig,
+  inputCount: number,
+  walletKeys: RootWalletKeys,
+  xprivs: Triple<BIP32>,
+): Promise<BenchmarkResult> {
+  // Create PSBT
+  const psbt = createPsbtWithInputs(inputCount, scriptType, walletKeys);
+
+  // Run bulk sign benchmark
+  const bulkSignMs = await benchmarkBulkSign(psbt, walletKeys, xprivs, scriptType);
+
+  // Run per-input sign benchmark
+  const perInputSignMs = await benchmarkPerInputSign(psbt, walletKeys, xprivs, scriptType);
+
+  return {
+    scriptType: scriptType.name,
+    inputCount,
+    bulkSignMs,
+    perInputSignMs,
+    bulkSignPerInputMs: bulkSignMs / inputCount,
+    perInputSignPerInputMs: perInputSignMs / inputCount,
+  };
+}
+
+function formatResults(results: BenchmarkResult[]): string {
+  const lines: string[] = [];
+
+  lines.push("=".repeat(100));
+  lines.push("SIGNING BENCHMARK RESULTS");
+  lines.push("=".repeat(100));
+  lines.push("");
+
+  // Group by script type
+  const byScriptType = new Map<string, BenchmarkResult[]>();
+  for (const r of results) {
+    const existing = byScriptType.get(r.scriptType) ?? [];
+    existing.push(r);
+    byScriptType.set(r.scriptType, existing);
+  }
+
+  for (const [scriptType, scriptResults] of byScriptType) {
+    lines.push(`\n${scriptType.toUpperCase()}`);
+    lines.push("-".repeat(100));
+    lines.push(
+      "| Inputs | Bulk (ms) | Per-Input (ms) | Bulk/Input (ms) | PerInput/Input (ms) | Ratio |",
+    );
+    lines.push(
+      "|--------|-----------|----------------|-----------------|---------------------|-------|",
+    );
+
+    for (const r of scriptResults) {
+      const ratio = (r.perInputSignMs / r.bulkSignMs).toFixed(2);
+      lines.push(
+        `| ${r.inputCount.toString().padStart(6)} | ${r.bulkSignMs.toFixed(1).padStart(9)} | ${r.perInputSignMs.toFixed(1).padStart(14)} | ${r.bulkSignPerInputMs.toFixed(3).padStart(15)} | ${r.perInputSignPerInputMs.toFixed(3).padStart(19)} | ${ratio.padStart(5)}x |`,
+      );
+    }
+  }
+
+  lines.push("");
+  lines.push("=".repeat(100));
+
+  // JSON output for easy comparison
+  lines.push("\nJSON Results (for automated comparison):");
+  lines.push(JSON.stringify(results, null, 2));
+
+  return lines.join("\n");
+}
+
+describe("Signing Benchmark", function () {
+  // Increase timeout for benchmarks
+  this.timeout(300000); // 5 minutes
+
+  let walletKeys: RootWalletKeys;
+  let xprivs: Triple<BIP32>;
+  const allResults: BenchmarkResult[] = [];
+
+  before(function () {
+    const testKeys = createTestWalletKeys();
+    walletKeys = testKeys.keys;
+    xprivs = testKeys.xprivs;
+  });
+
+  for (const scriptType of SCRIPT_TYPES) {
+    describe(`${scriptType.name}`, function () {
+      for (const inputCount of INPUT_COUNTS) {
+        it(`should benchmark ${inputCount} inputs`, async function () {
+          console.log(`\nBenchmarking ${scriptType.name} with ${inputCount} inputs...`);
+
+          const result = await runBenchmark(scriptType, inputCount, walletKeys, xprivs);
+          allResults.push(result);
+
+          console.log(`  Bulk sign: ${result.bulkSignMs.toFixed(1)}ms`);
+          console.log(`  Per-input sign: ${result.perInputSignMs.toFixed(1)}ms`);
+          console.log(
+            `  Ratio (per-input/bulk): ${(result.perInputSignMs / result.bulkSignMs).toFixed(2)}x`,
+          );
+        });
+      }
+    });
+  }
+
+  after(function () {
+    const output = formatResults(allResults);
+    console.log("\n" + output);
+
+    // Write results to file
+    const __filename = fileURLToPath(import.meta.url);
+    const __dirname = path.dirname(__filename);
+    const resultsDir = path.join(__dirname, "results");
+    if (!fs.existsSync(resultsDir)) {
+      fs.mkdirSync(resultsDir, { recursive: true });
+    }
+
+    const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+    const resultsFile = path.join(resultsDir, `benchmark-${timestamp}.txt`);
+    fs.writeFileSync(resultsFile, output);
+    console.log(`\nResults written to: ${resultsFile}`);
+  });
+});

--- a/packages/wasm-utxo/test/fixedScript/singleInputSigning.ts
+++ b/packages/wasm-utxo/test/fixedScript/singleInputSigning.ts
@@ -1,0 +1,334 @@
+/**
+ * Tests for single-input signing behavior
+ *
+ * Verifies that signInput() truly only signs the specified input and
+ * does not add signatures to other inputs.
+ */
+
+import assert from "node:assert";
+import { BIP32 } from "../../js/bip32.js";
+import { BitGoPsbt, RootWalletKeys } from "../../js/fixedScriptWallet/index.js";
+import type { BIP32Interface } from "../../js/bip32.js";
+import type { IWalletKeys } from "../../js/fixedScriptWallet/RootWalletKeys.js";
+import type { NetworkName } from "../../js/fixedScriptWallet/BitGoPsbt.js";
+
+type Triple<T> = [T, T, T];
+
+function createTestWalletKeys(): { keys: RootWalletKeys; xprivs: Triple<BIP32> } {
+  const seeds = [
+    Buffer.alloc(32, 0x01), // user
+    Buffer.alloc(32, 0x02), // backup
+    Buffer.alloc(32, 0x03), // bitgo
+  ];
+
+  const xprivs = seeds.map((seed) => BIP32.fromSeed(seed)) as Triple<BIP32>;
+  const xpubs = xprivs.map((k) => k.neutered()) as unknown as Triple<BIP32Interface>;
+
+  const walletKeysLike: IWalletKeys = {
+    triple: xpubs,
+    derivationPrefixes: ["0/0", "0/0", "0/0"],
+  };
+
+  return {
+    keys: RootWalletKeys.from(walletKeysLike),
+    xprivs,
+  };
+}
+
+type SignPath = { signer: "user" | "backup" | "bitgo"; cosigner: "user" | "backup" | "bitgo" };
+
+function createPsbtWithInputs(
+  inputCount: number,
+  chain: number,
+  walletKeys: RootWalletKeys,
+  signPath?: SignPath,
+): BitGoPsbt {
+  const network: NetworkName = "bitcoin";
+
+  const psbt = BitGoPsbt.createEmpty(network, walletKeys, {
+    version: 2,
+    lockTime: 0,
+  });
+
+  for (let i = 0; i < inputCount; i++) {
+    const txidBytes = Buffer.alloc(32);
+    txidBytes.writeUInt32BE(i, 0);
+    const txid = txidBytes.toString("hex");
+
+    const walletOptions: { scriptId: { chain: number; index: number }; signPath?: SignPath } = {
+      scriptId: { chain, index: i },
+    };
+
+    // p2tr and p2trMusig2 require signPath
+    if (signPath) {
+      walletOptions.signPath = signPath;
+    }
+
+    psbt.addWalletInput(
+      {
+        txid,
+        vout: 0,
+        value: BigInt(100000),
+        sequence: 0xfffffffe,
+      },
+      walletKeys,
+      walletOptions,
+    );
+  }
+
+  // Add output
+  psbt.addWalletOutput(walletKeys, {
+    chain: chain + 1,
+    index: 0,
+    value: BigInt(inputCount * 100000 - 10000),
+  });
+
+  return psbt;
+}
+
+/**
+ * Count signatures on a specific input by checking each key
+ */
+function countInputSignatures(psbt: BitGoPsbt, inputIndex: number, xprivs: Triple<BIP32>): number {
+  let count = 0;
+  for (const xpriv of xprivs) {
+    if (psbt.verifySignature(inputIndex, xpriv.neutered())) {
+      count++;
+    }
+  }
+  return count;
+}
+
+/**
+ * Check if any input other than the specified one has signatures from any key
+ */
+function hasSignaturesOnOtherInputs(
+  psbt: BitGoPsbt,
+  inputCount: number,
+  excludeIndex: number,
+  xprivs: Triple<BIP32>,
+): boolean {
+  for (let i = 0; i < inputCount; i++) {
+    if (i === excludeIndex) continue;
+
+    for (const xpriv of xprivs) {
+      if (psbt.verifySignature(i, xpriv.neutered())) {
+        return true;
+      }
+    }
+  }
+
+  return false;
+}
+
+describe("Single-input signing", function () {
+  let walletKeys: RootWalletKeys;
+  let xprivs: Triple<BIP32>;
+
+  before(function () {
+    const testKeys = createTestWalletKeys();
+    walletKeys = testKeys.keys;
+    xprivs = testKeys.xprivs;
+  });
+
+  describe("p2sh (ECDSA)", function () {
+    it("should sign only the specified input, not others", function () {
+      const psbt = createPsbtWithInputs(5, 0, walletKeys); // chain 0 = p2sh
+
+      // Sign only input 2 with user key
+      psbt.signInput(2, xprivs[0]);
+
+      // Verify input 2 has a signature from user
+      assert.strictEqual(
+        psbt.verifySignature(2, xprivs[0].neutered()),
+        true,
+        "Input 2 should have user signature",
+      );
+
+      // Verify no other inputs have signatures
+      assert.strictEqual(
+        hasSignaturesOnOtherInputs(psbt, 5, 2, xprivs),
+        false,
+        "Other inputs should not have signatures",
+      );
+    });
+
+    it("should allow signing different inputs with different keys", function () {
+      const psbt = createPsbtWithInputs(5, 0, walletKeys);
+
+      // Sign input 1 with user key
+      psbt.signInput(1, xprivs[0]);
+
+      // Sign input 3 with bitgo key
+      psbt.signInput(3, xprivs[2]);
+
+      // Verify input 1 has user's signature only
+      assert.strictEqual(
+        psbt.verifySignature(1, xprivs[0].neutered()),
+        true,
+        "Input 1 should have user sig",
+      );
+      assert.strictEqual(
+        psbt.verifySignature(1, xprivs[2].neutered()),
+        false,
+        "Input 1 should not have bitgo sig",
+      );
+
+      // Verify input 3 has bitgo's signature only
+      assert.strictEqual(
+        psbt.verifySignature(3, xprivs[2].neutered()),
+        true,
+        "Input 3 should have bitgo sig",
+      );
+      assert.strictEqual(
+        psbt.verifySignature(3, xprivs[0].neutered()),
+        false,
+        "Input 3 should not have user sig",
+      );
+
+      // Verify inputs 0, 2, 4 have no signatures
+      assert.strictEqual(countInputSignatures(psbt, 0, xprivs), 0, "Input 0 should have no sigs");
+      assert.strictEqual(countInputSignatures(psbt, 2, xprivs), 0, "Input 2 should have no sigs");
+      assert.strictEqual(countInputSignatures(psbt, 4, xprivs), 0, "Input 4 should have no sigs");
+    });
+
+    it("should allow completing a single input with both signers", function () {
+      const psbt = createPsbtWithInputs(5, 0, walletKeys);
+
+      // Sign input 2 with user key
+      psbt.signInput(2, xprivs[0]);
+
+      // Sign input 2 with bitgo key
+      psbt.signInput(2, xprivs[2]);
+
+      // Verify input 2 has 2 signatures (user + bitgo)
+      assert.strictEqual(
+        countInputSignatures(psbt, 2, xprivs),
+        2,
+        "Input 2 should have 2 signatures",
+      );
+
+      // Verify no other inputs have signatures
+      assert.strictEqual(
+        hasSignaturesOnOtherInputs(psbt, 5, 2, xprivs),
+        false,
+        "Other inputs should not have signatures",
+      );
+    });
+  });
+
+  describe("p2wsh (SegWit ECDSA)", function () {
+    it("should sign only the specified input, not others", function () {
+      const psbt = createPsbtWithInputs(5, 20, walletKeys); // chain 20 = p2wsh
+
+      // Sign only input 0 with user key
+      psbt.signInput(0, xprivs[0]);
+
+      // Verify input 0 has a signature
+      assert.strictEqual(
+        psbt.verifySignature(0, xprivs[0].neutered()),
+        true,
+        "Input 0 should have signature",
+      );
+
+      // Verify no other inputs have signatures
+      assert.strictEqual(
+        hasSignaturesOnOtherInputs(psbt, 5, 0, xprivs),
+        false,
+        "Other inputs should not have signatures",
+      );
+    });
+  });
+
+  describe("p2trMusig2KeyPath (MuSig2)", function () {
+    it("should sign only the specified input, not others", function () {
+      // chain 40 = p2trMusig2, requires signPath with signer and cosigner
+      const psbt = createPsbtWithInputs(5, 40, walletKeys, { signer: "user", cosigner: "bitgo" });
+
+      // Generate nonces for all inputs (required for MuSig2)
+      psbt.generateMusig2Nonces(xprivs[0]);
+      psbt.generateMusig2Nonces(xprivs[2]);
+
+      // Sign only input 1 with user key
+      psbt.signInput(1, xprivs[0]);
+
+      // Verify input 1 has a partial signature from user
+      assert.strictEqual(
+        psbt.verifySignature(1, xprivs[0].neutered()),
+        true,
+        "Input 1 should have user signature",
+      );
+
+      // Verify no other inputs have signatures
+      assert.strictEqual(
+        hasSignaturesOnOtherInputs(psbt, 5, 1, xprivs),
+        false,
+        "Other inputs should not have signatures",
+      );
+    });
+
+    it("should allow completing a single input with both signers", function () {
+      const psbt = createPsbtWithInputs(5, 40, walletKeys, { signer: "user", cosigner: "bitgo" });
+
+      // Generate nonces
+      psbt.generateMusig2Nonces(xprivs[0]);
+      psbt.generateMusig2Nonces(xprivs[2]);
+
+      // Sign input 3 with user key
+      psbt.signInput(3, xprivs[0]);
+
+      // Sign input 3 with bitgo key
+      psbt.signInput(3, xprivs[2]);
+
+      // Verify input 3 has 2 partial signatures
+      assert.strictEqual(
+        countInputSignatures(psbt, 3, xprivs),
+        2,
+        "Input 3 should have 2 signatures",
+      );
+
+      // Verify no other inputs have signatures
+      assert.strictEqual(
+        hasSignaturesOnOtherInputs(psbt, 5, 3, xprivs),
+        false,
+        "Other inputs should not have signatures",
+      );
+    });
+  });
+
+  describe("bulk vs single-input comparison", function () {
+    it("bulk sign should sign all inputs, single-input should sign one", function () {
+      // Create two identical PSBTs
+      const psbtBulk = createPsbtWithInputs(5, 0, walletKeys);
+      const psbtSingle = createPsbtWithInputs(5, 0, walletKeys);
+
+      // Bulk sign all inputs
+      const bulkSigned = psbtBulk.sign(xprivs[0]);
+      assert.strictEqual(bulkSigned.length, 5, "Bulk sign should sign all 5 inputs");
+
+      // Verify all inputs have signatures
+      for (let i = 0; i < 5; i++) {
+        assert.strictEqual(
+          psbtBulk.verifySignature(i, xprivs[0].neutered()),
+          true,
+          `Bulk: Input ${i} should have signature`,
+        );
+      }
+
+      // Single-input sign only input 2
+      psbtSingle.signInput(2, xprivs[0]);
+
+      // Verify only input 2 has a signature
+      assert.strictEqual(
+        psbtSingle.verifySignature(2, xprivs[0].neutered()),
+        true,
+        "Single: Input 2 should have signature",
+      );
+      assert.strictEqual(
+        hasSignaturesOnOtherInputs(psbtSingle, 5, 2, xprivs),
+        false,
+        "Single: Other inputs should not have signatures",
+      );
+    });
+  });
+});


### PR DESCRIPTION

This PR introduces a comprehensive redesign of the PSBT signing API to improve
clarity and performance, along with benchmarking tools to measure the impact.

### Changes

- Redesigned WASM/Rust API that explicitly communicates method behavior and 
  performance implications
- Implemented efficient bulk signing for MuSig2 inputs with SighashCache reuse, 
  resulting in 2x performance improvement
- Added clear type-specific signing methods to replace the misleading API
- Created comprehensive benchmarking for PSBT signing across different script
  types and input counts

### New WASM API (backward compatible)

- `is_musig2_input(index)` - Check if input is MuSig2 keypath
- `sign_all_wallet_inputs(xpriv)` - Bulk sign ECDSA/Schnorr script path
- `sign_wallet_input(index, xpriv)` - Single input with save/restore
- `sign_musig2_input(index, xpriv)` - Single MuSig2 input
- `sign_all_musig2_inputs(xpriv)` - Bulk MuSig2 with SighashCache reuse
- `sign_replay_protection_inputs(ecpair)` - Bulk replay protection

### Performance Improvements

MuSig2 bulk signing now shows ~4.5ms per input (down from ~9.5ms), 
representing a 2x improvement by reusing the SighashCache.

BTC-2980