### PR TITLE
feat(wasm-utxo): export testutils module, fix testutils browser compat

### DIFF
--- a/packages/wasm-utxo/js/bip32.ts
+++ b/packages/wasm-utxo/js/bip32.ts
@@ -98,6 +98,18 @@ export class BIP32 implements BIP32Interface {
   }
 
   /**
+   * Create a BIP32 master key from a string by hashing it with SHA256.
+   * Useful for deterministic test key generation.
+   * @param seedString - The seed string to hash
+   * @param network - Optional network string
+   * @returns A BIP32 instance
+   */
+  static fromSeedSha256(seedString: string, network?: string | null): BIP32 {
+    const wasm = WasmBIP32.from_seed_sha256(seedString, network);
+    return new BIP32(wasm);
+  }
+
+  /**
    * Get the chain code as a Uint8Array
    */
   get chainCode(): Uint8Array {

--- a/packages/wasm-utxo/js/index.ts
+++ b/packages/wasm-utxo/js/index.ts
@@ -14,6 +14,7 @@ export * as utxolibCompat from "./utxolibCompat.js";
 export * as fixedScriptWallet from "./fixedScriptWallet/index.js";
 export * as bip32 from "./bip32.js";
 export * as ecpair from "./ecpair.js";
+export * as testutils from "./testutils/index.js";
 
 // Only the most commonly used classes and types are exported at the top level for convenience
 export { ECPair } from "./ecpair.js";

--- a/packages/wasm-utxo/js/testutils/keys.ts
+++ b/packages/wasm-utxo/js/testutils/keys.ts
@@ -1,4 +1,3 @@
-import * as crypto from "crypto";
 import { BIP32 } from "../bip32.js";
 import { RootWalletKeys } from "../fixedScriptWallet/RootWalletKeys.js";
 import type { Triple } from "../triple.js";
@@ -17,7 +16,7 @@ import type { Triple } from "../triple.js";
  * ```
  */
 export function getKey(seed: string): BIP32 {
-  return BIP32.fromSeed(crypto.createHash("sha256").update(seed).digest());
+  return BIP32.fromSeedSha256(seed);
 }
 
 /**

--- a/packages/wasm-utxo/src/wasm/bip32.rs
+++ b/packages/wasm-utxo/src/wasm/bip32.rs
@@ -210,6 +210,18 @@ impl WasmBIP32 {
         Ok(WasmBIP32(BIP32Key::Private(xpriv)))
     }
 
+    /// Create a BIP32 master key from a string by hashing it with SHA256.
+    /// This is useful for deterministic test key generation.
+    #[wasm_bindgen]
+    pub fn from_seed_sha256(
+        seed_string: &str,
+        network: Option<String>,
+    ) -> Result<WasmBIP32, WasmUtxoError> {
+        use crate::bitcoin::hashes::{sha256, Hash};
+        let hash = sha256::Hash::hash(seed_string.as_bytes());
+        Self::from_seed(&hash[..], network)
+    }
+
     /// Get the chain code as a Uint8Array
     #[wasm_bindgen(getter)]
     pub fn chain_code(&self) -> js_sys::Uint8Array {


### PR DESCRIPTION
## Summary

- Export testutils namespace from the main index.ts to make test utilities available to library consumers
- Add `BIP32.fromSeedSha256()` method for creating BIP32 keys from string seeds by hashing with SHA256, simplifying deterministic test key generation and eliminating the need for Node's crypto module in testutils

## Changes

### `fromSeedSha256` (Rust + TypeScript)
- New WASM method that takes a string, hashes it with SHA256, and creates a master BIP32 key
- Removes dependency on Node's `crypto` module from `js/testutils/keys.ts`

### testutils export
- Adds `testutils` namespace export to `js/index.ts`

## Test plan
- [x] All 925 mocha tests pass
- [x] New tests verify `fromSeedSha256` produces identical results to manual SHA256 + fromSeed approach
- [x] TypeScript compiles without errors

Issue: BTC-2980