### PR TITLE
feat(wasm-utxo): add hasPsbtMagic utility function

### DIFF
--- a/packages/wasm-utxo/js/index.ts
+++ b/packages/wasm-utxo/js/index.ts
@@ -68,3 +68,4 @@ export { WrapDescriptor as Descriptor } from "./wasm/wasm_utxo.js";
 export { WrapMiniscript as Miniscript } from "./wasm/wasm_utxo.js";
 export { WrapPsbt as Psbt } from "./wasm/wasm_utxo.js";
 export { DashTransaction, Transaction, ZcashTransaction } from "./transaction.js";
+export { hasPsbtMagic } from "./psbt.js";

--- a/packages/wasm-utxo/js/psbt.ts
+++ b/packages/wasm-utxo/js/psbt.ts
@@ -1,0 +1,32 @@
+/** PSBT magic bytes: "psbt" (0x70 0x73 0x62 0x74) followed by separator 0xff */
+const PSBT_MAGIC = new Uint8Array([0x70, 0x73, 0x62, 0x74, 0xff]);
+
+/**
+ * Check if a byte array has the PSBT magic bytes
+ *
+ * PSBTs start with the magic bytes "psbt" (0x70 0x73 0x62 0x74) followed by a separator 0xff.
+ * This method checks if the given bytes start with these 5 magic bytes.
+ *
+ * @param bytes - The byte array to check
+ * @returns true if the bytes start with PSBT magic, false otherwise
+ *
+ * @example
+ * ```typescript
+ * import { hasPsbtMagic } from "@bitgo/wasm-utxo";
+ *
+ * if (hasPsbtMagic(data)) {
+ *   const psbt = BitGoPsbt.fromBytes(data, network);
+ * }
+ * ```
+ */
+export function hasPsbtMagic(bytes: Uint8Array): boolean {
+  if (bytes.length < PSBT_MAGIC.length) {
+    return false;
+  }
+  for (let i = 0; i < PSBT_MAGIC.length; i++) {
+    if (bytes[i] !== PSBT_MAGIC[i]) {
+      return false;
+    }
+  }
+  return true;
+}


### PR DESCRIPTION

Creates a utility function to check if a byte array contains the PSBT magic
bytes header. Exports the function through the main package index.

Issue: BTC-2980