### PR TITLE
feat(wasm-solana): return Transaction types from builder functions

### DIFF
--- a/packages/wasm-solana/js/index.ts
+++ b/packages/wasm-solana/js/index.ts
@@ -45,6 +45,7 @@ export {
 // Type exports
 export type { AccountMeta, Instruction } from "./transaction.js";
 export type {
+  TransactionInput,
   ParsedTransaction,
   DurableNonce,
   InstructionParams,

--- a/packages/wasm-solana/js/transaction.ts
+++ b/packages/wasm-solana/js/transaction.ts
@@ -58,6 +58,14 @@ export class Transaction {
   }
 
   /**
+   * Create a Transaction from a WasmTransaction instance.
+   * @internal Used by builder functions
+   */
+  static fromWasm(wasm: WasmTransaction): Transaction {
+    return new Transaction(wasm);
+  }
+
+  /**
    * Get the fee payer address as a base58 string
    * Returns null if there are no account keys (shouldn't happen for valid transactions)
    */

--- a/packages/wasm-solana/js/versioned.ts
+++ b/packages/wasm-solana/js/versioned.ts
@@ -91,6 +91,14 @@ export class VersionedTransaction {
   }
 
   /**
+   * Create a VersionedTransaction from a WasmVersionedTransaction instance.
+   * @internal Used by builder functions
+   */
+  static fromWasm(wasm: WasmVersionedTransaction): VersionedTransaction {
+    return new VersionedTransaction(wasm);
+  }
+
+  /**
    * Create a versioned transaction from raw MessageV0 data.
    *
    * This is used for the `fromVersionedTransactionData()` path where we have
@@ -120,10 +128,9 @@ export class VersionedTransaction {
    * ```
    */
   static fromVersionedData(data: RawVersionedTransactionData): VersionedTransaction {
-    // Build the transaction bytes using WASM
-    const bytes = BuilderNamespace.build_from_versioned_data(data);
-    // Parse the bytes to create a VersionedTransaction
-    return VersionedTransaction.fromBytes(bytes);
+    // Build the transaction using WASM and wrap in TypeScript class
+    const wasm = BuilderNamespace.build_from_versioned_data(data);
+    return VersionedTransaction.fromWasm(wasm);
   }
 
   /**

--- a/packages/wasm-solana/test/builder.ts
+++ b/packages/wasm-solana/test/builder.ts
@@ -30,8 +30,7 @@ describe("buildTransaction", () => {
       assert.ok(txBytes instanceof Uint8Array);
       assert.ok(txBytes.length > 0);
 
-      // Parse it back to verify structure
-      const parsed = parseTransaction(txBytes);
+      const parsed = parseTransaction(tx);
       assert.strictEqual(parsed.feePayer, SENDER);
       assert.strictEqual(parsed.nonce, BLOCKHASH);
       assert.strictEqual(parsed.instructionsData.length, 1);
@@ -53,8 +52,7 @@ describe("buildTransaction", () => {
       };
 
       const tx = buildTransaction(intent);
-      const txBytes = tx.toBytes();
-      const parsed = parseTransaction(txBytes);
+      const parsed = parseTransaction(tx);
 
       const transfer = parsed.instructionsData[0];
       assert.strictEqual(transfer.type, "Transfer");
@@ -79,8 +77,7 @@ describe("buildTransaction", () => {
       };
 
       const tx = buildTransaction(intent);
-      const txBytes = tx.toBytes();
-      const parsed = parseTransaction(txBytes);
+      const parsed = parseTransaction(tx);
 
       assert.strictEqual(parsed.instructionsData.length, 2);
       assert.strictEqual(parsed.instructionsData[0].type, "Transfer");
@@ -106,8 +103,7 @@ describe("buildTransaction", () => {
       };
 
       const tx = buildTransaction(intent);
-      const txBytes = tx.toBytes();
-      const parsed = parseTransaction(txBytes);
+      const parsed = parseTransaction(tx);
 
       assert.strictEqual(parsed.instructionsData.length, 2);
       assert.strictEqual(parsed.instructionsData[0].type, "SetComputeUnitLimit");
@@ -130,8 +126,7 @@ describe("buildTransaction", () => {
       };
 
       const tx = buildTransaction(intent);
-      const txBytes = tx.toBytes();
-      const parsed = parseTransaction(txBytes);
+      const parsed = parseTransaction(tx);
 
       assert.strictEqual(parsed.instructionsData.length, 2);
       assert.strictEqual(parsed.instructionsData[0].type, "SetPriorityFee");
@@ -164,8 +159,7 @@ describe("buildTransaction", () => {
       };
 
       const tx = buildTransaction(intent);
-      const txBytes = tx.toBytes();
-      const parsed = parseTransaction(txBytes);
+      const parsed = parseTransaction(tx);
 
       // Should have 2 instructions: NonceAdvance + Transfer
       assert.strictEqual(parsed.instructionsData.length, 2);
@@ -204,8 +198,7 @@ describe("buildTransaction", () => {
       };
 
       const tx = buildTransaction(intent);
-      const txBytes = tx.toBytes();
-      const parsed = parseTransaction(txBytes);
+      const parsed = parseTransaction(tx);
 
       assert.strictEqual(parsed.instructionsData.length, 1);
       assert.strictEqual(parsed.instructionsData[0].type, "CreateAccount");
@@ -293,8 +286,7 @@ describe("buildTransaction", () => {
       };
 
       const tx = buildTransaction(intent);
-      const txBytes = tx.toBytes();
-      const parsed = parseTransaction(txBytes);
+      const parsed = parseTransaction(tx);
 
       assert.strictEqual(parsed.instructionsData.length, 1);
       assert.strictEqual(parsed.instructionsData[0].type, "StakeInitialize");
@@ -322,8 +314,7 @@ describe("buildTransaction", () => {
       };
 
       const tx = buildTransaction(intent);
-      const txBytes = tx.toBytes();
-      const parsed = parseTransaction(txBytes);
+      const parsed = parseTransaction(tx);
 
       assert.strictEqual(parsed.instructionsData.length, 1);
       assert.strictEqual(parsed.instructionsData[0].type, "StakingDelegate");
@@ -350,8 +341,7 @@ describe("buildTransaction", () => {
       };
 
       const tx = buildTransaction(intent);
-      const txBytes = tx.toBytes();
-      const parsed = parseTransaction(txBytes);
+      const parsed = parseTransaction(tx);
 
       assert.strictEqual(parsed.instructionsData.length, 1);
       assert.strictEqual(parsed.instructionsData[0].type, "StakingDeactivate");
@@ -379,8 +369,7 @@ describe("buildTransaction", () => {
       };
 
       const tx = buildTransaction(intent);
-      const txBytes = tx.toBytes();
-      const parsed = parseTransaction(txBytes);
+      const parsed = parseTransaction(tx);
 
       assert.strictEqual(parsed.instructionsData.length, 1);
       assert.strictEqual(parsed.instructionsData[0].type, "StakingWithdraw");
@@ -426,8 +415,7 @@ describe("buildTransaction", () => {
       };
 
       const tx = buildTransaction(intent);
-      const txBytes = tx.toBytes();
-      const parsed = parseTransaction(txBytes);
+      const parsed = parseTransaction(tx);
 
       // Parser returns individual instructions; combining is done in BitGoJS wasmInstructionCombiner
       assert.strictEqual(parsed.instructionsData.length, 3);
@@ -477,8 +465,7 @@ describe("buildTransaction", () => {
       };
 
       const tx = buildTransaction(intent);
-      const txBytes = tx.toBytes();
-      const parsed = parseTransaction(txBytes);
+      const parsed = parseTransaction(tx);
 
       assert.strictEqual(parsed.instructionsData.length, 1);
       assert.strictEqual(parsed.instructionsData[0].type, "TokenTransfer");
@@ -508,8 +495,7 @@ describe("buildTransaction", () => {
       };
 
       const tx = buildTransaction(intent);
-      const txBytes = tx.toBytes();
-      const parsed = parseTransaction(txBytes);
+      const parsed = parseTransaction(tx);
 
       assert.strictEqual(parsed.instructionsData.length, 1);
       assert.strictEqual(parsed.instructionsData[0].type, "CreateAssociatedTokenAccount");
@@ -537,8 +523,7 @@ describe("buildTransaction", () => {
       };
 
       const tx = buildTransaction(intent);
-      const txBytes = tx.toBytes();
-      const parsed = parseTransaction(txBytes);
+      const parsed = parseTransaction(tx);
 
       assert.strictEqual(parsed.instructionsData.length, 1);
       assert.strictEqual(parsed.instructionsData[0].type, "CloseAssociatedTokenAccount");
@@ -576,8 +561,7 @@ describe("buildTransaction", () => {
       };
 
       const tx = buildTransaction(intent);
-      const txBytes = tx.toBytes();
-      const parsed = parseTransaction(txBytes);
+      const parsed = parseTransaction(tx);
 
       assert.strictEqual(parsed.instructionsData.length, 3);
       assert.strictEqual(parsed.instructionsData[0].type, "CreateAssociatedTokenAccount");
@@ -620,8 +604,7 @@ describe("buildTransaction", () => {
       };
 
       const tx = buildTransaction(intent);
-      const txBytes = tx.toBytes();
-      const parsed = parseTransaction(txBytes);
+      const parsed = parseTransaction(tx);
 
       assert.strictEqual(parsed.instructionsData.length, 1);
       assert.strictEqual(parsed.instructionsData[0].type, "StakePoolDepositSol");
@@ -658,8 +641,7 @@ describe("buildTransaction", () => {
       };
 
       const tx = buildTransaction(intent);
-      const txBytes = tx.toBytes();
-      const parsed = parseTransaction(txBytes);
+      const parsed = parseTransaction(tx);
 
       assert.strictEqual(parsed.instructionsData.length, 1);
       assert.strictEqual(parsed.instructionsData[0].type, "StakePoolWithdrawStake");
@@ -702,8 +684,7 @@ describe("buildTransaction", () => {
       };
 
       const tx = buildTransaction(intent);
-      const txBytes = tx.toBytes();
-      const parsed = parseTransaction(txBytes);
+      const parsed = parseTransaction(tx);
 
       assert.strictEqual(parsed.instructionsData.length, 2);
       assert.strictEqual(parsed.instructionsData[0].type, "CreateAssociatedTokenAccount");

--- a/packages/wasm-solana/test/builder.ts
+++ b/packages/wasm-solana/test/builder.ts
@@ -25,7 +25,8 @@ describe("buildTransaction", () => {
         instructions: [{ type: "transfer", from: SENDER, to: RECIPIENT, lamports: 1000000n }],
       };
 
-      const txBytes = buildTransaction(intent);
+      const tx = buildTransaction(intent);
+      const txBytes = tx.toBytes();
       assert.ok(txBytes instanceof Uint8Array);
       assert.ok(txBytes.length > 0);
 
@@ -51,7 +52,8 @@ describe("buildTransaction", () => {
         ],
       };
 
-      const txBytes = buildTransaction(intent);
+      const tx = buildTransaction(intent);
+      const txBytes = tx.toBytes();
       const parsed = parseTransaction(txBytes);
 
       const transfer = parsed.instructionsData[0];
@@ -76,7 +78,8 @@ describe("buildTransaction", () => {
         ],
       };
 
-      const txBytes = buildTransaction(intent);
+      const tx = buildTransaction(intent);
+      const txBytes = tx.toBytes();
       const parsed = parseTransaction(txBytes);
 
       assert.strictEqual(parsed.instructionsData.length, 2);
@@ -102,7 +105,8 @@ describe("buildTransaction", () => {
         ],
       };
 
-      const txBytes = buildTransaction(intent);
+      const tx = buildTransaction(intent);
+      const txBytes = tx.toBytes();
       const parsed = parseTransaction(txBytes);
 
       assert.strictEqual(parsed.instructionsData.length, 2);
@@ -125,7 +129,8 @@ describe("buildTransaction", () => {
         ],
       };
 
-      const txBytes = buildTransaction(intent);
+      const tx = buildTransaction(intent);
+      const txBytes = tx.toBytes();
       const parsed = parseTransaction(txBytes);
 
       assert.strictEqual(parsed.instructionsData.length, 2);
@@ -158,7 +163,8 @@ describe("buildTransaction", () => {
         instructions: [{ type: "transfer", from: SENDER, to: RECIPIENT, lamports: 1000000n }],
       };
 
-      const txBytes = buildTransaction(intent);
+      const tx = buildTransaction(intent);
+      const txBytes = tx.toBytes();
       const parsed = parseTransaction(txBytes);
 
       // Should have 2 instructions: NonceAdvance + Transfer
@@ -197,7 +203,8 @@ describe("buildTransaction", () => {
         ],
       };
 
-      const txBytes = buildTransaction(intent);
+      const tx = buildTransaction(intent);
+      const txBytes = tx.toBytes();
       const parsed = parseTransaction(txBytes);
 
       assert.strictEqual(parsed.instructionsData.length, 1);
@@ -258,10 +265,11 @@ describe("buildTransaction", () => {
         ],
       };
 
-      const txBytes1 = buildTransaction(intent);
-      const txBytes2 = buildTransaction(intent);
+      const tx1 = buildTransaction(intent);
+      const tx2 = buildTransaction(intent);
 
-      assert.deepStrictEqual(txBytes1, txBytes2);
+      // Compare serialized bytes since Transaction objects have different wasm pointers
+      assert.deepStrictEqual(tx1.toBytes(), tx2.toBytes());
     });
   });
 
@@ -284,7 +292,8 @@ describe("buildTransaction", () => {
         ],
       };
 
-      const txBytes = buildTransaction(intent);
+      const tx = buildTransaction(intent);
+      const txBytes = tx.toBytes();
       const parsed = parseTransaction(txBytes);
 
       assert.strictEqual(parsed.instructionsData.length, 1);
@@ -312,7 +321,8 @@ describe("buildTransaction", () => {
         ],
       };
 
-      const txBytes = buildTransaction(intent);
+      const tx = buildTransaction(intent);
+      const txBytes = tx.toBytes();
       const parsed = parseTransaction(txBytes);
 
       assert.strictEqual(parsed.instructionsData.length, 1);
@@ -339,7 +349,8 @@ describe("buildTransaction", () => {
         ],
       };
 
-      const txBytes = buildTransaction(intent);
+      const tx = buildTransaction(intent);
+      const txBytes = tx.toBytes();
       const parsed = parseTransaction(txBytes);
 
       assert.strictEqual(parsed.instructionsData.length, 1);
@@ -367,7 +378,8 @@ describe("buildTransaction", () => {
         ],
       };
 
-      const txBytes = buildTransaction(intent);
+      const tx = buildTransaction(intent);
+      const txBytes = tx.toBytes();
       const parsed = parseTransaction(txBytes);
 
       assert.strictEqual(parsed.instructionsData.length, 1);
@@ -413,7 +425,8 @@ describe("buildTransaction", () => {
         ],
       };
 
-      const txBytes = buildTransaction(intent);
+      const tx = buildTransaction(intent);
+      const txBytes = tx.toBytes();
       const parsed = parseTransaction(txBytes);
 
       // Parser returns individual instructions; combining is done in BitGoJS wasmInstructionCombiner
@@ -463,7 +476,8 @@ describe("buildTransaction", () => {
         ],
       };
 
-      const txBytes = buildTransaction(intent);
+      const tx = buildTransaction(intent);
+      const txBytes = tx.toBytes();
       const parsed = parseTransaction(txBytes);
 
       assert.strictEqual(parsed.instructionsData.length, 1);
@@ -493,7 +507,8 @@ describe("buildTransaction", () => {
         ],
       };
 
-      const txBytes = buildTransaction(intent);
+      const tx = buildTransaction(intent);
+      const txBytes = tx.toBytes();
       const parsed = parseTransaction(txBytes);
 
       assert.strictEqual(parsed.instructionsData.length, 1);
@@ -521,7 +536,8 @@ describe("buildTransaction", () => {
         ],
       };
 
-      const txBytes = buildTransaction(intent);
+      const tx = buildTransaction(intent);
+      const txBytes = tx.toBytes();
       const parsed = parseTransaction(txBytes);
 
       assert.strictEqual(parsed.instructionsData.length, 1);
@@ -559,7 +575,8 @@ describe("buildTransaction", () => {
         ],
       };
 
-      const txBytes = buildTransaction(intent);
+      const tx = buildTransaction(intent);
+      const txBytes = tx.toBytes();
       const parsed = parseTransaction(txBytes);
 
       assert.strictEqual(parsed.instructionsData.length, 3);
@@ -602,7 +619,8 @@ describe("buildTransaction", () => {
         ],
       };
 
-      const txBytes = buildTransaction(intent);
+      const tx = buildTransaction(intent);
+      const txBytes = tx.toBytes();
       const parsed = parseTransaction(txBytes);
 
       assert.strictEqual(parsed.instructionsData.length, 1);
@@ -639,7 +657,8 @@ describe("buildTransaction", () => {
         ],
       };
 
-      const txBytes = buildTransaction(intent);
+      const tx = buildTransaction(intent);
+      const txBytes = tx.toBytes();
       const parsed = parseTransaction(txBytes);
 
       assert.strictEqual(parsed.instructionsData.length, 1);
@@ -682,7 +701,8 @@ describe("buildTransaction", () => {
         ],
       };
 
-      const txBytes = buildTransaction(intent);
+      const tx = buildTransaction(intent);
+      const txBytes = tx.toBytes();
       const parsed = parseTransaction(txBytes);
 
       assert.strictEqual(parsed.instructionsData.length, 2);


### PR DESCRIPTION
## Summary

- Changed `buildTransaction()` to return `Transaction` instead of `Uint8Array`
- Changed `buildFromVersionedData()` to return `VersionedTransaction` instead of `Uint8Array`
- Added `fromWasm()` factory methods to Transaction and VersionedTransaction classes
- Callers that need bytes can simply call `.toBytes()` on the result

This addresses feedback from PR #113 to return rich Transaction objects that can be inspected before serializing, which is more ergonomic.

## Test plan

- [x] All 90 existing tests pass
- [x] Updated tests to use new return types