### PR TITLE
ci: add wasm-solana build artifacts to publish workflow

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -208,7 +208,7 @@ jobs:
         run: npm test
         working-directory: packages/webui
 
-      - name: Upload final build artifacts
+      - name: Upload wasm-utxo build artifacts
         if: inputs.upload-artifacts
         uses: actions/upload-artifact@v4
         with:
@@ -216,6 +216,15 @@ jobs:
           path: |
             packages/wasm-utxo/pkg/
             packages/wasm-utxo/dist/
+          retention-days: 1
+
+      - name: Upload wasm-solana build artifacts
+        if: inputs.upload-artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: wasm-solana-build
+          path: |
+            packages/wasm-solana/dist/
           retention-days: 1
 
   # This job provides a stable "test / Test" status check for branch protection.

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,4 +1,4 @@
-name: Publish @bitgo/wasm-utxo
+name: Publish @bitgo/wasm packages
 on:
   push:
     branches:
@@ -30,11 +30,17 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Download build artifacts
+      - name: Download wasm-utxo build artifacts
         uses: actions/download-artifact@v4
         with:
           name: wasm-utxo-build
           path: packages/wasm-utxo/
+
+      - name: Download wasm-solana build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: wasm-solana-build
+          path: packages/wasm-solana/
 
       - name: Setup Node
         uses: actions/setup-node@v4


### PR DESCRIPTION
The publish workflow was only uploading and downloading wasm-utxo build artifacts, causing wasm-solana (and wasm-bip32) to be published to npm without their dist/ folders. This resulted in broken npm packages that only contained package.json and README.md.

This fix adds a separate artifact upload step for wasm-solana in the finalize job, and a corresponding download step in the publish job, ensuring the built files are included when multi-semantic-release publishes to npm.

BTC-2990