### PR TITLE
feat(wasm-utxo): add version tracking to PSBTs

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -27,6 +27,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          fetch-depth: 0
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
@@ -122,6 +123,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          fetch-depth: 0
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
@@ -186,6 +188,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          fetch-depth: 0
 
       - name: Setup Node
         uses: actions/setup-node@v4

--- a/packages/wasm-utxo/Cargo.toml
+++ b/packages/wasm-utxo/Cargo.toml
@@ -34,6 +34,9 @@ pastey = "0.1"
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 zebra-chain = { version = "3.1", default-features = false }
 
+[build-dependencies]
+serde_json = "1.0"
+
 [profile.release]
 # this is required to make webpack happy
 # https://github.com/webpack/webpack/issues/15566#issuecomment-2558347645

--- a/packages/wasm-utxo/build.rs
+++ b/packages/wasm-utxo/build.rs
@@ -1,0 +1,37 @@
+use std::process::Command;
+
+fn main() {
+    // Extract version from package.json using proper JSON parsing
+    let package_json =
+        std::fs::read_to_string("package.json").expect("Failed to read package.json");
+
+    let package: serde_json::Value =
+        serde_json::from_str(&package_json).expect("Failed to parse package.json as JSON");
+
+    let version = package
+        .get("version")
+        .and_then(|v| v.as_str())
+        .expect("Failed to find 'version' field in package.json");
+
+    println!("cargo:rustc-env=WASM_UTXO_VERSION={}", version);
+
+    // Capture git commit hash
+    let git_hash = Command::new("git")
+        .args(["rev-parse", "HEAD"])
+        .output()
+        .ok()
+        .and_then(|output| {
+            if output.status.success() {
+                String::from_utf8(output.stdout).ok()
+            } else {
+                None
+            }
+        })
+        .map(|s| s.trim().to_string())
+        .unwrap_or_else(|| "unknown".to_string());
+
+    println!("cargo:rustc-env=WASM_UTXO_GIT_HASH={}", git_hash);
+
+    // Rerun if package.json changes
+    println!("cargo:rerun-if-changed=package.json");
+}

--- a/packages/wasm-utxo/src/fixed_script_wallet/bitgo_psbt/mod.rs
+++ b/packages/wasm-utxo/src/fixed_script_wallet/bitgo_psbt/mod.rs
@@ -16,7 +16,7 @@ pub mod zcash_psbt;
 use crate::Network;
 pub use dash_psbt::DashBitGoPsbt;
 use miniscript::bitcoin::{psbt::Psbt, secp256k1, CompressedPublicKey, Txid};
-pub use propkv::{BitGoKeyValue, ProprietaryKeySubtype, BITGO};
+pub use propkv::{BitGoKeyValue, ProprietaryKeySubtype, WasmUtxoVersionInfo, BITGO};
 pub use sighash::validate_sighash_type;
 pub use zcash_psbt::{
     decode_zcash_transaction_meta, ZcashBitGoPsbt, ZcashTransactionMeta,


### PR DESCRIPTION

This PR adds PSBT version tracking capabilities to the wasm-utxo library by:

1. Creating a new WasmUtxoVersionInfo class to encode version and git hash 
   information in PSBTs
   
2. Adding a set_version_info method to BitGoPsbt that embeds version 
   information into proprietary fields
   
3. Adding a build script that extracts version from package.json and 
   captures git commit hash during build time

These changes enable tracking which version of the WASM library created
or modified a PSBT, supporting debugging and compatibility verification.

BTC-2992