### PR TITLE
feat(wasm-utxo): add half-signed legacy transaction format extraction

### DIFF
--- a/packages/wasm-utxo/js/fixedScriptWallet/BitGoPsbt.ts
+++ b/packages/wasm-utxo/js/fixedScriptWallet/BitGoPsbt.ts
@@ -761,4 +761,33 @@ export class BitGoPsbt {
   extractTransaction(): Uint8Array {
     return this._wasm.extract_transaction();
   }
+
+  /**
+   * Extract a half-signed transaction in legacy format for p2ms-based script types.
+   *
+   * This method extracts a transaction where each input has exactly one signature,
+   * formatted in the legacy style used by utxo-lib and bitcoinjs-lib. The legacy
+   * format places signatures in the correct position (0, 1, or 2) based on which
+   * key signed, with empty placeholders for unsigned positions.
+   *
+   * Requirements:
+   * - All inputs must be p2ms-based (p2sh, p2shP2wsh, or p2wsh)
+   * - Each input must have exactly 1 partial signature
+   *
+   * @returns The serialized half-signed transaction bytes
+   * @throws Error if any input is not a p2ms type (Taproot, replay protection, etc.)
+   * @throws Error if any input has 0 or more than 1 partial signature
+   *
+   * @example
+   * ```typescript
+   * // Sign with user key only
+   * psbt.sign(userXpriv);
+   *
+   * // Extract half-signed transaction in legacy format
+   * const halfSignedTx = psbt.getHalfSignedLegacyFormat();
+   * ```
+   */
+  getHalfSignedLegacyFormat(): Uint8Array {
+    return this._wasm.extract_half_signed_legacy_tx();
+  }
 }

--- a/packages/wasm-utxo/src/fixed_script_wallet/bitgo_psbt/legacy_txformat.rs
+++ b/packages/wasm-utxo/src/fixed_script_wallet/bitgo_psbt/legacy_txformat.rs
@@ -1,0 +1,149 @@
+//! Legacy transaction format extraction for half-signed transactions.
+//!
+//! This module provides functionality to extract half-signed transactions in the
+//! legacy format used by utxo-lib and bitcoinjs-lib, where signatures are placed
+//! in scriptSig/witness with OP_0 placeholders for missing signatures.
+
+use crate::fixed_script_wallet::wallet_scripts::parse_multisig_script_2_of_3;
+use miniscript::bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_0;
+use miniscript::bitcoin::blockdata::script::Builder;
+use miniscript::bitcoin::psbt::Psbt;
+use miniscript::bitcoin::script::PushBytesBuf;
+use miniscript::bitcoin::{Transaction, Witness};
+
+/// Build a half-signed transaction in legacy format from a PSBT.
+///
+/// Returns the Transaction with signatures placed in scriptSig/witness.
+/// Use `extract_half_signed_legacy_tx` for serialized bytes.
+pub fn build_half_signed_legacy_tx(psbt: &Psbt) -> Result<Transaction, String> {
+    // Validate we have inputs and outputs
+    if psbt.inputs.is_empty() || psbt.unsigned_tx.output.is_empty() {
+        return Err("empty inputs or outputs".to_string());
+    }
+
+    // Clone the unsigned transaction - we'll set scriptSig/witness on this
+    let mut tx = psbt.unsigned_tx.clone();
+
+    for (input_index, psbt_input) in psbt.inputs.iter().enumerate() {
+        // Determine script type and get the multisig script
+        let (is_p2sh, is_p2wsh, multisig_script) =
+            if let Some(ref witness_script) = psbt_input.witness_script {
+                // p2wsh or p2shP2wsh - witness_script contains the multisig script
+                let is_p2sh = psbt_input.redeem_script.is_some();
+                (is_p2sh, true, witness_script.clone())
+            } else if let Some(ref redeem_script) = psbt_input.redeem_script {
+                // p2sh only - redeem_script contains the multisig script
+                (true, false, redeem_script.clone())
+            } else {
+                return Err(format!(
+                "Input {}: unsupported script type (no witness_script or redeem_script found). \
+                 Only p2ms-based types (p2sh, p2shP2wsh, p2wsh) are supported.",
+                input_index
+            ));
+            };
+
+        // Check for taproot inputs (not supported)
+        if !psbt_input.tap_script_sigs.is_empty() || !psbt_input.tap_key_origins.is_empty() {
+            return Err(format!(
+                "Input {}: Taproot inputs are not supported in legacy half-signed format",
+                input_index
+            ));
+        }
+
+        // Validate exactly 1 partial signature
+        let sig_count = psbt_input.partial_sigs.len();
+        if sig_count != 1 {
+            return Err(format!(
+                "Input {}: expected exactly 1 partial signature, got {}",
+                input_index, sig_count
+            ));
+        }
+
+        // Get the single partial signature
+        let (sig_pubkey, ecdsa_sig) = psbt_input.partial_sigs.iter().next().unwrap();
+
+        // Parse the multisig script to get the 3 public keys
+        let pubkeys = parse_multisig_script_2_of_3(&multisig_script).map_err(|e| {
+            format!(
+                "Input {}: failed to parse multisig script: {}",
+                input_index, e
+            )
+        })?;
+
+        // Find which key index (0, 1, 2) matches the signature's pubkey
+        let sig_key_index = pubkeys
+            .iter()
+            .position(|pk| pk.to_bytes() == sig_pubkey.to_bytes()[..])
+            .ok_or_else(|| {
+                format!(
+                    "Input {}: signature pubkey not found in multisig script",
+                    input_index
+                )
+            })?;
+
+        // Serialize the signature
+        let sig_bytes = ecdsa_sig.to_vec();
+
+        // Build the signatures array with the signature in the correct position
+        // Format: [OP_0, sig_or_empty, sig_or_empty, sig_or_empty]
+        let mut sig_stack: Vec<Vec<u8>> = vec![vec![]]; // Start with OP_0 (empty)
+        for i in 0..3 {
+            if i == sig_key_index {
+                sig_stack.push(sig_bytes.clone());
+            } else {
+                sig_stack.push(vec![]); // OP_0 placeholder
+            }
+        }
+
+        // Build scriptSig and/or witness based on script type
+        if is_p2wsh {
+            // p2wsh or p2shP2wsh: witness = [empty, sigs..., witnessScript]
+            let mut witness_items = sig_stack;
+            witness_items.push(multisig_script.to_bytes());
+            tx.input[input_index].witness = Witness::from_slice(&witness_items);
+
+            if is_p2sh {
+                // p2shP2wsh: also need scriptSig = [redeemScript]
+                // The redeemScript is the p2wsh script (hash of witness script)
+                let redeem_script = psbt_input.redeem_script.as_ref().unwrap();
+                let redeem_script_bytes = PushBytesBuf::try_from(redeem_script.to_bytes())
+                    .map_err(|e| {
+                        format!(
+                            "Input {}: failed to convert redeem script to push bytes: {}",
+                            input_index, e
+                        )
+                    })?;
+                let script_sig = Builder::new().push_slice(redeem_script_bytes).into_script();
+                tx.input[input_index].script_sig = script_sig;
+            }
+        } else {
+            // p2sh only: scriptSig = [OP_0, sigs..., redeemScript]
+            let mut builder = Builder::new().push_opcode(OP_PUSHBYTES_0);
+            for i in 0..3 {
+                if i == sig_key_index {
+                    let sig_push_bytes =
+                        PushBytesBuf::try_from(sig_bytes.clone()).map_err(|e| {
+                            format!(
+                                "Input {}: failed to convert signature to push bytes: {}",
+                                input_index, e
+                            )
+                        })?;
+                    builder = builder.push_slice(sig_push_bytes);
+                } else {
+                    builder = builder.push_opcode(OP_PUSHBYTES_0);
+                }
+            }
+            let multisig_push_bytes =
+                PushBytesBuf::try_from(multisig_script.to_bytes()).map_err(|e| {
+                    format!(
+                        "Input {}: failed to convert multisig script to push bytes: {}",
+                        input_index, e
+                    )
+                })?;
+            builder = builder.push_slice(multisig_push_bytes);
+            tx.input[input_index].script_sig = builder.into_script();
+        }
+    }
+
+    Ok(tx)
+}

--- a/packages/wasm-utxo/src/wasm/fixed_script_wallet/mod.rs
+++ b/packages/wasm-utxo/src/wasm/fixed_script_wallet/mod.rs
@@ -1489,4 +1489,28 @@ impl BitGoPsbt {
             .extract_tx()
             .map_err(|e| WasmUtxoError::new(&e))
     }
+
+    /// Extract a half-signed transaction in legacy format for p2ms-based script types.
+    ///
+    /// This method extracts a transaction where each input has exactly one signature,
+    /// formatted in the legacy style used by utxo-lib and bitcoinjs-lib. The legacy
+    /// format places signatures in the correct position (0, 1, or 2) based on which
+    /// key signed, with empty placeholders for unsigned positions.
+    ///
+    /// # Requirements
+    /// - All inputs must be p2ms-based (p2sh, p2shP2wsh, or p2wsh)
+    /// - Each input must have exactly 1 partial signature
+    ///
+    /// # Returns
+    /// - `Ok(Vec<u8>)` containing the serialized half-signed transaction bytes
+    /// - `Err(WasmUtxoError)` if validation fails or extraction fails
+    ///
+    /// # Errors
+    /// - Returns error if any input is not a p2ms type (Taproot, replay protection, etc.)
+    /// - Returns error if any input has 0 or more than 1 partial signature
+    pub fn extract_half_signed_legacy_tx(&self) -> Result<Vec<u8>, WasmUtxoError> {
+        self.psbt
+            .extract_half_signed_legacy_tx()
+            .map_err(|e| WasmUtxoError::new(&e))
+    }
 }

--- a/packages/wasm-utxo/test/address/utxolibCompat.ts
+++ b/packages/wasm-utxo/test/address/utxolibCompat.ts
@@ -5,66 +5,13 @@ import { dirname } from "node:path";
 
 import * as utxolib from "@bitgo/utxo-lib";
 import assert from "node:assert";
-import {
-  utxolibCompat,
-  address as addressNs,
-  type CoinName,
-  AddressFormat,
-} from "../../js/index.js";
+import { utxolibCompat, address as addressNs, AddressFormat } from "../../js/index.js";
+import { getCoinNameForNetwork } from "../networks.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
 type Fixture = [type: string, script: string, address: string];
-
-function getCoinNameForNetwork(name: string): CoinName {
-  switch (name) {
-    case "bitcoin":
-      return "btc";
-    case "testnet":
-      return "tbtc";
-    case "bitcoinTestnet4":
-      return "tbtc4";
-    case "bitcoinPublicSignet":
-      return "tbtcsig";
-    case "bitcoinBitGoSignet":
-      return "tbtcbgsig";
-    case "bitcoincash":
-      return "bch";
-    case "bitcoincashTestnet":
-      return "tbch";
-    case "ecash":
-      return "bcha";
-    case "ecashTest":
-      return "tbcha";
-    case "bitcoingold":
-      return "btg";
-    case "bitcoingoldTestnet":
-      return "tbtg";
-    case "bitcoinsv":
-      return "bsv";
-    case "bitcoinsvTestnet":
-      return "tbsv";
-    case "dash":
-      return "dash";
-    case "dashTest":
-      return "tdash";
-    case "dogecoin":
-      return "doge";
-    case "dogecoinTest":
-      return "tdoge";
-    case "litecoin":
-      return "ltc";
-    case "litecoinTest":
-      return "tltc";
-    case "zcash":
-      return "zec";
-    case "zcashTest":
-      return "tzec";
-    default:
-      throw new Error(`Unknown network: ${name}`);
-  }
-}
 
 async function getFixtures(name: string, addressFormat?: AddressFormat): Promise<Fixture[]> {
   if (name === "bitcoinBitGoSignet") {
@@ -97,7 +44,7 @@ function runTest(network: utxolib.Network, addressFormat?: AddressFormat) {
     });
 
     it("should convert using coin name", function () {
-      const coinName = getCoinNameForNetwork(name);
+      const coinName = getCoinNameForNetwork(network);
 
       for (const fixture of fixtures) {
         const [, script, addressRef] = fixture;

--- a/packages/wasm-utxo/test/fixedScript/halfSignedLegacyFormat.ts
+++ b/packages/wasm-utxo/test/fixedScript/halfSignedLegacyFormat.ts
@@ -1,0 +1,251 @@
+/**
+ * Tests for getHalfSignedLegacyFormat() method against reference utxo-lib implementation
+ */
+import { describe, it } from "mocha";
+import * as assert from "assert";
+import * as utxolib from "@bitgo/utxo-lib";
+import { BitGoPsbt } from "../../js/fixedScriptWallet/BitGoPsbt.js";
+import { ZcashBitGoPsbt } from "../../js/fixedScriptWallet/ZcashBitGoPsbt.js";
+import { ChainCode } from "../../js/fixedScriptWallet/chains.js";
+import { getDefaultWalletKeys, getKeyTriple } from "../../js/testutils/keys.js";
+import { getCoinNameForNetwork } from "../networks.js";
+
+// Zcash Nu5 activation height (mainnet) - use a height after Nu5 activation
+const ZCASH_NU5_HEIGHT = 1687105;
+
+// P2ms script types that are supported by extractP2msOnlyHalfSignedTx
+const p2msScriptTypes = ["p2sh", "p2shP2wsh", "p2wsh"] as const;
+
+// Networks that support p2ms script types (mainnet only, excluding bsv and ecash)
+const p2msNetworks = utxolib
+  .getNetworkList()
+  .filter(
+    (n) => utxolib.isMainnet(n) && n !== utxolib.networks.bitcoinsv && n !== utxolib.networks.ecash,
+  );
+
+/**
+ * Create a PSBT with only p2ms inputs (p2sh, p2shP2wsh, p2wsh) and sign it with user key
+ */
+function createHalfSignedP2msPsbt(network: utxolib.Network): BitGoPsbt {
+  const coinName = getCoinNameForNetwork(network);
+  const rootWalletKeys = getDefaultWalletKeys();
+  const xprvTriple = getKeyTriple("default");
+
+  // Determine which p2ms types are supported by this network
+  const supportedTypes = p2msScriptTypes.filter((scriptType) =>
+    utxolib.bitgo.outputScripts.isSupportedScriptType(network, scriptType),
+  );
+
+  // Create unsigned PSBT - Zcash requires special handling with blockHeight
+  const isZcash = utxolib.getMainnet(network) === utxolib.networks.zcash;
+  const psbt = isZcash
+    ? ZcashBitGoPsbt.createEmpty(coinName as "zec" | "tzec", rootWalletKeys, {
+        version: 4, // Zcash uses version 4
+        lockTime: 0,
+        blockHeight: ZCASH_NU5_HEIGHT,
+      })
+    : BitGoPsbt.createEmpty(coinName, rootWalletKeys, {
+        version: 2,
+        lockTime: 0,
+      });
+
+  // Add inputs for each supported p2ms type
+  supportedTypes.forEach((scriptType, index) => {
+    const scriptId = { chain: ChainCode.value(scriptType, "external"), index };
+    psbt.addWalletInput(
+      {
+        txid: `${"00".repeat(31)}${index.toString(16).padStart(2, "0")}`,
+        vout: 0,
+        value: BigInt(10000 + index * 10000),
+        sequence: 0xfffffffd,
+      },
+      rootWalletKeys,
+      { scriptId },
+    );
+  });
+
+  // Add a p2sh output
+  psbt.addWalletOutput(rootWalletKeys, { chain: 0, index: 100, value: BigInt(5000) });
+
+  // Sign with user key only (halfsigned)
+  psbt.sign(xprvTriple[0]);
+
+  return psbt;
+}
+
+/**
+ * Convert wasm-utxo PSBT to utxo-lib PSBT for comparison
+ */
+function toUtxolibPsbt(wasmPsbt: BitGoPsbt, network: utxolib.Network): utxolib.bitgo.UtxoPsbt {
+  const bytes = wasmPsbt.serialize();
+  return utxolib.bitgo.createPsbtFromBuffer(Buffer.from(bytes), network);
+}
+
+describe("getHalfSignedLegacyFormat", function () {
+  describe("Basic functionality", function () {
+    it("should extract half-signed transaction for p2ms inputs", function () {
+      const psbt = createHalfSignedP2msPsbt(utxolib.networks.bitcoin);
+      assert.ok(psbt, "Should create PSBT");
+
+      const halfSignedTx = psbt.getHalfSignedLegacyFormat();
+      assert.ok(halfSignedTx, "Should extract half-signed transaction");
+      assert.ok(halfSignedTx.length > 0, "Transaction should have data");
+
+      // Verify it's a valid transaction by deserializing
+      const tx = utxolib.bitgo.createTransactionFromBuffer(
+        Buffer.from(halfSignedTx),
+        utxolib.networks.bitcoin,
+        { amountType: "bigint" },
+      );
+      assert.ok(tx, "Should deserialize as valid transaction");
+      // Should have at least 1 input
+      assert.ok(tx.ins.length >= 1, "Should have at least 1 input");
+    });
+
+    it("should fail for unsigned inputs", function () {
+      const rootWalletKeys = getDefaultWalletKeys();
+
+      // Create unsigned PSBT (no signatures)
+      const psbt = BitGoPsbt.createEmpty("btc", rootWalletKeys, {
+        version: 2,
+        lockTime: 0,
+      });
+
+      // Add a p2sh input
+      psbt.addWalletInput(
+        {
+          txid: "00".repeat(32),
+          vout: 0,
+          value: BigInt(10000),
+          sequence: 0xfffffffd,
+        },
+        rootWalletKeys,
+        { scriptId: { chain: 0, index: 0 } },
+      );
+
+      psbt.addWalletOutput(rootWalletKeys, { chain: 0, index: 100, value: BigInt(5000) });
+
+      // Should fail because no signatures
+      assert.throws(
+        () => psbt.getHalfSignedLegacyFormat(),
+        /expected exactly 1 partial signature/i,
+        "Should throw for unsigned inputs",
+      );
+    });
+  });
+
+  describe("Comparison with utxo-lib extractP2msOnlyHalfSignedTx", function () {
+    for (const network of p2msNetworks) {
+      const networkName = utxolib.getNetworkName(network);
+      it(`${networkName}: should produce identical output to utxo-lib extractP2msOnlyHalfSignedTx`, function () {
+        const psbt = createHalfSignedP2msPsbt(network);
+
+        // Get half-signed tx from wasm-utxo
+        const wasmHalfSignedTx = psbt.getHalfSignedLegacyFormat();
+
+        // Convert to utxo-lib PSBT and extract using reference implementation
+        const utxolibPsbt = toUtxolibPsbt(psbt, network);
+        const utxolibHalfSignedTx = utxolib.bitgo.extractP2msOnlyHalfSignedTx(utxolibPsbt);
+        const utxolibHalfSignedTxBytes = utxolibHalfSignedTx.toBuffer();
+
+        // Compare the results
+        assert.strictEqual(
+          Buffer.from(wasmHalfSignedTx).toString("hex"),
+          utxolibHalfSignedTxBytes.toString("hex"),
+          `Half-signed transaction should match utxo-lib output for ${networkName}`,
+        );
+      });
+    }
+  });
+
+  describe("Script type specific tests", function () {
+    it("should correctly place signature at position 0 (user key)", function () {
+      const psbt = createHalfSignedP2msPsbt(utxolib.networks.bitcoin);
+
+      const halfSignedTx = psbt.getHalfSignedLegacyFormat();
+      const tx = utxolib.bitgo.createTransactionFromBuffer(
+        Buffer.from(halfSignedTx),
+        utxolib.networks.bitcoin,
+        { amountType: "bigint" },
+      );
+
+      // Verify each input has the signature in the correct position
+      for (let i = 0; i < tx.ins.length; i++) {
+        const input = tx.ins[i];
+
+        // For witness inputs, check witness array
+        if (input.witness && input.witness.length > 0) {
+          // Format: [empty, sig_or_empty, sig_or_empty, sig_or_empty, witnessScript]
+          assert.strictEqual(
+            input.witness[0].length,
+            0,
+            `Input ${i}: First item should be empty (OP_0)`,
+          );
+          // User key is at position 0, so signature should be at witness[1]
+          assert.ok(
+            input.witness[1].length > 0,
+            `Input ${i}: User signature should be at position 1`,
+          );
+          assert.strictEqual(input.witness[2].length, 0, `Input ${i}: Position 2 should be empty`);
+          assert.strictEqual(input.witness[3].length, 0, `Input ${i}: Position 3 should be empty`);
+        } else {
+          // For non-witness (p2sh), check scriptSig
+          // Format: OP_0 <sig_or_OP_0> <sig_or_OP_0> <sig_or_OP_0> <redeemScript>
+          assert.ok(input.script.length > 0, `Input ${i}: Should have scriptSig`);
+        }
+      }
+    });
+  });
+
+  describe("Error handling", function () {
+    it("should throw descriptive error for empty PSBT", function () {
+      const rootWalletKeys = getDefaultWalletKeys();
+      const psbt = BitGoPsbt.createEmpty("btc", rootWalletKeys, {
+        version: 2,
+        lockTime: 0,
+      });
+
+      assert.throws(
+        () => psbt.getHalfSignedLegacyFormat(),
+        /empty inputs or outputs/i,
+        "Should throw for empty PSBT",
+      );
+    });
+
+    it("should throw for inputs with 2 signatures", function () {
+      const rootWalletKeys = getDefaultWalletKeys();
+      const xprvTriple = getKeyTriple("default");
+
+      // Create PSBT and sign with both user and bitgo keys
+      const psbt = BitGoPsbt.createEmpty("btc", rootWalletKeys, {
+        version: 2,
+        lockTime: 0,
+      });
+
+      psbt.addWalletInput(
+        {
+          txid: "00".repeat(32),
+          vout: 0,
+          value: BigInt(10000),
+          sequence: 0xfffffffd,
+        },
+        rootWalletKeys,
+        { scriptId: { chain: 0, index: 0 } },
+      );
+
+      psbt.addWalletOutput(rootWalletKeys, { chain: 0, index: 100, value: BigInt(5000) });
+
+      // Sign with user key
+      psbt.sign(xprvTriple[0]);
+      // Sign with bitgo key
+      psbt.sign(xprvTriple[2]);
+
+      // Should fail because inputs have 2 signatures
+      assert.throws(
+        () => psbt.getHalfSignedLegacyFormat(),
+        /expected exactly 1 partial signature/i,
+        "Should throw for fully signed inputs",
+      );
+    });
+  });
+});

--- a/packages/wasm-utxo/test/networks.ts
+++ b/packages/wasm-utxo/test/networks.ts
@@ -1,4 +1,5 @@
 import type { CoinName } from "../js/coinName.js";
+import * as utxolib from "@bitgo/utxo-lib";
 
 /**
  * Mainnet coin names for third-party fixtures.
@@ -29,4 +30,51 @@ export function getNetworkName(coin: MainnetCoinName): string {
 
 export function isZcash(coin: MainnetCoinName): boolean {
   return coin === "zec";
+}
+
+/** Convert utxolib network to CoinName */
+export function getCoinNameForNetwork(network: utxolib.Network): CoinName {
+  const name = utxolib.getNetworkName(network);
+  switch (name) {
+    case "bitcoin":
+      return "btc";
+    case "testnet":
+      return "tbtc";
+    case "bitcoinPublicSignet":
+      return "tbtcsig";
+    case "bitcoinBitGoSignet":
+      return "tbtcbgsig";
+    case "bitcoincash":
+      return "bch";
+    case "bitcoincashTestnet":
+      return "tbch";
+    case "ecash":
+      return "bcha";
+    case "ecashTest":
+      return "tbcha";
+    case "bitcoingold":
+      return "btg";
+    case "bitcoingoldTestnet":
+      return "tbtg";
+    case "bitcoinsv":
+      return "bsv";
+    case "bitcoinsvTestnet":
+      return "tbsv";
+    case "dash":
+      return "dash";
+    case "dashTest":
+      return "tdash";
+    case "dogecoin":
+      return "doge";
+    case "dogecoinTest":
+      return "tdoge";
+    case "litecoin":
+      return "ltc";
+    case "litecoinTest":
+      return "tltc";
+    case "zcash":
+      return "zec";
+    case "zcashTest":
+      return "tzec";
+  }
 }


### PR DESCRIPTION

Add support for extracting half-signed transactions in legacy format
compatible with utxo-lib and bitcoinjs-lib. This format places
signatures in the correct position based on the key index with empty
placeholders for unsigned positions.

The implementation handles all supported p2ms-based script types
(p2sh, p2shP2wsh, and p2wsh) and works across all UTXO networks,
including Bitcoin, Litecoin, Dash, and Zcash.

BTC-2993