### PR TITLE
feat(wasm-utxo): add version info embedding in PSBTs

### DIFF
--- a/packages/wasm-utxo/js/fixedScriptWallet/index.ts
+++ b/packages/wasm-utxo/js/fixedScriptWallet/index.ts
@@ -28,6 +28,7 @@ export {
   type AddOutputOptions,
   type AddWalletInputOptions,
   type AddWalletOutputOptions,
+  type WasmUtxoVersionInfo,
 } from "./BitGoPsbt.js";
 
 // Zcash-specific PSBT subclass

--- a/packages/wasm-utxo/src/fixed_script_wallet/bitgo_psbt/mod.rs
+++ b/packages/wasm-utxo/src/fixed_script_wallet/bitgo_psbt/mod.rs
@@ -1236,6 +1236,23 @@ impl BitGoPsbt {
         self.psbt_mut().proprietary.insert(key, value);
     }
 
+    /// Get version information from the PSBT's proprietary fields
+    ///
+    /// Returns the wasm-utxo version and git hash that was embedded in the PSBT,
+    /// or None if no version info is present.
+    pub fn get_version_info(&self) -> Option<WasmUtxoVersionInfo> {
+        use miniscript::bitcoin::psbt::raw::ProprietaryKey;
+        let key = ProprietaryKey {
+            prefix: BITGO.to_vec(),
+            subtype: ProprietaryKeySubtype::WasmUtxoVersion as u8,
+            key: vec![],
+        };
+        self.psbt()
+            .proprietary
+            .get(&key)
+            .and_then(|value| WasmUtxoVersionInfo::from_bytes(value).ok())
+    }
+
     pub fn finalize_input<C: secp256k1::Verification>(
         &mut self,
         secp: &secp256k1::Secp256k1<C>,

--- a/packages/wasm-utxo/src/wasm/fixed_script_wallet/mod.rs
+++ b/packages/wasm-utxo/src/wasm/fixed_script_wallet/mod.rs
@@ -615,6 +615,31 @@ impl BitGoPsbt {
         }
     }
 
+    /// Set wasm-utxo version information in the PSBT's proprietary fields
+    ///
+    /// This embeds the wasm-utxo version and git hash into the PSBT's global
+    /// proprietary fields, allowing identification of which library version
+    /// processed the PSBT.
+    pub fn set_version_info(&mut self) {
+        self.psbt.set_version_info();
+    }
+
+    /// Get wasm-utxo version information from the PSBT's proprietary fields
+    ///
+    /// Returns an object with `version` and `gitHash` fields, or undefined
+    /// if no version info is present in the PSBT.
+    pub fn get_version_info(&self) -> JsValue {
+        match self.psbt.get_version_info() {
+            Some(info) => {
+                let obj = js_sys::Object::new();
+                js_sys::Reflect::set(&obj, &"version".into(), &info.version.into()).unwrap();
+                js_sys::Reflect::set(&obj, &"gitHash".into(), &info.git_hash.into()).unwrap();
+                obj.into()
+            }
+            None => JsValue::UNDEFINED,
+        }
+    }
+
     /// Parse transaction with wallet keys to identify wallet inputs/outputs
     pub fn parse_transaction_with_wallet_keys(
         &self,


### PR DESCRIPTION

Add methods to set and get wasm-utxo version information in PSBTs.
This allows identification of which library version processed a PSBT
by embedding the semantic version and git hash in proprietary fields.

Issue: BTC-2992