### PR TITLE
feat(wasm-utxo)!: return transaction object from extractTransaction

### DIFF
--- a/packages/wasm-utxo/js/fixedScriptWallet/BitGoPsbt.ts
+++ b/packages/wasm-utxo/js/fixedScriptWallet/BitGoPsbt.ts
@@ -6,6 +6,12 @@ import { type ECPairArg, ECPair } from "../ecpair.js";
 import type { UtxolibName } from "../utxolibCompat.js";
 import type { CoinName } from "../coinName.js";
 import type { InputScriptType } from "./scriptType.js";
+import {
+  Transaction,
+  DashTransaction,
+  ZcashTransaction,
+  type ITransaction,
+} from "../transaction.js";
 
 export type { InputScriptType };
 
@@ -755,11 +761,19 @@ export class BitGoPsbt {
   /**
    * Extract the final transaction from a finalized PSBT
    *
-   * @returns The serialized transaction bytes
+   * @returns The extracted transaction instance
    * @throws Error if the PSBT is not fully finalized or extraction fails
    */
-  extractTransaction(): Uint8Array {
-    return this._wasm.extract_transaction();
+  extractTransaction(): ITransaction {
+    const networkType = this._wasm.get_network_type();
+
+    if (networkType === "dash") {
+      return DashTransaction.fromWasm(this._wasm.extract_dash_transaction());
+    }
+    if (networkType === "zcash") {
+      return ZcashTransaction.fromWasm(this._wasm.extract_zcash_transaction());
+    }
+    return Transaction.fromWasm(this._wasm.extract_bitcoin_transaction());
   }
 
   /**

--- a/packages/wasm-utxo/js/fixedScriptWallet/ZcashBitGoPsbt.ts
+++ b/packages/wasm-utxo/js/fixedScriptWallet/ZcashBitGoPsbt.ts
@@ -1,6 +1,7 @@
 import { BitGoPsbt as WasmBitGoPsbt } from "../wasm/wasm_utxo.js";
 import { type WalletKeysArg, RootWalletKeys } from "./RootWalletKeys.js";
 import { BitGoPsbt, type CreateEmptyOptions } from "./BitGoPsbt.js";
+import { ZcashTransaction } from "../transaction.js";
 
 /** Zcash network names */
 export type ZcashNetworkName = "zcash" | "zcashTest" | "zec" | "tzec";
@@ -159,5 +160,15 @@ export class ZcashBitGoPsbt extends BitGoPsbt {
    */
   get expiryHeight(): number {
     return this.wasm.expiry_height();
+  }
+
+  /**
+   * Extract the final Zcash transaction from a finalized PSBT
+   *
+   * @returns The extracted Zcash transaction instance
+   * @throws Error if the PSBT is not fully finalized or extraction fails
+   */
+  override extractTransaction(): ZcashTransaction {
+    return ZcashTransaction.fromWasm(this.wasm.extract_zcash_transaction());
   }
 }

--- a/packages/wasm-utxo/js/transaction.ts
+++ b/packages/wasm-utxo/js/transaction.ts
@@ -1,19 +1,46 @@
 import { WasmDashTransaction, WasmTransaction, WasmZcashTransaction } from "./wasm/wasm_utxo.js";
 
 /**
+ * Common interface for all transaction types
+ */
+export interface ITransaction {
+  toBytes(): Uint8Array;
+  getId(): string;
+}
+
+/**
  * Transaction wrapper (Bitcoin-like networks)
  *
  * Provides a camelCase, strongly-typed API over the snake_case WASM bindings.
  */
-export class Transaction {
+export class Transaction implements ITransaction {
   private constructor(private _wasm: WasmTransaction) {}
 
   static fromBytes(bytes: Uint8Array): Transaction {
     return new Transaction(WasmTransaction.from_bytes(bytes));
   }
 
+  /**
+   * @internal Create from WASM instance directly (avoids re-parsing bytes)
+   */
+  static fromWasm(wasm: WasmTransaction): Transaction {
+    return new Transaction(wasm);
+  }
+
   toBytes(): Uint8Array {
     return this._wasm.to_bytes();
+  }
+
+  /**
+   * Get the transaction ID (txid)
+   *
+   * The txid is the double SHA256 of the transaction bytes (excluding witness
+   * data for segwit transactions), displayed in reverse byte order as is standard.
+   *
+   * @returns The transaction ID as a hex string
+   */
+  getId(): string {
+    return this._wasm.get_txid();
   }
 
   /**
@@ -40,15 +67,34 @@ export class Transaction {
  *
  * Provides a camelCase, strongly-typed API over the snake_case WASM bindings.
  */
-export class ZcashTransaction {
+export class ZcashTransaction implements ITransaction {
   private constructor(private _wasm: WasmZcashTransaction) {}
 
   static fromBytes(bytes: Uint8Array): ZcashTransaction {
     return new ZcashTransaction(WasmZcashTransaction.from_bytes(bytes));
   }
 
+  /**
+   * @internal Create from WASM instance directly (avoids re-parsing bytes)
+   */
+  static fromWasm(wasm: WasmZcashTransaction): ZcashTransaction {
+    return new ZcashTransaction(wasm);
+  }
+
   toBytes(): Uint8Array {
     return this._wasm.to_bytes();
+  }
+
+  /**
+   * Get the transaction ID (txid)
+   *
+   * The txid is the double SHA256 of the full Zcash transaction bytes,
+   * displayed in reverse byte order as is standard.
+   *
+   * @returns The transaction ID as a hex string
+   */
+  getId(): string {
+    return this._wasm.get_txid();
   }
 
   /**
@@ -64,15 +110,34 @@ export class ZcashTransaction {
  *
  * Round-trip only: bytes -> parse -> bytes.
  */
-export class DashTransaction {
+export class DashTransaction implements ITransaction {
   private constructor(private _wasm: WasmDashTransaction) {}
 
   static fromBytes(bytes: Uint8Array): DashTransaction {
     return new DashTransaction(WasmDashTransaction.from_bytes(bytes));
   }
 
+  /**
+   * @internal Create from WASM instance directly (avoids re-parsing bytes)
+   */
+  static fromWasm(wasm: WasmDashTransaction): DashTransaction {
+    return new DashTransaction(wasm);
+  }
+
   toBytes(): Uint8Array {
     return this._wasm.to_bytes();
+  }
+
+  /**
+   * Get the transaction ID (txid)
+   *
+   * The txid is the double SHA256 of the full Dash transaction bytes,
+   * displayed in reverse byte order as is standard.
+   *
+   * @returns The transaction ID as a hex string
+   */
+  getId(): string {
+    return this._wasm.get_txid();
   }
 
   /**

--- a/packages/wasm-utxo/src/wasm/dash_transaction.rs
+++ b/packages/wasm-utxo/src/wasm/dash_transaction.rs
@@ -7,6 +7,13 @@ pub struct WasmDashTransaction {
     parts: crate::dash::transaction::DashTransactionParts,
 }
 
+impl WasmDashTransaction {
+    /// Create from parts (internal use)
+    pub(crate) fn from_parts(parts: crate::dash::transaction::DashTransactionParts) -> Self {
+        WasmDashTransaction { parts }
+    }
+}
+
 #[wasm_bindgen]
 impl WasmDashTransaction {
     /// Deserialize a Dash transaction from bytes (supports EVO special tx extra payload).
@@ -23,5 +30,27 @@ impl WasmDashTransaction {
         crate::dash::transaction::encode_dash_transaction_parts(&self.parts).map_err(|e| {
             WasmUtxoError::new(&format!("Failed to serialize Dash transaction: {}", e))
         })
+    }
+
+    /// Get the transaction ID (txid)
+    ///
+    /// The txid is the double SHA256 of the full Dash transaction bytes,
+    /// displayed in reverse byte order (big-endian) as is standard.
+    ///
+    /// # Returns
+    /// The transaction ID as a hex string
+    ///
+    /// # Errors
+    /// Returns an error if the transaction cannot be serialized
+    pub fn get_txid(&self) -> Result<String, WasmUtxoError> {
+        use miniscript::bitcoin::hashes::{sha256d, Hash};
+        use miniscript::bitcoin::Txid;
+        let tx_bytes = crate::dash::transaction::encode_dash_transaction_parts(&self.parts)
+            .map_err(|e| {
+                WasmUtxoError::new(&format!("Failed to serialize Dash transaction: {}", e))
+            })?;
+        let hash = sha256d::Hash::hash(&tx_bytes);
+        let txid = Txid::from_raw_hash(hash);
+        Ok(txid.to_string())
     }
 }

--- a/packages/wasm-utxo/src/wasm/transaction.rs
+++ b/packages/wasm-utxo/src/wasm/transaction.rs
@@ -12,6 +12,13 @@ pub struct WasmTransaction {
     pub(crate) tx: Transaction,
 }
 
+impl WasmTransaction {
+    /// Create a WasmTransaction from a Transaction (internal use)
+    pub(crate) fn from_tx(tx: Transaction) -> Self {
+        WasmTransaction { tx }
+    }
+}
+
 #[wasm_bindgen]
 impl WasmTransaction {
     /// Deserialize a transaction from bytes
@@ -53,6 +60,18 @@ impl WasmTransaction {
     pub fn get_vsize(&self) -> usize {
         self.tx.vsize()
     }
+
+    /// Get the transaction ID (txid)
+    ///
+    /// The txid is the double SHA256 of the transaction bytes (excluding witness
+    /// data for segwit transactions), displayed in reverse byte order (big-endian)
+    /// as is standard for Bitcoin.
+    ///
+    /// # Returns
+    /// The transaction ID as a hex string
+    pub fn get_txid(&self) -> String {
+        self.tx.compute_txid().to_string()
+    }
 }
 
 /// A Zcash transaction with network-specific fields
@@ -62,6 +81,13 @@ impl WasmTransaction {
 #[wasm_bindgen]
 pub struct WasmZcashTransaction {
     parts: crate::zcash::transaction::ZcashTransactionParts,
+}
+
+impl WasmZcashTransaction {
+    /// Create from parts (internal use)
+    pub(crate) fn from_parts(parts: crate::zcash::transaction::ZcashTransactionParts) -> Self {
+        WasmZcashTransaction { parts }
+    }
 }
 
 #[wasm_bindgen]
@@ -92,5 +118,27 @@ impl WasmZcashTransaction {
         crate::zcash::transaction::encode_zcash_transaction_parts(&self.parts).map_err(|e| {
             WasmUtxoError::new(&format!("Failed to serialize Zcash transaction: {}", e))
         })
+    }
+
+    /// Get the transaction ID (txid)
+    ///
+    /// The txid is the double SHA256 of the full Zcash transaction bytes,
+    /// displayed in reverse byte order (big-endian) as is standard.
+    ///
+    /// # Returns
+    /// The transaction ID as a hex string
+    ///
+    /// # Errors
+    /// Returns an error if the transaction cannot be serialized
+    pub fn get_txid(&self) -> Result<String, WasmUtxoError> {
+        use miniscript::bitcoin::hashes::{sha256d, Hash};
+        use miniscript::bitcoin::Txid;
+        let tx_bytes = crate::zcash::transaction::encode_zcash_transaction_parts(&self.parts)
+            .map_err(|e| {
+                WasmUtxoError::new(&format!("Failed to serialize Zcash transaction: {}", e))
+            })?;
+        let hash = sha256d::Hash::hash(&tx_bytes);
+        let txid = Txid::from_raw_hash(hash);
+        Ok(txid.to_string())
     }
 }

--- a/packages/wasm-utxo/test/fixedScript/dogecoinLOLAmount.ts
+++ b/packages/wasm-utxo/test/fixedScript/dogecoinLOLAmount.ts
@@ -51,6 +51,6 @@ describe("Dogecoin large output limit amount (LOL amounts) (1-in/1-out)", functi
 
     psbt.finalizeAllInputs();
     const extractedTx = psbt.extractTransaction();
-    assert.ok(extractedTx.length > 0, "expected extracted tx bytes");
+    assert.ok(extractedTx.toBytes().length > 0, "expected extracted tx bytes");
   });
 });

--- a/packages/wasm-utxo/test/fixedScript/psbtReconstruction.ts
+++ b/packages/wasm-utxo/test/fixedScript/psbtReconstruction.ts
@@ -345,6 +345,29 @@ describe("PSBT reconstruction", function () {
           "PSBTs should serialize to identical bytes",
         );
       });
+
+      it("should extract transaction with valid getId() after finalization", function () {
+        // Load fullsigned fixture for this network
+        const fullsignedFixture = loadPsbtFixture(networkName, "fullsigned");
+        const psbt = fixedScriptWallet.BitGoPsbt.fromBytes(
+          getPsbtBuffer(fullsignedFixture),
+          networkName,
+        );
+
+        // Finalize and extract
+        psbt.finalizeAllInputs();
+        const extractedTx = psbt.extractTransaction();
+
+        // Verify getId() returns a valid 64-character hex txid
+        const txid = extractedTx.getId();
+        assert.strictEqual(txid.length, 64, "txid should be 64 characters");
+        assert.match(txid, /^[0-9a-f]{64}$/, "txid should be lowercase hex");
+
+        // Verify unsignedTxid() also returns valid format
+        const unsignedTxid = psbt.unsignedTxid();
+        assert.strictEqual(unsignedTxid.length, 64, "unsignedTxid should be 64 characters");
+        assert.match(unsignedTxid, /^[0-9a-f]{64}$/, "unsignedTxid should be lowercase hex");
+      });
     });
   });
 });


### PR DESCRIPTION

Changes extractTransaction() to return a Transaction object instead of raw
bytes. The transaction object provides additional functionality like getId()
to get the transaction ID directly.

This is a breaking change as the return type changes from Uint8Array to a
Transaction object. Clients need to call toBytes() on the returned object
to get the raw bytes.

BTC-2978