### PR TITLE
fix(wasm-solana): update module documentation

### DIFF
--- a/packages/wasm-solana/js/parser.ts
+++ b/packages/wasm-solana/js/parser.ts
@@ -5,6 +5,7 @@
  * matching BitGoJS's TxData format.
  *
  * All monetary amounts (amount, fee, lamports, poolTokens) are returned as bigint.
+ * Accepts both raw bytes and Transaction objects for convenience.
  */
 
 import { ParserNamespace } from "./wasm/wasm_solana.js";


### PR DESCRIPTION
## Summary
- Add note about accepting Transaction objects in addition to bytes in module doc

This is a trivial change to trigger a new npm publish since the current 1.4.0 package is missing the dist folder.

Ticket: BTC-2988