### PR TITLE
fix(wasm-solana): include pkg/ in artifact upload to preserve dist/ path

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -227,6 +227,7 @@ jobs:
         with:
           name: wasm-solana-build
           path: |
+            packages/wasm-solana/pkg/
             packages/wasm-solana/dist/
           retention-days: 1
 

--- a/packages/wasm-solana/js/parser.ts
+++ b/packages/wasm-solana/js/parser.ts
@@ -18,7 +18,7 @@ import type { VersionedTransaction } from "./versioned.js";
 export type TransactionInput = Uint8Array | Transaction | VersionedTransaction;
 
 // =============================================================================
-// Instruction Types - matching BitGoJS InstructionParams
+// Instruction Types - matching BitGoJS InstructionParams.
 // =============================================================================
 
 /** SOL transfer parameters */


### PR DESCRIPTION
The upload-artifact action uses the least common ancestor of all paths as the artifact root. With only dist/ specified, the artifact structure loses the dist/ prefix, causing files to be extracted to the wrong location during publish.

Adding pkg/ (matching wasm-utxo's pattern) ensures the common ancestor is packages/wasm-solana/, preserving the dist/ directory structure.