### PR TITLE
feat: return undefined instead of magic string for unsigned txid

### DIFF
--- a/packages/wasm-solana/js/transaction.ts
+++ b/packages/wasm-solana/js/transaction.ts
@@ -91,7 +91,7 @@ export class Transaction {
    * Get the transaction ID (first signature as base58).
    *
    * For Solana, the transaction ID is the first signature.
-   * Returns "UNSIGNED" if the transaction has no valid signatures.
+   * Returns `undefined` if the transaction is unsigned (no signatures or all-zeros signature).
    *
    * @example
    * ```typescript
@@ -100,7 +100,7 @@ export class Transaction {
    * console.log(tx.id); // Base58 encoded signature
    * ```
    */
-  get id(): string {
+  get id(): string | undefined {
     return this._wasm.id;
   }
 

--- a/packages/wasm-solana/js/versioned.ts
+++ b/packages/wasm-solana/js/versioned.ts
@@ -172,9 +172,9 @@ export class VersionedTransaction {
    * Get the transaction ID (first signature as base58).
    *
    * For Solana, the transaction ID is the first signature.
-   * Returns "UNSIGNED" if the transaction has no valid signatures.
+   * Returns `undefined` if the transaction is unsigned (no signatures or all-zeros signature).
    */
-  get id(): string {
+  get id(): string | undefined {
     return this.inner.id;
   }
 

--- a/packages/wasm-solana/src/wasm/transaction.rs
+++ b/packages/wasm-solana/src/wasm/transaction.rs
@@ -60,18 +60,18 @@ impl WasmTransaction {
     /// Get the transaction ID (first signature as base58).
     ///
     /// For Solana, the transaction ID is the first signature.
-    /// Returns "UNSIGNED" if the first signature is all zeros (unsigned transaction).
+    /// Returns `undefined` if the transaction is unsigned (no signatures or all-zeros signature).
     #[wasm_bindgen(getter)]
-    pub fn id(&self) -> String {
+    pub fn id(&self) -> Option<String> {
         if let Some(sig) = self.inner.signatures.first() {
             let bytes: &[u8] = sig.as_ref();
             // Check if signature is all zeros (unsigned)
             if bytes.iter().all(|&b| b == 0) {
-                return "UNSIGNED".to_string();
+                return None;
             }
-            bs58::encode(bytes).into_string()
+            Some(bs58::encode(bytes).into_string())
         } else {
-            "UNSIGNED".to_string()
+            None
         }
     }
 
@@ -270,18 +270,18 @@ impl WasmVersionedTransaction {
     /// Get the transaction ID (first signature as base58).
     ///
     /// For Solana, the transaction ID is the first signature.
-    /// Returns "UNSIGNED" if the first signature is all zeros (unsigned transaction).
+    /// Returns `undefined` if the transaction is unsigned (no signatures or all-zeros signature).
     #[wasm_bindgen(getter)]
-    pub fn id(&self) -> String {
+    pub fn id(&self) -> Option<String> {
         if let Some(sig) = self.inner.signatures.first() {
             let bytes: &[u8] = sig.as_ref();
             // Check if signature is all zeros (unsigned)
             if bytes.iter().all(|&b| b == 0) {
-                return "UNSIGNED".to_string();
+                return None;
             }
-            bs58::encode(bytes).into_string()
+            Some(bs58::encode(bytes).into_string())
         } else {
-            "UNSIGNED".to_string()
+            None
         }
     }
 

--- a/packages/wasm-solana/test/transaction.ts
+++ b/packages/wasm-solana/test/transaction.ts
@@ -127,10 +127,10 @@ describe("Transaction", () => {
   });
 
   describe("id getter", () => {
-    it("should return UNSIGNED for unsigned transaction", () => {
+    it("should return undefined for unsigned transaction", () => {
       const tx = Transaction.fromBytes(TEST_TX_BYTES);
       // The test transaction has an all-zeros signature (unsigned)
-      assert.strictEqual(tx.id, "UNSIGNED");
+      assert.strictEqual(tx.id, undefined);
     });
 
     it("should return base58 signature after signing", () => {
@@ -144,8 +144,8 @@ describe("Transaction", () => {
 
       // ID should now be a base58-encoded string of the signature
       const id = tx.id;
-      assert.notStrictEqual(id, "UNSIGNED");
-      assert.ok(id.length > 20); // base58 encoded 64 bytes should be ~80+ chars
+      assert.notStrictEqual(id, undefined);
+      assert.ok(id && id.length > 20); // base58 encoded 64 bytes should be ~80+ chars
     });
   });
 

--- a/packages/wasm-solana/test/versioned.ts
+++ b/packages/wasm-solana/test/versioned.ts
@@ -94,11 +94,11 @@ describe("VersionedTransaction", () => {
   });
 
   describe("id getter", () => {
-    it("should return UNSIGNED for unsigned transaction", () => {
+    it("should return undefined for unsigned transaction", () => {
       const bytes = Buffer.from(LEGACY_TX_BASE64, "base64");
       const tx = VersionedTransaction.fromBytes(bytes);
       // The test transaction has an all-zeros signature (unsigned)
-      assert.strictEqual(tx.id, "UNSIGNED");
+      assert.strictEqual(tx.id, undefined);
     });
 
     it("should return base58 signature after signing", () => {
@@ -113,8 +113,8 @@ describe("VersionedTransaction", () => {
 
       // ID should now be a base58-encoded string of the signature
       const id = tx.id;
-      assert.notStrictEqual(id, "UNSIGNED");
-      assert.ok(id.length > 20); // base58 encoded 64 bytes should be ~80+ chars
+      assert.notStrictEqual(id, undefined);
+      assert.ok(id && id.length > 20); // base58 encoded 64 bytes should be ~80+ chars
     });
   });
 });


### PR DESCRIPTION
Change Transaction.id and VersionedTransaction.id to return `undefined` (Option<String> in Rust) when the transaction is unsigned, instead of the magic string "UNSIGNED".

This is a cleaner API that:
- Forces callers to handle the unsigned case via type system
- Is semantically clearer (undefined = doesn't exist yet)
- Allows proper null checks instead of string comparison

Ticket: BTC-3017