### PR TITLE
feat: support enableToken intent with token address arrays

### DIFF
--- a/packages/wasm-solana/package.json
+++ b/packages/wasm-solana/package.json
@@ -9,9 +9,7 @@
   },
   "license": "MIT",
   "files": [
-    "dist/esm/js/**/*",
-    "dist/cjs/js/**/*",
-    "dist/cjs/package.json"
+    "dist"
   ],
   "exports": {
     ".": {

--- a/packages/wasm-solana/src/intent/types.rs
+++ b/packages/wasm-solana/src/intent/types.rs
@@ -233,16 +233,25 @@ pub struct DelegateIntent {
 }
 
 /// Enable token intent (create ATA)
+/// Supports both single token (tokenAddress) and multiple tokens (tokenAddresses array)
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct EnableTokenIntent {
     pub intent_type: String,
     #[serde(default)]
     pub recipient_address: Option<String>,
+    /// Single token address (legacy format)
     #[serde(default)]
     pub token_address: Option<String>,
+    /// Multiple token addresses (array format from wallet-platform)
+    #[serde(default)]
+    pub token_addresses: Option<Vec<String>>,
+    /// Single token program ID (legacy format)
     #[serde(default)]
     pub token_program_id: Option<String>,
+    /// Multiple token program IDs (array format, parallel to token_addresses)
+    #[serde(default)]
+    pub token_program_ids: Option<Vec<String>>,
     #[serde(default)]
     pub memo: Option<String>,
 }

--- a/packages/wasm-solana/test/intentBuilder.ts
+++ b/packages/wasm-solana/test/intentBuilder.ts
@@ -259,6 +259,43 @@ describe("buildFromIntent", function () {
       );
       assert(createAta, "Should have CreateAssociatedTokenAccount instruction");
     });
+
+    it("should build enableToken with multiple tokens (tokenAddresses array)", function () {
+      const intent = {
+        intentType: "enableToken",
+        tokenAddresses: [
+          "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v", // USDC
+          "SRMuApVNdxXokk5GT7XD5cUUgXMBCoAz2LHeuAoKWRt", // SRM
+          "orcaEKTdK7LKz57vaAYr9QeNsVEPfiu6QeMU1kektZE", // ORCA
+        ],
+        tokenProgramIds: [
+          "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+          "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+          "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+        ],
+        recipientAddress: feePayer,
+      };
+
+      const result = buildFromIntent(intent, {
+        feePayer,
+        nonce: { type: "blockhash", value: blockhash },
+      });
+
+      assert(result.transaction instanceof Transaction, "Should return Transaction object");
+      assert.equal(result.generatedKeypairs.length, 0, "Should not generate keypairs");
+
+      // Verify instructions
+      const parsed = parseTransaction(result.transaction.toBytes());
+
+      const createAtaInstructions = parsed.instructionsData.filter(
+        (i: any) => i.type === "CreateAssociatedTokenAccount",
+      );
+      assert.equal(
+        createAtaInstructions.length,
+        3,
+        "Should have 3 CreateAssociatedTokenAccount instructions",
+      );
+    });
   });
 
   describe("closeAssociatedTokenAccount intent", function () {


### PR DESCRIPTION
- Update EnableTokenIntent to accept token_addresses and token_program_ids arrays
- Update build_enable_token to iterate arrays and create one ATA instruction per token
- Maintains backward compatibility with single tokenAddress format