### PR TITLE
feat(wasm-utxo): add and simplify PSBT transaction extraction

### DIFF
--- a/packages/wasm-utxo/js/fixedScriptWallet/BitGoPsbt.ts
+++ b/packages/wasm-utxo/js/fixedScriptWallet/BitGoPsbt.ts
@@ -766,14 +766,16 @@ export class BitGoPsbt {
    */
   extractTransaction(): ITransaction {
     const networkType = this._wasm.get_network_type();
+    const wasm: unknown = this._wasm.extract_transaction();
 
-    if (networkType === "dash") {
-      return DashTransaction.fromWasm(this._wasm.extract_dash_transaction());
+    switch (networkType) {
+      case "dash":
+        return DashTransaction.fromWasm(wasm as Parameters<typeof DashTransaction.fromWasm>[0]);
+      case "zcash":
+        return ZcashTransaction.fromWasm(wasm as Parameters<typeof ZcashTransaction.fromWasm>[0]);
+      default:
+        return Transaction.fromWasm(wasm as Parameters<typeof Transaction.fromWasm>[0]);
     }
-    if (networkType === "zcash") {
-      return ZcashTransaction.fromWasm(this._wasm.extract_zcash_transaction());
-    }
-    return Transaction.fromWasm(this._wasm.extract_bitcoin_transaction());
   }
 
   /**

--- a/packages/wasm-utxo/js/index.ts
+++ b/packages/wasm-utxo/js/index.ts
@@ -111,6 +111,9 @@ declare module "./wasm/wasm_utxo.js" {
     validateSignatureAtInput(inputIndex: number, pubkey: Uint8Array): boolean;
     verifySignatureWithKey(inputIndex: number, key: WasmBIP32): boolean;
 
+    // Extraction methods
+    extractTransaction(): WasmTransaction;
+
     // Metadata methods
     unsignedTxId(): string;
     lockTime(): number;

--- a/packages/wasm-utxo/src/wasm/psbt.rs
+++ b/packages/wasm-utxo/src/wasm/psbt.rs
@@ -521,6 +521,25 @@ impl WrapPsbt {
             })
     }
 
+    /// Extract the final transaction from a finalized PSBT
+    ///
+    /// This method should be called after all inputs have been finalized.
+    /// It extracts the fully signed transaction as a WasmTransaction instance.
+    ///
+    /// # Returns
+    /// - `Ok(WasmTransaction)` containing the extracted transaction
+    /// - `Err(WasmUtxoError)` if the PSBT is not fully finalized or extraction fails
+    #[wasm_bindgen(js_name = extractTransaction)]
+    pub fn extract_transaction(
+        &self,
+    ) -> Result<crate::wasm::transaction::WasmTransaction, WasmUtxoError> {
+        let tx =
+            self.0.clone().extract_tx().map_err(|e| {
+                WasmUtxoError::new(&format!("Failed to extract transaction: {}", e))
+            })?;
+        Ok(crate::wasm::transaction::WasmTransaction::from_tx(tx))
+    }
+
     /// Get the number of inputs in the PSBT
     #[wasm_bindgen(js_name = inputCount)]
     pub fn input_count(&self) -> usize {


### PR DESCRIPTION

This PR adds transaction extraction functionality to the WASM UTXO module and 
simplifies the extraction API through refactoring.

Key changes:
- Add extractTransaction method to WrapPsbt for converting a finalized PSBT 
  into a transaction object
- Include TypeScript bindings for the new functionality
- Add comprehensive tests to verify extraction works with different script types
- Refactor BitGoPsbt.extractTransaction to use a single unified method in both 
  Rust and TypeScript
- Simplify the implementation to handle all network types with a single call 
  rather than using separate methods per network type

Issue: BTC-2980