### PR TITLE
feat(wasm-utxo): fix coinName function exports

### DIFF
--- a/packages/wasm-utxo/js/index.ts
+++ b/packages/wasm-utxo/js/index.ts
@@ -21,7 +21,7 @@ export { ECPair } from "./ecpair.js";
 export { BIP32 } from "./bip32.js";
 export { Dimensions } from "./fixedScriptWallet/Dimensions.js";
 
-export type { CoinName, getMainnet, isMainnet, isTestnet, isCoinName } from "./coinName.js";
+export { type CoinName, getMainnet, isMainnet, isTestnet, isCoinName } from "./coinName.js";
 export type { Triple } from "./triple.js";
 export type { AddressFormat } from "./address.js";
 export type { TapLeafScript, PreparedInscriptionRevealData } from "./inscriptions.js";


### PR DESCRIPTION

Export coinName helper functions correctly as values rather than types.
This ensures they can be called in client code.

The `export type { ... }` syntax is a bit of a footgun.

Issue: BTC-2650