### PR TITLE
feat(wasm-utxo): add PSBT introspection methods

### DIFF
--- a/packages/wasm-utxo/js/fixedScriptWallet/index.ts
+++ b/packages/wasm-utxo/js/fixedScriptWallet/index.ts
@@ -37,6 +37,15 @@ export {
   type CreateEmptyZcashOptions,
 } from "./ZcashBitGoPsbt.js";
 
+// PSBT introspection types (re-exported for consumer convenience)
+export type {
+  PsbtBip32Derivation,
+  PsbtInputData,
+  PsbtOutputData,
+  PsbtOutputDataWithAddress,
+  PsbtWitnessUtxo,
+} from "../wasm/wasm_utxo.js";
+
 import type { ScriptType } from "./scriptType.js";
 
 /**

--- a/packages/wasm-utxo/js/index.ts
+++ b/packages/wasm-utxo/js/index.ts
@@ -130,4 +130,8 @@ export { WrapDescriptor as Descriptor } from "./wasm/wasm_utxo.js";
 export { WrapMiniscript as Miniscript } from "./wasm/wasm_utxo.js";
 export { WrapPsbt as Psbt } from "./wasm/wasm_utxo.js";
 export { DashTransaction, Transaction, ZcashTransaction } from "./transaction.js";
-export { hasPsbtMagic } from "./psbt.js";
+export {
+  hasPsbtMagic,
+  type IPsbtIntrospection,
+  type IPsbtIntrospectionWithAddress,
+} from "./psbt.js";

--- a/packages/wasm-utxo/js/psbt.ts
+++ b/packages/wasm-utxo/js/psbt.ts
@@ -1,3 +1,18 @@
+import type { PsbtInputData, PsbtOutputData, PsbtOutputDataWithAddress } from "./wasm/wasm_utxo.js";
+
+/** Common interface for PSBT introspection methods */
+export interface IPsbtIntrospection {
+  readonly inputCount: number;
+  readonly outputCount: number;
+  getInputs(): PsbtInputData[];
+  getOutputs(): PsbtOutputData[];
+}
+
+/** Extended introspection with address resolution (no coin parameter needed) */
+export interface IPsbtIntrospectionWithAddress extends IPsbtIntrospection {
+  getOutputsWithAddress(): PsbtOutputDataWithAddress[];
+}
+
 /** PSBT magic bytes: "psbt" (0x70 0x73 0x62 0x74) followed by separator 0xff */
 const PSBT_MAGIC = new Uint8Array([0x70, 0x73, 0x62, 0x74, 0xff]);
 

--- a/packages/wasm-utxo/src/wasm/fixed_script_wallet/mod.rs
+++ b/packages/wasm-utxo/src/wasm/fixed_script_wallet/mod.rs
@@ -628,6 +628,40 @@ impl BitGoPsbt {
         }
     }
 
+    /// Get the number of inputs in the PSBT
+    pub fn input_count(&self) -> usize {
+        self.psbt.psbt().inputs.len()
+    }
+
+    /// Get the number of outputs in the PSBT
+    pub fn output_count(&self) -> usize {
+        self.psbt.psbt().outputs.len()
+    }
+
+    /// Get all PSBT inputs as an array of PsbtInputData
+    ///
+    /// Returns an array with witness_utxo, bip32_derivation, and tap_bip32_derivation
+    /// for each input.
+    pub fn get_inputs(&self) -> Result<JsValue, WasmUtxoError> {
+        crate::wasm::psbt::get_inputs_from_psbt(self.psbt.psbt())
+    }
+
+    /// Get all PSBT outputs as an array of PsbtOutputData
+    ///
+    /// Returns an array with script, value, bip32_derivation, and tap_bip32_derivation
+    /// for each output.
+    pub fn get_outputs(&self) -> Result<JsValue, WasmUtxoError> {
+        crate::wasm::psbt::get_outputs_from_psbt(self.psbt.psbt())
+    }
+
+    /// Get all PSBT outputs with resolved address strings.
+    ///
+    /// Unlike the generic WrapPsbt which requires a coin parameter, BitGoPsbt
+    /// uses the network it was created/deserialized with to resolve addresses.
+    pub fn get_outputs_with_address(&self) -> Result<JsValue, WasmUtxoError> {
+        crate::wasm::psbt::get_outputs_with_address_from_psbt(self.psbt.psbt(), self.psbt.network())
+    }
+
     /// Parse transaction with wallet keys to identify wallet inputs/outputs
     pub fn parse_transaction_with_wallet_keys(
         &self,


### PR DESCRIPTION

Adds introspection methods to BitGoPsbt class to examine inputs/outputs:
- getInputs() and getOutputs() for raw PSBT data
- getOutputsWithAddress() for outputs with resolved addresses
- inputCount and outputCount properties
- Shared implementation with WrapPsbt for code reuse
- Added interfaces for PSBT introspection

Issue: BTC-2650