### PR TITLE
feat(wasm-solana): add Native StakingType and make StakePoolConfig fi…

### DIFF
--- a/packages/wasm-solana/src/intent/build.rs
+++ b/packages/wasm-solana/src/intent/build.rs
@@ -226,7 +226,7 @@ fn build_stake(
             system_ix::create_account(
                 &fee_payer,
                 &stake_pubkey,
-                amount + STAKE_ACCOUNT_RENT,
+                amount,
                 STAKE_ACCOUNT_SPACE,
                 &solana_stake_interface::program::ID,
             ),

--- a/packages/wasm-solana/src/intent/build.rs
+++ b/packages/wasm-solana/src/intent/build.rs
@@ -300,6 +300,8 @@ fn build_jito_stake(
         .map_err(|_| WasmSolanaError::new("Invalid withdrawAuthority"))?;
     let reserve_stake: Pubkey = config
         .reserve_stake
+        .as_ref()
+        .ok_or_else(|| WasmSolanaError::new("Missing reserveStake"))?
         .parse()
         .map_err(|_| WasmSolanaError::new("Invalid reserveStake"))?;
     let destination_pool_account: Pubkey = config
@@ -310,6 +312,8 @@ fn build_jito_stake(
         .map_err(|_| WasmSolanaError::new("Invalid destinationPoolAccount"))?;
     let manager_fee_account: Pubkey = config
         .manager_fee_account
+        .as_ref()
+        .ok_or_else(|| WasmSolanaError::new("Missing managerFeeAccount"))?
         .parse()
         .map_err(|_| WasmSolanaError::new("Invalid managerFeeAccount"))?;
     let referral_pool_account: Pubkey = config
@@ -323,8 +327,10 @@ fn build_jito_stake(
         .map_err(|_| WasmSolanaError::new("Invalid referralPoolAccount"))?;
     let pool_mint: Pubkey = config
         .pool_mint
+        .as_ref()
+        .ok_or_else(|| WasmSolanaError::new("Missing poolMint"))?
         .parse()
-        .map_err(|_| WasmSolanaError::new(&format!("Invalid poolMint: {}", config.pool_mint)))?;
+        .map_err(|_| WasmSolanaError::new("Invalid poolMint"))?;
 
     // Build instruction data
     let instruction_data = StakePoolInstruction::DepositSol(amount);
@@ -541,10 +547,14 @@ fn build_jito_unstake(
         .map_err(|_| WasmSolanaError::new("Invalid sourcePoolAccount"))?;
     let manager_fee_account: Pubkey = config
         .manager_fee_account
+        .as_ref()
+        .ok_or_else(|| WasmSolanaError::new("Missing managerFeeAccount"))?
         .parse()
         .map_err(|_| WasmSolanaError::new("Invalid managerFeeAccount"))?;
     let pool_mint: Pubkey = config
         .pool_mint
+        .as_ref()
+        .ok_or_else(|| WasmSolanaError::new("Missing poolMint"))?
         .parse()
         .map_err(|_| WasmSolanaError::new("Invalid poolMint"))?;
 

--- a/packages/wasm-solana/src/intent/types.rs
+++ b/packages/wasm-solana/src/intent/types.rs
@@ -26,6 +26,7 @@ pub enum IntentType {
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum StakingType {
+    Native,
     Jito,
     Marinade,
 }
@@ -189,13 +190,16 @@ pub struct StakePoolConfig {
     pub stake_pool_address: Option<String>,
     #[serde(default)]
     pub withdraw_authority: Option<String>,
-    pub reserve_stake: String,
+    #[serde(default)]
+    pub reserve_stake: Option<String>,
     #[serde(default)]
     pub destination_pool_account: Option<String>,
-    pub manager_fee_account: String,
+    #[serde(default)]
+    pub manager_fee_account: Option<String>,
     #[serde(default)]
     pub referral_pool_account: Option<String>,
-    pub pool_mint: String,
+    #[serde(default)]
+    pub pool_mint: Option<String>,
     #[serde(default)]
     pub validator_list: Option<String>,
     #[serde(default)]


### PR DESCRIPTION
…elds optional

Add Native variant to StakingType enum so WASM can handle native staking intents that pass stakingType: "NATIVE". Make StakePoolConfig fields (reserveStake, managerFeeAccount, poolMint) optional since not all staking contexts provide every field.

BTC-3025