### PR TITLE
feat(wasm-solana): complete Jito stake/unstake and sign generated key…

### DIFF
--- a/packages/wasm-solana/js/intentBuilder.ts
+++ b/packages/wasm-solana/js/intentBuilder.ts
@@ -267,6 +267,11 @@ export function buildFromIntent(
 ): BuildFromIntentResult {
   const result = IntentNamespace.build_from_intent(intent, params) as WasmBuildResult;
 
+  // Generated keypair signing happens in Rust (build_from_intent signs
+  // before returning). Signatures survive the wasm-bindgen boundary
+  // because WasmTransaction is a heap-allocated Rust object that JS
+  // holds a handle to — no serialization round-trip.
+
   return {
     transaction: Transaction.fromWasm(result.transaction),
     generatedKeypairs: result.generatedKeypairs,

--- a/packages/wasm-solana/js/keypair.ts
+++ b/packages/wasm-solana/js/keypair.ts
@@ -70,6 +70,15 @@ export class Keypair {
   }
 
   /**
+   * Sign a message with this keypair
+   * @param message - The message bytes to sign
+   * @returns The 64-byte Ed25519 signature
+   */
+  sign(message: Uint8Array): Uint8Array {
+    return this._wasm.sign(message);
+  }
+
+  /**
    * Get the underlying WASM instance (internal use only)
    * @internal
    */

--- a/packages/wasm-solana/js/transaction.ts
+++ b/packages/wasm-solana/js/transaction.ts
@@ -225,6 +225,18 @@ export class Transaction {
   }
 
   /**
+   * Sign this transaction with a base58-encoded Ed25519 secret key.
+   *
+   * Derives the public key from the secret, signs the transaction message,
+   * and places the signature at the correct signer index.
+   *
+   * @param secretKeyBase58 - The Ed25519 secret key (32-byte seed) as base58
+   */
+  signWithSecretKey(secretKeyBase58: string): void {
+    this._wasm.sign_with_secret_key(secretKeyBase58);
+  }
+
+  /**
    * Get the underlying WASM instance (internal use only)
    * @internal
    */

--- a/packages/wasm-solana/src/instructions/decode.rs
+++ b/packages/wasm-solana/src/instructions/decode.rs
@@ -1,6 +1,7 @@
 //! Instruction decoding using official Solana interface crates.
 
 use super::types::*;
+use crate::intent::AuthorizeType;
 use solana_compute_budget_interface::ComputeBudgetInstruction;
 use solana_stake_interface::instruction::StakeInstruction;
 use solana_system_interface::instruction::SystemInstruction;
@@ -155,8 +156,10 @@ fn decode_stake_instruction(ctx: InstructionContext) -> ParsedInstruction {
             // Accounts: [0] stake, [1] clock, [2] authority, [3] optional custodian
             if ctx.accounts.len() >= 3 {
                 let auth_type = match stake_authorize {
-                    solana_stake_interface::state::StakeAuthorize::Staker => "Staker",
-                    solana_stake_interface::state::StakeAuthorize::Withdrawer => "Withdrawer",
+                    solana_stake_interface::state::StakeAuthorize::Staker => AuthorizeType::Staker,
+                    solana_stake_interface::state::StakeAuthorize::Withdrawer => {
+                        AuthorizeType::Withdrawer
+                    }
                 };
                 let custodian = if ctx.accounts.len() >= 4 {
                     Some(ctx.accounts[3].clone())
@@ -167,7 +170,7 @@ fn decode_stake_instruction(ctx: InstructionContext) -> ParsedInstruction {
                     staking_address: ctx.accounts[0].clone(),
                     old_authorize_address: ctx.accounts[2].clone(),
                     new_authorize_address: new_authority.to_string(),
-                    authorize_type: auth_type.to_string(),
+                    authorize_type: auth_type,
                     custodian_address: custodian,
                 })
             } else {
@@ -178,8 +181,10 @@ fn decode_stake_instruction(ctx: InstructionContext) -> ParsedInstruction {
             // Accounts: [0] stake, [1] clock, [2] authority, [3] new_authority (signer), [4] optional custodian
             if ctx.accounts.len() >= 4 {
                 let auth_type = match stake_authorize {
-                    solana_stake_interface::state::StakeAuthorize::Staker => "Staker",
-                    solana_stake_interface::state::StakeAuthorize::Withdrawer => "Withdrawer",
+                    solana_stake_interface::state::StakeAuthorize::Staker => AuthorizeType::Staker,
+                    solana_stake_interface::state::StakeAuthorize::Withdrawer => {
+                        AuthorizeType::Withdrawer
+                    }
                 };
                 let custodian = if ctx.accounts.len() >= 5 {
                     Some(ctx.accounts[4].clone())
@@ -190,7 +195,7 @@ fn decode_stake_instruction(ctx: InstructionContext) -> ParsedInstruction {
                     staking_address: ctx.accounts[0].clone(),
                     old_authorize_address: ctx.accounts[2].clone(),
                     new_authorize_address: ctx.accounts[3].clone(),
-                    authorize_type: auth_type.to_string(),
+                    authorize_type: auth_type,
                     custodian_address: custodian,
                 })
             } else {

--- a/packages/wasm-solana/src/instructions/try_into_js_value.rs
+++ b/packages/wasm-solana/src/instructions/try_into_js_value.rs
@@ -9,6 +9,43 @@ use base64::prelude::*;
 use wasm_bindgen::JsValue;
 
 use super::types::*;
+use crate::intent::{AuthorizeType, KeypairPurpose, StakingType};
+
+// =============================================================================
+// Enum → JS string conversions
+// =============================================================================
+
+impl TryIntoJsValue for StakingType {
+    fn try_to_js_value(&self) -> Result<JsValue, JsConversionError> {
+        let s = match self {
+            StakingType::Native => "NATIVE",
+            StakingType::Jito => "JITO",
+            StakingType::Marinade => "MARINADE",
+        };
+        Ok(JsValue::from_str(s))
+    }
+}
+
+impl TryIntoJsValue for AuthorizeType {
+    fn try_to_js_value(&self) -> Result<JsValue, JsConversionError> {
+        let s = match self {
+            AuthorizeType::Staker => "Staker",
+            AuthorizeType::Withdrawer => "Withdrawer",
+        };
+        Ok(JsValue::from_str(s))
+    }
+}
+
+impl TryIntoJsValue for KeypairPurpose {
+    fn try_to_js_value(&self) -> Result<JsValue, JsConversionError> {
+        let s = match self {
+            KeypairPurpose::StakeAccount => "stakeAccount",
+            KeypairPurpose::UnstakeAccount => "unstakeAccount",
+            KeypairPurpose::TransferAuthority => "transferAuthority",
+        };
+        Ok(JsValue::from_str(s))
+    }
+}
 
 // =============================================================================
 // System Program Params

--- a/packages/wasm-solana/src/instructions/types.rs
+++ b/packages/wasm-solana/src/instructions/types.rs
@@ -124,7 +124,7 @@ pub struct StakingActivateParams {
     pub staking_address: String,
     pub amount: u64,
     pub validator: String,
-    pub staking_type: String, // "NATIVE", "JITO", "MARINADE"
+    pub staking_type: crate::intent::StakingType,
 }
 
 #[derive(Debug, Clone)]
@@ -152,7 +152,7 @@ pub struct StakingAuthorizeParams {
     pub staking_address: String,
     pub old_authorize_address: String,
     pub new_authorize_address: String,
-    pub authorize_type: String, // "Staker" or "Withdrawer"
+    pub authorize_type: crate::intent::AuthorizeType,
     pub custodian_address: Option<String>,
 }
 

--- a/packages/wasm-solana/src/intent/types.rs
+++ b/packages/wasm-solana/src/intent/types.rs
@@ -65,12 +65,28 @@ pub struct IntentBuildResult {
     pub generated_keypairs: Vec<GeneratedKeypair>,
 }
 
+/// Purpose of a generated keypair.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum KeypairPurpose {
+    StakeAccount,
+    UnstakeAccount,
+    TransferAuthority,
+}
+
+/// Authorize type for stake account authority changes.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AuthorizeType {
+    Staker,
+    Withdrawer,
+}
+
 /// A keypair generated during transaction building.
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GeneratedKeypair {
     /// Purpose of this keypair
-    pub purpose: String,
+    pub purpose: KeypairPurpose,
     /// Public address (base58)
     pub address: String,
     /// Secret key (base58)
@@ -204,6 +220,9 @@ pub struct StakePoolConfig {
     pub validator_list: Option<String>,
     #[serde(default)]
     pub source_pool_account: Option<String>,
+    /// Whether to create an ATA for the pool mint before depositing (Jito staking)
+    #[serde(default)]
+    pub create_associated_token_account: Option<bool>,
 }
 
 /// Unstake intent

--- a/packages/wasm-solana/src/wasm/keypair.rs
+++ b/packages/wasm-solana/src/wasm/keypair.rs
@@ -60,6 +60,17 @@ impl WasmKeypair {
     pub fn to_base58(&self) -> String {
         self.inner.address()
     }
+
+    /// Sign a message with this keypair and return the 64-byte Ed25519 signature.
+    ///
+    /// @param message - The message bytes to sign
+    /// @returns The 64-byte signature as a Uint8Array
+    #[wasm_bindgen]
+    pub fn sign(&self, message: &[u8]) -> js_sys::Uint8Array {
+        use solana_signer::Signer;
+        let sig = self.inner.sign_message(message);
+        js_sys::Uint8Array::from(sig.as_ref())
+    }
 }
 
 impl WasmKeypair {


### PR DESCRIPTION
…pairs in Rust

Jito staking:
- Add ATA creation support (createAssociatedTokenAccount field)
- Derive withdraw authority PDA, destination/source pool accounts, and referral pool account when not explicitly provided
- Use validatorAddress as fallback for stakePoolAddress

Jito unstaking:
- Build full 4-instruction pattern: Approve, CreateAccount, WithdrawStake, Deactivate (matches legacy SDK behavior)
- Build SPL Token Approve instruction manually to avoid spl-token v6/v3 type incompatibility

Generated keypair signing:
- Sign generated keypairs (stake/unstake accounts) in Rust inside build_from_intent before returning to JS
- Signatures survive the wasm-bindgen boundary because WasmTransaction is a heap-allocated Rust object that JS holds a handle to
- Add sign_with_secret_key to WasmTransaction and sign to WasmKeypair for use by other callers

BTC-3025