### PR TITLE
refactor: address PR #160 review feedback

### DIFF
--- a/packages/wasm-solana/js/keypair.ts
+++ b/packages/wasm-solana/js/keypair.ts
@@ -62,14 +62,6 @@ export class Keypair {
   }
 
   /**
-   * Get the public key as a base58 string
-   * @returns The public key as a base58 string
-   */
-  toBase58(): string {
-    return this._wasm.to_base58();
-  }
-
-  /**
    * Sign a message with this keypair
    * @param message - The message bytes to sign
    * @returns The 64-byte Ed25519 signature

--- a/packages/wasm-solana/js/transaction.ts
+++ b/packages/wasm-solana/js/transaction.ts
@@ -1,4 +1,5 @@
 import { WasmTransaction } from "./wasm/wasm_solana.js";
+import { Keypair } from "./keypair.js";
 import { Pubkey } from "./pubkey.js";
 
 /**
@@ -225,15 +226,15 @@ export class Transaction {
   }
 
   /**
-   * Sign this transaction with a base58-encoded Ed25519 secret key.
+   * Sign this transaction with a Keypair.
    *
-   * Derives the public key from the secret, signs the transaction message,
-   * and places the signature at the correct signer index.
+   * Signs the transaction message and places the signature at the correct
+   * signer index.
    *
-   * @param secretKeyBase58 - The Ed25519 secret key (32-byte seed) as base58
+   * @param keypair - A Keypair instance
    */
-  signWithSecretKey(secretKeyBase58: string): void {
-    this._wasm.sign_with_secret_key(secretKeyBase58);
+  signWithKeypair(keypair: Keypair): void {
+    this._wasm.sign_with_keypair(keypair.wasm);
   }
 
   /**

--- a/packages/wasm-solana/src/instructions/try_into_js_value.rs
+++ b/packages/wasm-solana/src/instructions/try_into_js_value.rs
@@ -15,6 +15,7 @@ use crate::intent::{AuthorizeType, KeypairPurpose, StakingType};
 // Enum → JS string conversions
 // =============================================================================
 
+// UPPER_CASE: matches BitGo platform enum format
 impl TryIntoJsValue for StakingType {
     fn try_to_js_value(&self) -> Result<JsValue, JsConversionError> {
         let s = match self {
@@ -26,6 +27,7 @@ impl TryIntoJsValue for StakingType {
     }
 }
 
+// PascalCase: matches Solana SDK StakeAuthorize variant names
 impl TryIntoJsValue for AuthorizeType {
     fn try_to_js_value(&self) -> Result<JsValue, JsConversionError> {
         let s = match self {
@@ -36,6 +38,7 @@ impl TryIntoJsValue for AuthorizeType {
     }
 }
 
+// camelCase: matches JS/TS field naming convention
 impl TryIntoJsValue for KeypairPurpose {
     fn try_to_js_value(&self) -> Result<JsValue, JsConversionError> {
         let s = match self {

--- a/packages/wasm-solana/src/wasm/keypair.rs
+++ b/packages/wasm-solana/src/wasm/keypair.rs
@@ -55,12 +55,6 @@ impl WasmKeypair {
         self.inner.address()
     }
 
-    /// Get the public key as a base58 string.
-    #[wasm_bindgen]
-    pub fn to_base58(&self) -> String {
-        self.inner.address()
-    }
-
     /// Sign a message with this keypair and return the 64-byte Ed25519 signature.
     ///
     /// @param message - The message bytes to sign


### PR DESCRIPTION
- Replace signWithSecretKey(string) with signWithKeypair(Keypair) for type safety and to avoid needless base58 decoding at the call site
- Remove duplicate toBase58() from Keypair (identical to getAddress())
- Add comments explaining casing conventions in enum JS conversions

BTC-3025