### PR TITLE
feat: download wasm-mps build artifacts in publish workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -42,6 +42,12 @@ jobs:
           name: wasm-solana-build
           path: packages/wasm-solana/
 
+      - name: Download wasm-mps build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: wasm-mps-build
+          path: packages/wasm-mps/
+
       - name: Setup Node
         uses: actions/setup-node@v4
         with:

--- a/packages/wasm-mps/src/lib.rs
+++ b/packages/wasm-mps/src/lib.rs
@@ -52,7 +52,7 @@ mod mps {
     }
 
     /// Process round 0 of protocol.
-    /// party_id: Party indentifier / index.
+    /// party_id: Party identifier / index.
     /// decryption_key: Private Curve25519 key.
     /// encryption_keys: Public Curve25519 keys of other parties.
     /// seed: PRNG seed for entropy.


### PR DESCRIPTION
The publish workflow was missing the download step for wasm-mps-build artifacts, causing npm publish to only include README.md and package.json (since dist/ didn't exist). Also fixes a typo in lib.rs doc comment.