### PR TITLE
refactor: align wasm-solana with wasm-utxo parse conventions

### DIFF
--- a/packages/wasm-solana/js/explain.ts
+++ b/packages/wasm-solana/js/explain.ts
@@ -9,7 +9,7 @@
  * overall transaction type.
  */
 
-import { parseTransactionData } from "./parser.js";
+import { parseTransaction } from "./parser.js";
 import type { InstructionParams, ParsedTransaction } from "./parser.js";
 
 // =============================================================================
@@ -238,7 +238,7 @@ export function explainTransaction(
 ): ExplainedTransaction {
   const { lamportsPerSignature, tokenAccountRentExemptAmount } = options;
 
-  const parsed: ParsedTransaction = parseTransactionData(input);
+  const parsed: ParsedTransaction = parseTransaction(input);
 
   // --- Transaction ID ---
   const id = extractTransactionId(parsed.signatures);

--- a/packages/wasm-solana/js/index.ts
+++ b/packages/wasm-solana/js/index.ts
@@ -21,49 +21,10 @@ export { VersionedTransaction, isVersionedTransaction } from "./versioned.js";
 export type { AddressLookupTableData } from "./versioned.js";
 
 // Top-level function exports
-export { parseTransactionData } from "./parser.js";
+export { parseTransaction } from "./parser.js";
 export { buildFromVersionedData } from "./builder.js";
 export { buildFromIntent, buildFromIntent as buildTransactionFromIntent } from "./intentBuilder.js";
 export { explainTransaction, TransactionType } from "./explain.js";
-
-// Re-export Transaction import for parseTransaction
-import { Transaction as _Transaction } from "./transaction.js";
-
-/**
- * Parse a Solana transaction from raw bytes.
- *
- * Returns a `Transaction` instance that can be both inspected and signed.
- * Use `.parse()` on the returned Transaction to get decoded instruction data.
- *
- * This is the single entry point for working with transactions — like
- * `BitGoPsbt.fromBytes()` in wasm-utxo.
- *
- * @param bytes - Raw transaction bytes
- * @returns A Transaction that can be inspected (`.parse()`) and signed (`.addSignature()`)
- *
- * @example
- * ```typescript
- * import { parseTransaction } from '@bitgo/wasm-solana';
- *
- * const tx = parseTransaction(txBytes);
- *
- * // Inspect
- * const parsed = tx.parse();
- * console.log(parsed.feePayer);
- * for (const instr of parsed.instructionsData) {
- *   if (instr.type === 'Transfer') {
- *     console.log(`${instr.amount} lamports to ${instr.toAddress}`);
- *   }
- * }
- *
- * // Sign
- * tx.addSignature(pubkey, signature);
- * const signedBytes = tx.toBytes();
- * ```
- */
-export function parseTransaction(bytes: Uint8Array): _Transaction {
-  return _Transaction.fromBytes(bytes);
-}
 
 // Intent builder type exports
 export type {

--- a/packages/wasm-solana/js/parser.ts
+++ b/packages/wasm-solana/js/parser.ts
@@ -269,19 +269,21 @@ export interface ParsedTransaction {
 }
 
 // =============================================================================
-// parseTransactionData function
+// parseTransaction function
 // =============================================================================
 
 /**
  * Parse raw transaction bytes into a plain data object with decoded instructions.
  *
- * This is the low-level parsing function. Most callers should use the top-level
- * `parseTransaction(bytes)` which returns a `Transaction` instance with both
- * inspection (`.parse()`) and signing (`.addSignature()`) capabilities.
+ * This is the main parsing function that returns structured data with all
+ * instructions decoded into semantic types (Transfer, StakingActivate, etc.)
+ * with amounts as bigint.
+ *
+ * For signing/serialization, use `Transaction.fromBytes()` instead.
  *
  * @param bytes - Raw transaction bytes
  * @returns A ParsedTransaction with all instructions decoded
  */
-export function parseTransactionData(bytes: Uint8Array): ParsedTransaction {
+export function parseTransaction(bytes: Uint8Array): ParsedTransaction {
   return ParserNamespace.parse_transaction(bytes) as ParsedTransaction;
 }

--- a/packages/wasm-solana/js/transaction.ts
+++ b/packages/wasm-solana/js/transaction.ts
@@ -1,8 +1,6 @@
 import { WasmTransaction } from "./wasm/wasm_solana.js";
 import { Keypair } from "./keypair.js";
 import { Pubkey } from "./pubkey.js";
-import { parseTransactionData } from "./parser.js";
-import type { ParsedTransaction } from "./parser.js";
 
 /**
  * Account metadata for an instruction
@@ -29,27 +27,25 @@ export interface Instruction {
 }
 
 /**
- * Solana Transaction — the single object for inspecting and signing transactions.
+ * Solana Transaction — deserialization wrapper for signing and serialization.
  *
- * Use `parseTransaction(bytes)` to create an instance. The returned Transaction
- * can be both inspected (`.parse()` for decoded instructions) and signed
- * (`.addSignature()`, `.signablePayload()`, `.toBytes()`).
+ * Use `Transaction.fromBytes(bytes)` to create an instance for signing.
+ * Use `parseTransaction(bytes)` from parser.ts to get decoded instruction data.
  *
  * @example
  * ```typescript
- * import { parseTransaction } from '@bitgo/wasm-solana';
+ * import { Transaction, parseTransaction } from '@bitgo/wasm-solana';
  *
- * const tx = parseTransaction(txBytes);
- *
- * // Inspect decoded instructions
- * const parsed = tx.parse();
+ * // Parse for decoded instructions
+ * const parsed = parseTransaction(txBytes);
  * for (const instr of parsed.instructionsData) {
  *   if (instr.type === 'Transfer') {
  *     console.log(`${instr.amount} lamports to ${instr.toAddress}`);
  *   }
  * }
  *
- * // Sign and serialize
+ * // Deserialize for signing
+ * const tx = Transaction.fromBytes(txBytes);
  * tx.addSignature(pubkey, signature);
  * const signedBytes = tx.toBytes();
  * ```
@@ -244,26 +240,6 @@ export class Transaction {
    */
   signWithKeypair(keypair: Keypair): void {
     this._wasm.sign_with_keypair(keypair.wasm);
-  }
-
-  /**
-   * Parse the transaction into decoded instruction data.
-   *
-   * Returns structured data with all instructions decoded into semantic types
-   * (Transfer, StakeActivate, TokenTransfer, etc.) with amounts as bigint.
-   *
-   * @returns A ParsedTransaction with decoded instructions, feePayer, nonce, etc.
-   *
-   * @example
-   * ```typescript
-   * const tx = parseTransaction(txBytes);
-   * const parsed = tx.parse();
-   * console.log(parsed.feePayer);
-   * console.log(parsed.instructionsData); // Decoded instruction types
-   * ```
-   */
-  parse(): ParsedTransaction {
-    return parseTransactionData(this._wasm.to_bytes());
   }
 
   /**

--- a/packages/wasm-solana/test/bitgojs-compat.ts
+++ b/packages/wasm-solana/test/bitgojs-compat.ts
@@ -5,7 +5,7 @@
  * what BitGoJS's Transaction.toJson() produces.
  */
 import * as assert from "assert";
-import { parseTransactionData as parseTransaction } from "../js/parser.js";
+import { parseTransaction } from "../js/parser.js";
 
 // Helper to decode base64 in tests
 function base64ToBytes(base64: string): Uint8Array {

--- a/packages/wasm-solana/test/intentBuilder.ts
+++ b/packages/wasm-solana/test/intentBuilder.ts
@@ -8,11 +8,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-argument */
 
 import assert from "assert";
-import {
-  buildFromIntent,
-  Transaction,
-  parseTransactionData as parseTransaction,
-} from "../dist/cjs/js/index.js";
+import { buildFromIntent, Transaction, parseTransaction } from "../dist/cjs/js/index.js";
 
 describe("buildFromIntent", function () {
   // Common test params

--- a/packages/wasm-solana/test/parser.ts
+++ b/packages/wasm-solana/test/parser.ts
@@ -1,5 +1,5 @@
 import * as assert from "assert";
-import { parseTransactionData as parseTransaction } from "../js/parser.js";
+import { parseTransaction } from "../js/parser.js";
 
 // Helper to decode base64 in tests
 function base64ToBytes(base64: string): Uint8Array {

--- a/packages/webui/src/wasm-solana/transaction/index.ts
+++ b/packages/webui/src/wasm-solana/transaction/index.ts
@@ -516,8 +516,7 @@ class SolanaTransactionParser extends BaseComponent {
     try {
       // Parse the transaction
       const bytes = base64ToBytes(txData);
-      const tx = parseTransaction(bytes);
-      const parsed = tx.parse();
+      const parsed = parseTransaction(bytes);
 
       // Render transaction info
       txInfoEl.replaceChildren(this.renderTxInfo(parsed));


### PR DESCRIPTION
remove Transaction.parse(), rename parseTransactionData → parseTransaction

changes:
- remove Transaction.parse() method and parseTransactionData import from transaction.ts
- rename parseTransactionData → parseTransaction in parser.ts (returns ParsedTransaction)
- update explain.ts to import parseTransaction instead of parseTransactionData
- remove top-level parseTransaction function from index.ts (was returning Transaction)
- export parseTransaction from parser.ts (returns ParsedTransaction)
- update test imports: parseTransactionData as parseTransaction → parseTransaction

separation of concerns:
- Transaction.fromBytes(bytes) - deserialize for signing
- parseTransaction(bytes) - decode into structured data (ParsedTransaction)
- explainTransaction(bytes, options) - high-level explanation

aligns with wasm-utxo and wasm-dot conventions. 94/94 tests passing.

BTC-3063