### PR TITLE
feat: trigger publish for wasm-solana parse convention

### DIFF
--- a/packages/wasm-solana/js/parser.ts
+++ b/packages/wasm-solana/js/parser.ts
@@ -1,8 +1,8 @@
 /**
  * High-level transaction parsing.
  *
- * Provides types and functions for parsing Solana transactions into semantic data
- * matching BitGoJS's TxData format.
+ * Provides types and functions for parsing Solana transactions into
+ * semantic data matching BitGoJS's TxData format.
  *
  * All monetary amounts (amount, fee, lamports, poolTokens) are returned as bigint.
  */


### PR DESCRIPTION
## Summary

The parse convention refactor (PR #181) was merged with a `refactor:` prefix which did not trigger a version bump. This adds a trivial `feat:` commit to trigger the publish pipeline.

## Test plan

- [x] No functional changes — comment rewrap only

Ticket: BTC-3091