### PR TITLE
chore: remove wildcard from wasm-mps path

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -4,4 +4,4 @@
 
 # These owners and first officers will be the default owners for everything in the repo.
 *   @BitGo/btc-team
-packages/wasm-mps/* @BitGo/hsm
+packages/wasm-mps @BitGo/hsm


### PR DESCRIPTION
Looking for solution that allows HSM team full ownership of this package.

Ticket: HSM-1162