### PR TITLE
feat: publish package to NPM

### DIFF
--- a/packages/wasm-dot/js/types.ts
+++ b/packages/wasm-dot/js/types.ts
@@ -11,7 +11,7 @@
 // =============================================================================
 
 /**
- * Chain material metadata required for transaction encoding/decoding
+ * Chain material metadata required for transaction encoding/decoding.
  */
 export interface Material {
   /** Chain genesis hash (e.g., "0x91b171bb158e2d...") */

--- a/packages/wasm-dot/package.json
+++ b/packages/wasm-dot/package.json
@@ -2,7 +2,6 @@
   "name": "@bitgo/wasm-dot",
   "description": "WebAssembly wrapper for Polkadot/DOT cryptographic operations",
   "version": "0.0.1",
-  "private": true,
   "type": "module",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Make wasm-dot package public by removing private flag from package.json.

Co-authored-by: llm-git <llm-git@ttll.de>

Ticket: BTC-0