### PR TITLE
feat: add wasm-dot to CI/CD build and publish pipeline

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -43,6 +43,7 @@ jobs:
             packages/wasm-bip32
             packages/wasm-mps
             packages/wasm-solana
+            packages/wasm-dot
           cache-on-failure: true
 
       - name: Setup Node
@@ -96,6 +97,8 @@ jobs:
             packages/wasm-mps/js/wasm/
             packages/wasm-solana/dist/
             packages/wasm-solana/js/wasm/
+            packages/wasm-dot/dist/
+            packages/wasm-dot/js/wasm/
           retention-days: 1
 
       - name: Upload webui artifact
@@ -111,7 +114,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        package: [wasm-bip32, wasm-mps, wasm-utxo, wasm-solana]
+        package: [wasm-bip32, wasm-mps, wasm-utxo, wasm-solana, wasm-dot]
         include:
           - package: wasm-utxo
             needs-wasm-pack: true
@@ -123,6 +126,9 @@ jobs:
             needs-wasm-pack: false
             has-wasm-pack-tests: false
           - package: wasm-solana
+            needs-wasm-pack: false
+            has-wasm-pack-tests: false
+          - package: wasm-dot
             needs-wasm-pack: false
             has-wasm-pack-tests: false
     steps:
@@ -245,6 +251,16 @@ jobs:
           path: |
             packages/wasm-solana/pkg/
             packages/wasm-solana/dist/
+          retention-days: 1
+
+      - name: Upload wasm-dot build artifacts
+        if: inputs.upload-artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: wasm-dot-build
+          path: |
+            packages/wasm-dot/pkg/
+            packages/wasm-dot/dist/
           retention-days: 1
 
   # This job provides a stable "test / Test" status check for branch protection.

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -48,6 +48,12 @@ jobs:
           name: wasm-mps-build
           path: packages/wasm-mps/
 
+      - name: Download wasm-dot build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: wasm-dot-build
+          path: packages/wasm-dot/
+
       - name: Setup Node
         uses: actions/setup-node@v4
         with:

--- a/packages/wasm-dot/package.json
+++ b/packages/wasm-dot/package.json
@@ -45,6 +45,10 @@
     "lint": "eslint .",
     "lint:fix": "eslint . --fix"
   },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  },
   "devDependencies": {
     "@eslint/js": "^9.17.0",
     "@types/mocha": "^10.0.7",


### PR DESCRIPTION
Add wasm-dot to the Rust cache, build artifact upload/download,
test matrix, and publish workflow so the package publishes with
actual build artifacts instead of just package.json.
Also adds publishConfig for public NPM access.

BTC-3108