### PR TITLE
feat: remove unsafe any cast in wasm-dot builder

### DIFF
--- a/packages/wasm-dot/js/builder.ts
+++ b/packages/wasm-dot/js/builder.ts
@@ -74,7 +74,7 @@ import type { TransactionIntent, BuildContext } from "./types";
  */
 export function buildTransaction(intent: TransactionIntent, context: BuildContext): DotTransaction {
   const inner = BuilderNamespace.buildTransaction(intent, context);
-  return DotTransaction.fromInner(inner as any);
+  return DotTransaction.fromInner(inner);
 }
 
 // Re-export types for convenience

--- a/packages/wasm-dot/src/builder/types.rs
+++ b/packages/wasm-dot/src/builder/types.rs
@@ -205,7 +205,7 @@ mod tests {
                 "specName": "polkadot",
                 "specVersion": 9150,
                 "txVersion": 9,
-                "metadata": [0]
+                "metadata": "0x00"
             },
             "validity": {
                 "firstValid": 1000,


### PR DESCRIPTION
BuilderNamespace.buildTransaction already returns WasmTransaction,
so the cast is unnecessary and triggers eslint errors.

BTC-3108