### PR TITLE
fix: add .js extensions to ESM relative imports

### DIFF
--- a/packages/wasm-dot/js/index.ts
+++ b/packages/wasm-dot/js/index.ts
@@ -14,7 +14,7 @@ import {
   MaterialJs,
   ValidityJs,
   ParseContextJs,
-} from "./wasm/wasm_dot";
+} from "./wasm/wasm_dot.js";
 
 // Export WASM classes for advanced usage
 export {
@@ -27,7 +27,7 @@ export {
 };
 
 // Re-export all public API
-export * from "./types";
-export * from "./transaction";
-export * from "./parser";
-export * from "./builder";
+export * from "./types.js";
+export * from "./transaction.js";
+export * from "./parser.js";
+export * from "./builder.js";

--- a/packages/wasm-dot/js/parser.ts
+++ b/packages/wasm-dot/js/parser.ts
@@ -7,9 +7,9 @@
  * Use parseTransaction() when you need decoded data.
  */
 
-import { ParserNamespace, MaterialJs, ParseContextJs } from "./wasm/wasm_dot";
-import type { DotTransaction } from "./transaction";
-import type { ParseContext, ParsedTransaction } from "./types";
+import { ParserNamespace, MaterialJs, ParseContextJs } from "./wasm/wasm_dot.js";
+import type { DotTransaction } from "./transaction.js";
+import type { ParseContext, ParsedTransaction } from "./types.js";
 
 /**
  * Parse a DOT transaction into structured data.

--- a/packages/wasm-dot/js/transaction.ts
+++ b/packages/wasm-dot/js/transaction.ts
@@ -2,9 +2,9 @@
  * TypeScript wrapper for WasmTransaction
  */
 
-import { WasmTransaction, MaterialJs, ValidityJs, ParseContextJs } from "./wasm/wasm_dot";
-import type { Material, Validity, Era } from "./types";
-import { AddressFormat } from "./types";
+import { WasmTransaction, MaterialJs, ValidityJs, ParseContextJs } from "./wasm/wasm_dot.js";
+import type { Material, Validity, Era } from "./types.js";
+import { AddressFormat } from "./types.js";
 
 /**
  * DOT Transaction wrapper


### PR DESCRIPTION
wasm-dot ESM output had extensionless relative imports which break strict ESM resolution in Node.js and webpack 5. wasm-solana already uses .js extensions correctly, this makes wasm-dot consistent.

Ticket: BTC-3110