### PR TITLE
feat: add BondExtra variant to TransactionIntent

### DIFF
--- a/packages/wasm-dot/js/types.ts
+++ b/packages/wasm-dot/js/types.ts
@@ -98,6 +98,7 @@ export type TransactionIntent =
   | TransferIntent
   | TransferAllIntent
   | StakeIntent
+  | BondExtraIntent
   | UnstakeIntent
   | WithdrawUnbondedIntent
   | ChillIntent
@@ -136,6 +137,12 @@ export type StakePayee =
   | { type: "stash" }
   | { type: "controller" }
   | { type: "account"; address: string };
+
+export interface BondExtraIntent {
+  type: "bondExtra";
+  /** Additional amount to bond in planck */
+  amount: bigint;
+}
 
 export interface UnstakeIntent {
   type: "unstake";

--- a/packages/wasm-dot/src/builder/calls.rs
+++ b/packages/wasm-dot/src/builder/calls.rs
@@ -31,6 +31,7 @@ pub fn encode_call(
         }
         TransactionIntent::TransferAll { to, keep_alive } => transfer_all(to, *keep_alive)?,
         TransactionIntent::Stake { amount, payee } => staking_bond(*amount, payee)?,
+        TransactionIntent::BondExtra { amount } => staking_bond_extra(*amount),
         TransactionIntent::Unstake { amount } => staking_unbond(*amount),
         TransactionIntent::WithdrawUnbonded { slashing_spans } => {
             staking_withdraw_unbonded(*slashing_spans)
@@ -114,6 +115,14 @@ fn staking_bond(
             ("payee", payee_value),
         ]),
     ))
+}
+
+fn staking_bond_extra(amount: u64) -> subxt_core::tx::payload::DynamicPayload {
+    dynamic(
+        "Staking",
+        "bond_extra",
+        named([("max_additional", Value::u128(amount as u128))]),
+    )
 }
 
 fn staking_unbond(amount: u64) -> subxt_core::tx::payload::DynamicPayload {

--- a/packages/wasm-dot/src/builder/types.rs
+++ b/packages/wasm-dot/src/builder/types.rs
@@ -40,6 +40,11 @@ pub enum TransactionIntent {
         #[serde(default)]
         payee: StakePayee,
     },
+    /// Bond extra DOT to existing stake
+    BondExtra {
+        /// Additional amount to bond in planck (accepts JS BigInt natively)
+        amount: u64,
+    },
     /// Unstake (unbond) DOT
     Unstake {
         /// Amount to unstake in planck (accepts JS BigInt natively)
@@ -170,6 +175,22 @@ mod tests {
                 assert_eq!(amount, 5_000_000_000_000);
             }
             _ => panic!("Expected Stake"),
+        }
+    }
+
+    #[test]
+    fn test_deserialize_bond_extra_intent() {
+        let json = r#"{
+            "type": "bondExtra",
+            "amount": 2000000000000
+        }"#;
+
+        let intent: TransactionIntent = serde_json::from_str(json).unwrap();
+        match intent {
+            TransactionIntent::BondExtra { amount } => {
+                assert_eq!(amount, 2_000_000_000_000);
+            }
+            _ => panic!("Expected BondExtra"),
         }
     }
 


### PR DESCRIPTION
Add staking.bond_extra call encoding support for DOT transactions. This enables the WASM path to handle bond_extra intents (adding more stake to an existing bond) alongside the existing bond/unbond support.

- Add BondExtra { amount: u64 } variant to TransactionIntent enum
- Add staking_bond_extra() encoder function in calls.rs
- Wire up BondExtra in encode_call() match arm
- Add BondExtraIntent interface to TypeScript types
- Add deserialization test

Ticket: BTC-3119