### PR TITLE
feat(wasm-utxo): add Psbt wrapper class with typed interface

### DIFF
--- a/packages/wasm-utxo/js/descriptorWallet/Psbt.ts
+++ b/packages/wasm-utxo/js/descriptorWallet/Psbt.ts
@@ -1,0 +1,196 @@
+import {
+  WrapPsbt as WasmPsbt,
+  type WasmBIP32,
+  type WasmECPair,
+  type WrapDescriptor,
+  type PsbtInputData,
+  type PsbtOutputData,
+  type PsbtOutputDataWithAddress,
+} from "../wasm/wasm_utxo.js";
+import type { IPsbt } from "../psbt.js";
+import type { CoinName } from "../coinName.js";
+import type { BIP32 } from "../bip32.js";
+import { Transaction } from "../transaction.js";
+
+export type SignPsbtResult = {
+  [inputIndex: number]: [pubkey: string][];
+};
+
+export class Psbt implements IPsbt {
+  private _wasm: WasmPsbt;
+
+  constructor(versionOrWasm?: number | WasmPsbt, lockTime?: number) {
+    if (versionOrWasm instanceof WasmPsbt) {
+      this._wasm = versionOrWasm;
+    } else {
+      this._wasm = new WasmPsbt(versionOrWasm, lockTime);
+    }
+  }
+
+  /** @internal Access the underlying WASM instance */
+  get wasm(): WasmPsbt {
+    return this._wasm;
+  }
+
+  // -- Static / Factory --
+
+  static create(version?: number, lockTime?: number): Psbt {
+    return new Psbt(new WasmPsbt(version, lockTime));
+  }
+
+  static deserialize(bytes: Uint8Array): Psbt {
+    return new Psbt(WasmPsbt.deserialize(bytes));
+  }
+
+  // -- Serialization --
+
+  serialize(): Uint8Array {
+    return this._wasm.serialize();
+  }
+
+  clone(): Psbt {
+    return new Psbt(this._wasm.clone());
+  }
+
+  // -- IPsbt: introspection --
+
+  inputCount(): number {
+    return this._wasm.input_count();
+  }
+
+  outputCount(): number {
+    return this._wasm.output_count();
+  }
+
+  version(): number {
+    return this._wasm.version();
+  }
+
+  lockTime(): number {
+    return this._wasm.lock_time();
+  }
+
+  unsignedTxId(): string {
+    return this._wasm.unsigned_tx_id();
+  }
+
+  getInputs(): PsbtInputData[] {
+    return this._wasm.get_inputs() as PsbtInputData[];
+  }
+
+  getOutputs(): PsbtOutputData[] {
+    return this._wasm.get_outputs() as PsbtOutputData[];
+  }
+
+  getGlobalXpubs(): BIP32[] {
+    return this._wasm.get_global_xpubs() as BIP32[];
+  }
+
+  getOutputsWithAddress(coin: CoinName): PsbtOutputDataWithAddress[] {
+    return this._wasm.get_outputs_with_address(coin) as PsbtOutputDataWithAddress[];
+  }
+
+  // -- IPsbt: mutation --
+
+  addInputAtIndex(
+    index: number,
+    txid: string,
+    vout: number,
+    value: bigint,
+    script: Uint8Array,
+    sequence?: number,
+  ): number {
+    return this._wasm.add_input_at_index(index, txid, vout, value, script, sequence);
+  }
+
+  addInput(
+    txid: string,
+    vout: number,
+    value: bigint,
+    script: Uint8Array,
+    sequence?: number,
+  ): number {
+    return this._wasm.add_input(txid, vout, value, script, sequence);
+  }
+
+  addOutputAtIndex(index: number, script: Uint8Array, value: bigint): number {
+    return this._wasm.add_output_at_index(index, script, value);
+  }
+
+  addOutput(script: Uint8Array, value: bigint): number {
+    return this._wasm.add_output(script, value);
+  }
+
+  removeInput(index: number): void {
+    this._wasm.remove_input(index);
+  }
+
+  removeOutput(index: number): void {
+    this._wasm.remove_output(index);
+  }
+
+  // -- Descriptor updates --
+
+  updateInputWithDescriptor(inputIndex: number, descriptor: WrapDescriptor): void {
+    this._wasm.update_input_with_descriptor(inputIndex, descriptor);
+  }
+
+  updateOutputWithDescriptor(outputIndex: number, descriptor: WrapDescriptor): void {
+    this._wasm.update_output_with_descriptor(outputIndex, descriptor);
+  }
+
+  // -- Signing --
+
+  signWithXprv(xprv: string): SignPsbtResult {
+    return this._wasm.sign_with_xprv(xprv) as unknown as SignPsbtResult;
+  }
+
+  signWithPrv(prv: Uint8Array): SignPsbtResult {
+    return this._wasm.sign_with_prv(prv) as unknown as SignPsbtResult;
+  }
+
+  signAll(key: WasmBIP32): SignPsbtResult {
+    return this._wasm.sign_all(key) as unknown as SignPsbtResult;
+  }
+
+  signAllWithEcpair(key: WasmECPair): SignPsbtResult {
+    return this._wasm.sign_all_with_ecpair(key) as unknown as SignPsbtResult;
+  }
+
+  // -- Signature introspection --
+
+  getPartialSignatures(inputIndex: number): Array<{ pubkey: Uint8Array; signature: Uint8Array }> {
+    return this._wasm.get_partial_signatures(inputIndex) as Array<{
+      pubkey: Uint8Array;
+      signature: Uint8Array;
+    }>;
+  }
+
+  hasPartialSignatures(inputIndex: number): boolean {
+    return this._wasm.has_partial_signatures(inputIndex);
+  }
+
+  // -- Validation --
+
+  validateSignatureAtInput(inputIndex: number, pubkey: Uint8Array): boolean {
+    return this._wasm.validate_signature_at_input(inputIndex, pubkey);
+  }
+
+  verifySignatureWithKey(inputIndex: number, key: WasmBIP32): boolean {
+    return this._wasm.verify_signature_with_key(inputIndex, key);
+  }
+
+  // -- Transaction extraction --
+
+  getUnsignedTx(): Uint8Array {
+    return this._wasm.get_unsigned_tx();
+  }
+
+  finalize(): void {
+    this._wasm.finalize_mut();
+  }
+
+  extractTransaction(): Transaction {
+    return Transaction.fromWasm(this._wasm.extract_transaction());
+  }
+}

--- a/packages/wasm-utxo/js/descriptorWallet/index.ts
+++ b/packages/wasm-utxo/js/descriptorWallet/index.ts
@@ -45,5 +45,8 @@ export * from "./VirtualSize.js";
 // PSBT utilities
 export * from "./psbt/index.js";
 
+// PSBT wrapper
+export { Psbt, type SignPsbtResult } from "./Psbt.js";
+
 // Pattern matching
 export * from "./parse/PatternMatcher.js";

--- a/packages/wasm-utxo/js/index.ts
+++ b/packages/wasm-utxo/js/index.ts
@@ -32,10 +32,6 @@ export type DescriptorPkType = "derivable" | "definite" | "string";
 
 export type ScriptContext = "tap" | "segwitv0" | "legacy";
 
-export type SignPsbtResult = {
-  [inputIndex: number]: [pubkey: string][];
-};
-
 declare module "./wasm/wasm_utxo.js" {
   interface WrapDescriptor {
     /** These are not the same types of nodes as in the ast module */
@@ -90,58 +86,10 @@ declare module "./wasm/wasm_utxo.js" {
   interface PsbtOutputDataWithAddress extends PsbtOutputData {
     address: string;
   }
-
-  interface WrapPsbt {
-    // Signing methods (legacy - kept for backwards compatibility)
-    signWithXprv(this: WrapPsbt, xprv: string): SignPsbtResult;
-    signWithPrv(this: WrapPsbt, prv: Uint8Array): SignPsbtResult;
-
-    // Signing methods (new - using WasmBIP32/WasmECPair)
-    signAll(this: WrapPsbt, key: WasmBIP32): SignPsbtResult;
-    signAllWithEcpair(this: WrapPsbt, key: WasmECPair): SignPsbtResult;
-
-    // Introspection methods
-    inputCount(): number;
-    outputCount(): number;
-    getInputs(): PsbtInputData[];
-    getOutputs(): PsbtOutputData[];
-    getOutputsWithAddress(coin: import("./coinName.js").CoinName): PsbtOutputDataWithAddress[];
-    getGlobalXpubs(): WasmBIP32[];
-    getPartialSignatures(inputIndex: number): Array<{
-      pubkey: Uint8Array;
-      signature: Uint8Array;
-    }>;
-    hasPartialSignatures(inputIndex: number): boolean;
-
-    // Validation methods
-    validateSignatureAtInput(inputIndex: number, pubkey: Uint8Array): boolean;
-    verifySignatureWithKey(inputIndex: number, key: WasmBIP32): boolean;
-
-    // Extraction methods
-    extractTransaction(): WasmTransaction;
-
-    // Mutation methods
-    addInputAtIndex(
-      index: number,
-      txid: string,
-      vout: number,
-      value: bigint,
-      script: Uint8Array,
-      sequence?: number,
-    ): number;
-    addOutputAtIndex(index: number, script: Uint8Array, value: bigint): number;
-    removeInput(index: number): void;
-    removeOutput(index: number): void;
-
-    // Metadata methods
-    unsignedTxId(): string;
-    lockTime(): number;
-    version(): number;
-  }
 }
 
 export { WrapDescriptor as Descriptor } from "./wasm/wasm_utxo.js";
 export { WrapMiniscript as Miniscript } from "./wasm/wasm_utxo.js";
-export { WrapPsbt as Psbt } from "./wasm/wasm_utxo.js";
+export { Psbt } from "./descriptorWallet/Psbt.js";
 export { DashTransaction, Transaction, ZcashTransaction } from "./transaction.js";
 export { hasPsbtMagic, type IPsbt, type IPsbtWithAddress } from "./psbt.js";

--- a/packages/wasm-utxo/src/fixed_script_wallet/bitgo_psbt/mod.rs
+++ b/packages/wasm-utxo/src/fixed_script_wallet/bitgo_psbt/mod.rs
@@ -1273,11 +1273,7 @@ impl BitGoPsbt {
     /// This works for both BitcoinLike and Zcash PSBTs, returning a reference
     /// to the inner Bitcoin-compatible PSBT structure.
     pub fn psbt(&self) -> &Psbt {
-        match self {
-            BitGoPsbt::BitcoinLike(ref psbt, _network) => psbt,
-            BitGoPsbt::Dash(ref dash_psbt, _network) => &dash_psbt.psbt,
-            BitGoPsbt::Zcash(ref zcash_psbt, _network) => &zcash_psbt.psbt,
-        }
+        crate::psbt_ops::PsbtAccess::psbt(self)
     }
 
     /// Get a mutable reference to the underlying PSBT
@@ -1285,11 +1281,7 @@ impl BitGoPsbt {
     /// This works for both BitcoinLike and Zcash PSBTs, returning a reference
     /// to the inner Bitcoin-compatible PSBT structure.
     pub fn psbt_mut(&mut self) -> &mut Psbt {
-        match self {
-            BitGoPsbt::BitcoinLike(ref mut psbt, _network) => psbt,
-            BitGoPsbt::Dash(ref mut dash_psbt, _network) => &mut dash_psbt.psbt,
-            BitGoPsbt::Zcash(ref mut zcash_psbt, _network) => &mut zcash_psbt.psbt,
-        }
+        crate::psbt_ops::PsbtAccess::psbt_mut(self)
     }
 
     /// Returns the global xpubs from the PSBT, or None if the PSBT has no global xpubs.
@@ -3016,6 +3008,23 @@ impl BitGoPsbt {
             miner_fee,
             virtual_size: virtual_size as u32,
         })
+    }
+}
+
+impl crate::psbt_ops::PsbtAccess for BitGoPsbt {
+    fn psbt(&self) -> &Psbt {
+        match self {
+            BitGoPsbt::BitcoinLike(ref psbt, _) => psbt,
+            BitGoPsbt::Dash(ref dash_psbt, _) => &dash_psbt.psbt,
+            BitGoPsbt::Zcash(ref zcash_psbt, _) => &zcash_psbt.psbt,
+        }
+    }
+    fn psbt_mut(&mut self) -> &mut Psbt {
+        match self {
+            BitGoPsbt::BitcoinLike(ref mut psbt, _) => psbt,
+            BitGoPsbt::Dash(ref mut dash_psbt, _) => &mut dash_psbt.psbt,
+            BitGoPsbt::Zcash(ref mut zcash_psbt, _) => &mut zcash_psbt.psbt,
+        }
     }
 }
 

--- a/packages/wasm-utxo/src/psbt_ops.rs
+++ b/packages/wasm-utxo/src/psbt_ops.rs
@@ -1,5 +1,34 @@
 use miniscript::bitcoin::{psbt, Psbt, TxIn, TxOut};
 
+/// Shared accessor trait for types that wrap a `Psbt`.
+///
+/// Provides default implementations for common introspection methods so that
+/// both `WrapPsbt` and `BitGoPsbt` can reuse the same logic.
+pub trait PsbtAccess {
+    fn psbt(&self) -> &Psbt;
+    fn psbt_mut(&mut self) -> &mut Psbt;
+
+    fn input_count(&self) -> usize {
+        self.psbt().inputs.len()
+    }
+
+    fn output_count(&self) -> usize {
+        self.psbt().outputs.len()
+    }
+
+    fn version(&self) -> i32 {
+        self.psbt().unsigned_tx.version.0
+    }
+
+    fn lock_time(&self) -> u32 {
+        self.psbt().unsigned_tx.lock_time.to_consensus_u32()
+    }
+
+    fn unsigned_tx_id(&self) -> String {
+        self.psbt().unsigned_tx.compute_txid().to_string()
+    }
+}
+
 fn check_bounds(index: usize, len: usize, name: &str) -> Result<(), String> {
     if index > len {
         return Err(format!(

--- a/packages/wasm-utxo/src/wasm/fixed_script_wallet/mod.rs
+++ b/packages/wasm-utxo/src/wasm/fixed_script_wallet/mod.rs
@@ -687,14 +687,12 @@ impl BitGoPsbt {
         }
     }
 
-    /// Get the transaction version
     pub fn version(&self) -> i32 {
-        self.psbt.psbt().unsigned_tx.version.0
+        crate::psbt_ops::PsbtAccess::version(&self.psbt)
     }
 
-    /// Get the transaction lock time
     pub fn lock_time(&self) -> u32 {
-        self.psbt.psbt().unsigned_tx.lock_time.to_consensus_u32()
+        crate::psbt_ops::PsbtAccess::lock_time(&self.psbt)
     }
 
     /// Get the Zcash version group ID (returns None for non-Zcash PSBTs)
@@ -717,41 +715,26 @@ impl BitGoPsbt {
         }
     }
 
-    /// Get the number of inputs in the PSBT
     pub fn input_count(&self) -> usize {
-        self.psbt.psbt().inputs.len()
+        crate::psbt_ops::PsbtAccess::input_count(&self.psbt)
     }
 
-    /// Get the number of outputs in the PSBT
     pub fn output_count(&self) -> usize {
-        self.psbt.psbt().outputs.len()
+        crate::psbt_ops::PsbtAccess::output_count(&self.psbt)
     }
 
-    /// Get all PSBT inputs as an array of PsbtInputData
-    ///
-    /// Returns an array with witness_utxo, bip32_derivation, and tap_bip32_derivation
-    /// for each input.
     pub fn get_inputs(&self) -> Result<JsValue, WasmUtxoError> {
         crate::wasm::psbt::get_inputs_from_psbt(self.psbt.psbt())
     }
 
-    /// Get all PSBT outputs as an array of PsbtOutputData
-    ///
-    /// Returns an array with script, value, bip32_derivation, and tap_bip32_derivation
-    /// for each output.
     pub fn get_outputs(&self) -> Result<JsValue, WasmUtxoError> {
         crate::wasm::psbt::get_outputs_from_psbt(self.psbt.psbt())
     }
 
-    /// Get all PSBT outputs with resolved address strings.
-    ///
-    /// Unlike the generic WrapPsbt which requires a coin parameter, BitGoPsbt
-    /// uses the network it was created/deserialized with to resolve addresses.
     pub fn get_outputs_with_address(&self) -> Result<JsValue, WasmUtxoError> {
         crate::wasm::psbt::get_outputs_with_address_from_psbt(self.psbt.psbt(), self.psbt.network())
     }
 
-    /// Returns the global xpubs from the PSBT as an array of WasmBIP32 instances.
     pub fn get_global_xpubs(&self) -> JsValue {
         crate::wasm::psbt::get_global_xpubs_from_psbt(self.psbt.psbt())
     }

--- a/packages/wasm-utxo/src/wasm/psbt.rs
+++ b/packages/wasm-utxo/src/wasm/psbt.rs
@@ -297,7 +297,6 @@ impl WrapPsbt {
     ///
     /// # Returns
     /// The index of the newly added input
-    #[wasm_bindgen(js_name = addInputAtIndex)]
     pub fn add_input_at_index(
         &mut self,
         index: usize,
@@ -329,7 +328,6 @@ impl WrapPsbt {
             .map_err(|e| JsError::new(&e))
     }
 
-    #[wasm_bindgen(js_name = addInput)]
     pub fn add_input(
         &mut self,
         txid: &str,
@@ -349,7 +347,6 @@ impl WrapPsbt {
     ///
     /// # Returns
     /// The index of the newly added output
-    #[wasm_bindgen(js_name = addOutputAtIndex)]
     pub fn add_output_at_index(
         &mut self,
         index: usize,
@@ -366,18 +363,15 @@ impl WrapPsbt {
             .map_err(|e| JsError::new(&e))
     }
 
-    #[wasm_bindgen(js_name = addOutput)]
     pub fn add_output(&mut self, script: &[u8], value: u64) -> usize {
         self.add_output_at_index(self.0.outputs.len(), script, value)
             .expect("insert at len should never fail")
     }
 
-    #[wasm_bindgen(js_name = removeInput)]
     pub fn remove_input(&mut self, index: usize) -> Result<(), JsError> {
         crate::psbt_ops::remove_input(&mut self.0, index).map_err(|e| JsError::new(&e))
     }
 
-    #[wasm_bindgen(js_name = removeOutput)]
     pub fn remove_output(&mut self, index: usize) -> Result<(), JsError> {
         crate::psbt_ops::remove_output(&mut self.0, index).map_err(|e| JsError::new(&e))
     }
@@ -386,7 +380,6 @@ impl WrapPsbt {
     ///
     /// # Returns
     /// The serialized unsigned transaction
-    #[wasm_bindgen(js_name = getUnsignedTx)]
     pub fn get_unsigned_tx(&self) -> Vec<u8> {
         use miniscript::bitcoin::consensus::Encodable;
         let mut buf = Vec::new();
@@ -397,7 +390,6 @@ impl WrapPsbt {
         buf
     }
 
-    #[wasm_bindgen(js_name = updateInputWithDescriptor)]
     pub fn update_input_with_descriptor(
         &mut self,
         input_index: usize,
@@ -417,7 +409,6 @@ impl WrapPsbt {
         }
     }
 
-    #[wasm_bindgen(js_name = updateOutputWithDescriptor)]
     pub fn update_output_with_descriptor(
         &mut self,
         output_index: usize,
@@ -437,7 +428,6 @@ impl WrapPsbt {
         }
     }
 
-    #[wasm_bindgen(js_name = signWithXprv)]
     pub fn sign_with_xprv(&mut self, xprv: String) -> Result<JsValue, WasmUtxoError> {
         let key = bip32::Xpriv::from_str(&xprv).map_err(|_| WasmUtxoError::new("Invalid xprv"))?;
         self.0
@@ -448,7 +438,6 @@ impl WrapPsbt {
             .and_then(|r| r.try_to_js_value())
     }
 
-    #[wasm_bindgen(js_name = signWithPrv)]
     pub fn sign_with_prv(&mut self, prv: Vec<u8>) -> Result<JsValue, WasmUtxoError> {
         let privkey = PrivateKey::from_slice(&prv, miniscript::bitcoin::network::Network::Bitcoin)
             .map_err(|_| WasmUtxoError::new("Invalid private key"))?;
@@ -471,7 +460,6 @@ impl WrapPsbt {
     ///
     /// # Returns
     /// A SigningKeysMap converted to JsValue (object mapping input indices to signing keys)
-    #[wasm_bindgen(js_name = signAll)]
     pub fn sign_all(&mut self, key: &WasmBIP32) -> Result<JsValue, WasmUtxoError> {
         let xpriv = key.to_xpriv()?;
         self.0
@@ -492,7 +480,6 @@ impl WrapPsbt {
     ///
     /// # Returns
     /// A SigningKeysMap converted to JsValue (object mapping input indices to signing keys)
-    #[wasm_bindgen(js_name = signAllWithEcpair)]
     pub fn sign_all_with_ecpair(&mut self, key: &WasmECPair) -> Result<JsValue, WasmUtxoError> {
         let privkey = key.get_private_key()?;
         let secp = Secp256k1::new();
@@ -519,7 +506,6 @@ impl WrapPsbt {
     ///
     /// # Returns
     /// `true` if a valid signature exists for the key, `false` otherwise
-    #[wasm_bindgen(js_name = verifySignatureWithKey)]
     pub fn verify_signature_with_key(
         &self,
         input_index: usize,
@@ -614,7 +600,6 @@ impl WrapPsbt {
         Ok(false)
     }
 
-    #[wasm_bindgen(js_name = finalize)]
     pub fn finalize_mut(&mut self) -> Result<(), WasmUtxoError> {
         self.0
             .finalize_mut(&Secp256k1::verification_only())
@@ -631,7 +616,6 @@ impl WrapPsbt {
     /// # Returns
     /// - `Ok(WasmTransaction)` containing the extracted transaction
     /// - `Err(WasmUtxoError)` if the PSBT is not fully finalized or extraction fails
-    #[wasm_bindgen(js_name = extractTransaction)]
     pub fn extract_transaction(
         &self,
     ) -> Result<crate::wasm::transaction::WasmTransaction, WasmUtxoError> {
@@ -642,56 +626,32 @@ impl WrapPsbt {
         Ok(crate::wasm::transaction::WasmTransaction::from_tx(tx))
     }
 
-    /// Get the number of inputs in the PSBT
-    #[wasm_bindgen(js_name = inputCount)]
     pub fn input_count(&self) -> usize {
-        self.0.inputs.len()
+        crate::psbt_ops::PsbtAccess::input_count(self)
     }
 
-    /// Get the number of outputs in the PSBT
-    #[wasm_bindgen(js_name = outputCount)]
     pub fn output_count(&self) -> usize {
-        self.0.outputs.len()
+        crate::psbt_ops::PsbtAccess::output_count(self)
     }
 
-    /// Get all PSBT inputs as an array of PsbtInputData
-    ///
-    /// Returns an array with witness_utxo, bip32_derivation, and tap_bip32_derivation
-    /// for each input. This is useful for introspecting the PSBT structure.
-    #[wasm_bindgen(js_name = getInputs)]
     pub fn get_inputs(&self) -> Result<JsValue, WasmUtxoError> {
         get_inputs_from_psbt(&self.0)
     }
 
-    /// Get all PSBT outputs as an array of PsbtOutputData
-    ///
-    /// Returns an array with script, value, bip32_derivation, and tap_bip32_derivation
-    /// for each output. This is useful for introspecting the PSBT structure.
-    #[wasm_bindgen(js_name = getOutputs)]
     pub fn get_outputs(&self) -> Result<JsValue, WasmUtxoError> {
         get_outputs_from_psbt(&self.0)
     }
 
-    /// Get all PSBT outputs with resolved address strings.
-    ///
-    /// Like `getOutputs()` but each element also includes an `address` field
-    /// derived from the output script using the given coin name (e.g. "btc", "tbtc").
-    #[wasm_bindgen(js_name = getOutputsWithAddress)]
     pub fn get_outputs_with_address(&self, coin: &str) -> Result<JsValue, WasmUtxoError> {
         let network = crate::Network::from_coin_name(coin)
             .ok_or_else(|| WasmUtxoError::new(&format!("Unknown coin: {}", coin)))?;
         get_outputs_with_address_from_psbt(&self.0, network)
     }
 
-    /// Get global xpubs from the PSBT as an array of WasmBIP32 instances.
-    #[wasm_bindgen(js_name = getGlobalXpubs)]
     pub fn get_global_xpubs(&self) -> JsValue {
         get_global_xpubs_from_psbt(&self.0)
     }
 
-    /// Get partial signatures for an input
-    /// Returns array of { pubkey: Uint8Array, signature: Uint8Array }
-    #[wasm_bindgen(js_name = getPartialSignatures)]
     pub fn get_partial_signatures(&self, input_index: usize) -> Result<JsValue, WasmUtxoError> {
         use crate::wasm::try_into_js_value::{collect_partial_signatures, TryIntoJsValue};
 
@@ -703,8 +663,6 @@ impl WrapPsbt {
         signatures.try_to_js_value()
     }
 
-    /// Check if an input has any partial signatures
-    #[wasm_bindgen(js_name = hasPartialSignatures)]
     pub fn has_partial_signatures(&self, input_index: usize) -> Result<bool, JsError> {
         let input =
             self.0.inputs.get(input_index).ok_or_else(|| {
@@ -716,30 +674,18 @@ impl WrapPsbt {
             || input.tap_key_sig.is_some())
     }
 
-    /// Get the unsigned transaction ID as a hex string
-    #[wasm_bindgen(js_name = unsignedTxId)]
     pub fn unsigned_tx_id(&self) -> String {
-        self.0.unsigned_tx.compute_txid().to_string()
+        crate::psbt_ops::PsbtAccess::unsigned_tx_id(self)
     }
 
-    /// Get the transaction lock time
-    #[wasm_bindgen(js_name = lockTime)]
     pub fn lock_time(&self) -> u32 {
-        self.0.unsigned_tx.lock_time.to_consensus_u32()
+        crate::psbt_ops::PsbtAccess::lock_time(self)
     }
 
-    /// Get the transaction version
-    #[wasm_bindgen(js_name = version)]
     pub fn version(&self) -> i32 {
-        self.0.unsigned_tx.version.0
+        crate::psbt_ops::PsbtAccess::version(self)
     }
 
-    /// Validate a signature at a specific input against a pubkey
-    /// Returns true if the signature is valid
-    ///
-    /// This method handles both ECDSA (legacy/SegWit) and Schnorr (Taproot) signatures.
-    /// The pubkey should be provided as bytes (33 bytes for compressed ECDSA, 32 bytes for x-only Schnorr).
-    #[wasm_bindgen(js_name = validateSignatureAtInput)]
     pub fn validate_signature_at_input(
         &self,
         input_index: usize,
@@ -830,6 +776,15 @@ impl WrapPsbt {
 
         // No matching signature found
         Ok(false)
+    }
+}
+
+impl crate::psbt_ops::PsbtAccess for WrapPsbt {
+    fn psbt(&self) -> &Psbt {
+        &self.0
+    }
+    fn psbt_mut(&mut self) -> &mut Psbt {
+        &mut self.0
     }
 }
 

--- a/packages/wasm-utxo/test/psbtFromDescriptor.ts
+++ b/packages/wasm-utxo/test/psbtFromDescriptor.ts
@@ -4,8 +4,7 @@ import { getKey } from "@bitgo/utxo-lib/dist/src/testutil";
 
 import { DescriptorNode, formatNode } from "../js/ast/index.js";
 import { mockPsbtDefault } from "./psbtFromDescriptor.util.js";
-import { Descriptor } from "../js/index.js";
-import { WasmTransaction } from "../js/wasm/wasm_utxo.js";
+import { Descriptor, Transaction } from "../js/index.js";
 import { toWrappedPsbt } from "./psbt.util.js";
 
 function toKeyWithPath(k: BIP32Interface, path = "*"): string {
@@ -182,10 +181,10 @@ describe("WrapPsbt extractTransaction", function () {
       [a, b],
     );
 
-    assert.strictEqual(typeof tx.get_txid(), "string");
-    assert.strictEqual(tx.get_txid().length, 64);
-    assert.ok(tx.get_vsize() > 0);
-    assert.ok(tx.to_bytes().length > 0);
+    assert.strictEqual(typeof tx.getId(), "string");
+    assert.strictEqual(tx.getId().length, 64);
+    assert.ok(tx.getVSize() > 0);
+    assert.ok(tx.toBytes().length > 0);
   });
 
   it("should extract transaction from finalized Tr PSBT", function () {
@@ -197,10 +196,10 @@ describe("WrapPsbt extractTransaction", function () {
       [a],
     );
 
-    assert.strictEqual(typeof tx.get_txid(), "string");
-    assert.strictEqual(tx.get_txid().length, 64);
-    assert.ok(tx.get_vsize() > 0);
-    assert.ok(tx.to_bytes().length > 0);
+    assert.strictEqual(typeof tx.getId(), "string");
+    assert.strictEqual(tx.getId().length, 64);
+    assert.ok(tx.getVSize() > 0);
+    assert.ok(tx.toBytes().length > 0);
   });
 
   it("should produce consistent txid across repeated calls", function () {
@@ -212,7 +211,7 @@ describe("WrapPsbt extractTransaction", function () {
       [a, b],
     );
 
-    assert.strictEqual(tx.get_txid(), tx.get_txid());
+    assert.strictEqual(tx.getId(), tx.getId());
   });
 
   it("should produce a transaction whose bytes round-trip to the same txid", function () {
@@ -224,8 +223,8 @@ describe("WrapPsbt extractTransaction", function () {
       [a, b],
     );
 
-    const txBytes = tx.to_bytes();
-    const tx2 = WasmTransaction.from_bytes(txBytes);
-    assert.strictEqual(tx2.get_txid(), tx.get_txid());
+    const txBytes = tx.toBytes();
+    const tx2 = Transaction.fromBytes(txBytes);
+    assert.strictEqual(tx2.getId(), tx.getId());
   });
 });


### PR DESCRIPTION
Introduce a new TypeScript `Psbt` class that wraps `WasmPsbt` and
implements the `IPsbt` interface. This provides a cleaner, more
type-safe API compared to using the WASM types directly.

The wrapper:
- Encapsulates WASM instance management
- Provides factory methods for creation and deserialization
- Implements all IPsbt interface methods
- Adds descriptor-based update methods
- Includes signature verification and validation
- Supports transaction extraction with proper type handling

Update tests to use `Transaction` class methods (`getId()`,
`getVSize()`, `toBytes()`) instead of raw WASM calls.

Export the new `Psbt` class from the main entry point, replacing
direct WASM type exports. Remove `SignPsbtResult` type from main
index since it now lives with the Psbt implementation.

Issue: BTC-2650

Co-authored-by: llm-git <llm-git@ttll.de>