### PR TITLE
refactor: extract Recipient type in intentBuilder

### DIFF
--- a/packages/wasm-solana/js/index.ts
+++ b/packages/wasm-solana/js/index.ts
@@ -41,6 +41,7 @@ export type {
   CustomTxKey,
   SolanaIntent,
   StakePoolConfig,
+  Recipient,
   BuildFromIntentParams,
   BuildFromIntentResult,
   GeneratedKeypair,

--- a/packages/wasm-solana/js/intentBuilder.ts
+++ b/packages/wasm-solana/js/intentBuilder.ts
@@ -85,19 +85,22 @@ export interface BaseIntent {
   memo?: string;
 }
 
+/** A recipient in a transaction — native SOL or SPL token transfer */
+export interface Recipient {
+  address?: { address: string };
+  amount?: { value: bigint; symbol?: string };
+  /** Mint address (base58) — if set, this is an SPL token transfer */
+  tokenAddress?: string;
+  /** Token program ID (defaults to SPL Token Program) */
+  tokenProgramId?: string;
+  /** Decimal places for the token (required for transfer_checked) */
+  decimalPlaces?: number;
+}
+
 /** Payment intent */
 export interface PaymentIntent extends BaseIntent {
   intentType: "payment";
-  recipients?: Array<{
-    address?: { address: string };
-    amount?: { value: bigint; symbol?: string };
-    /** Mint address (base58) — if set, this is an SPL token transfer */
-    tokenAddress?: string;
-    /** Token program ID (defaults to SPL Token Program) */
-    tokenProgramId?: string;
-    /** Decimal places for the token (required for transfer_checked) */
-    decimalPlaces?: number;
-  }>;
+  recipients?: Recipient[];
 }
 
 /** Stake intent */
@@ -176,16 +179,7 @@ export interface ConsolidateIntent extends BaseIntent {
   /** The child address to consolidate from (sender) */
   receiveAddress: string;
   /** Recipients (root address for native SOL, wallet ATAs for tokens) */
-  recipients?: Array<{
-    address?: { address: string };
-    amount?: { value: bigint; symbol?: string };
-    /** Mint address (base58) — if set, this is an SPL token transfer */
-    tokenAddress?: string;
-    /** Token program ID (defaults to SPL Token Program) */
-    tokenProgramId?: string;
-    /** Decimal places for the token (required for transfer_checked) */
-    decimalPlaces?: number;
-  }>;
+  recipients?: Recipient[];
 }
 
 /** Authorize intent - pre-built transaction message */


### PR DESCRIPTION
PaymentIntent and ConsolidateIntent both had identical inline recipient shapes. Extract into a shared `Recipient` interface and export it from the package.

Stacked on #BTC-3188 (consolidate token support).

Addresses review feedback from Otto on #208.