### PR TITLE
fix: make material required in DotTransaction.fromHex/fromBytes

### DIFF
--- a/packages/wasm-dot/js/transaction.ts
+++ b/packages/wasm-dot/js/transaction.ts
@@ -27,8 +27,8 @@ export class DotTransaction {
    * @param material - Chain material from the fullnode. See {@link fromHex}
    *   for why material is needed at deserialization time.
    */
-  static fromBytes(bytes: Uint8Array, material?: Material): DotTransaction {
-    const ctx = material ? createContext(material) : undefined;
+  static fromBytes(bytes: Uint8Array, material: Material): DotTransaction {
+    const ctx = createContext(material);
     const inner = new WasmTransaction(bytes, ctx);
     return new DotTransaction(inner);
   }
@@ -71,8 +71,8 @@ export class DotTransaction {
    * @param material - Chain material from the fullnode (genesisHash,
    *   chainName, specName, specVersion, txVersion, metadata)
    */
-  static fromHex(hex: string, material?: Material): DotTransaction {
-    const ctx = material ? createContext(material) : undefined;
+  static fromHex(hex: string, material: Material): DotTransaction {
+    const ctx = createContext(material);
     const inner = WasmTransaction.fromHex(hex, ctx);
     return new DotTransaction(inner);
   }


### PR DESCRIPTION
## Summary

Make `material` a required parameter in `DotTransaction.fromHex()` and `DotTransaction.fromBytes()` instead of optional.

Without material, the parser silently falls back to guessing the signed extension layout (era + nonce + tip only). On chains with additional extensions (AuthorizeCall, StorageWeightReclaim, CheckMetadataHash, ChargeAssetTxPayment), extra extension bytes leak into call_data, producing silently corrupted transactions that the runtime rejects with a panic.

All existing callers already pass material. This turns a silent data corruption bug into a compile-time error.

Ticket: BTC-3062