### PR TITLE
chore: remove convenience wrappers to match wasm-sol/wasm-dot patterns

### DIFF
--- a/packages/wasm-ton/js/index.ts
+++ b/packages/wasm-ton/js/index.ts
@@ -11,7 +11,7 @@ export * as builder from "./builder.js";
 
 // Top-level function exports
 export { encodeAddress, encode, decode, validate } from "./address.js";
-export { Transaction, transactionFromBytes } from "./transaction.js";
+export { Transaction } from "./transaction.js";
 export { parseTransaction } from "./parser.js";
 export { buildTransaction } from "./builder.js";
 

--- a/packages/wasm-ton/js/parser.ts
+++ b/packages/wasm-ton/js/parser.ts
@@ -49,13 +49,3 @@ export interface ParsedTransaction {
 export function parseTransaction(tx: Transaction): ParsedTransaction {
   return ParserNamespace.parseFromTransaction(tx.wasm) as ParsedTransaction;
 }
-
-/**
- * Parse raw BOC bytes into structured data.
- *
- * @param bytes - Raw BOC bytes
- * @returns A ParsedTransaction
- */
-export function parseTransactionBytes(bytes: Uint8Array): ParsedTransaction {
-  return ParserNamespace.parseTransaction(bytes) as ParsedTransaction;
-}

--- a/packages/wasm-ton/js/transaction.ts
+++ b/packages/wasm-ton/js/transaction.ts
@@ -77,10 +77,3 @@ export class Transaction {
     return this._wasm;
   }
 }
-
-/**
- * Convenience function to create a Transaction from bytes.
- */
-export function transactionFromBytes(bytes: Uint8Array): Transaction {
-  return Transaction.fromBytes(bytes);
-}


### PR DESCRIPTION
Remove `transactionFromBytes()` and `parseTransactionBytes()` which are
thin wrappers that don't exist in wasm-solana or wasm-dot. Consumers
should use `Transaction.fromBytes()` and `parseTransaction(tx)` directly.
