### PR TITLE
chore: add wasm-ton to CI/CD pipeline and enable publishing

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -44,6 +44,7 @@ jobs:
             packages/wasm-mps
             packages/wasm-solana
             packages/wasm-dot
+            packages/wasm-ton
           cache-on-failure: true
 
       - name: Setup Node
@@ -99,6 +100,8 @@ jobs:
             packages/wasm-solana/js/wasm/
             packages/wasm-dot/dist/
             packages/wasm-dot/js/wasm/
+            packages/wasm-ton/dist/
+            packages/wasm-ton/js/wasm/
           retention-days: 1
 
       - name: Upload webui artifact
@@ -114,7 +117,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        package: [wasm-bip32, wasm-mps, wasm-utxo, wasm-solana, wasm-dot]
+        package: [wasm-bip32, wasm-mps, wasm-utxo, wasm-solana, wasm-dot, wasm-ton]
         include:
           - package: wasm-utxo
             needs-wasm-pack: true
@@ -129,6 +132,9 @@ jobs:
             needs-wasm-pack: false
             has-wasm-pack-tests: false
           - package: wasm-dot
+            needs-wasm-pack: false
+            has-wasm-pack-tests: false
+          - package: wasm-ton
             needs-wasm-pack: false
             has-wasm-pack-tests: false
     steps:
@@ -261,6 +267,16 @@ jobs:
           path: |
             packages/wasm-dot/pkg/
             packages/wasm-dot/dist/
+          retention-days: 1
+
+      - name: Upload wasm-ton build artifacts
+        if: inputs.upload-artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: wasm-ton-build
+          path: |
+            packages/wasm-ton/pkg/
+            packages/wasm-ton/dist/
           retention-days: 1
 
   # This job provides a stable "test / Test" status check for branch protection.

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -54,6 +54,12 @@ jobs:
           name: wasm-dot-build
           path: packages/wasm-dot/
 
+      - name: Download wasm-ton build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: wasm-ton-build
+          path: packages/wasm-ton/
+
       - name: Setup Node
         uses: actions/setup-node@v4
         with:

--- a/packages/wasm-ton/package.json
+++ b/packages/wasm-ton/package.json
@@ -2,7 +2,6 @@
   "name": "@bitgo/wasm-ton",
   "description": "WebAssembly wrapper for TON cryptographic operations",
   "version": "0.0.1",
-  "private": true,
   "type": "module",
   "repository": {
     "type": "git",
@@ -10,7 +9,9 @@
   },
   "license": "MIT",
   "files": [
-    "dist"
+    "dist/esm/js/**/*",
+    "dist/cjs/js/**/*",
+    "dist/cjs/package.json"
   ],
   "exports": {
     ".": {


### PR DESCRIPTION
Add wasm-ton to build-and-test and publish workflows, matching the existing wasm-dot configuration. Remove private:true and align the files field in package.json to match the standard publish pattern.

BTC-3241