### PR TITLE
refactor: improve error formatting in PSBT signing

### DIFF
--- a/packages/wasm-utxo/src/error.rs
+++ b/packages/wasm-utxo/src/error.rs
@@ -42,6 +42,15 @@ impl WasmUtxoError {
     pub fn new(s: &str) -> WasmUtxoError {
         WasmUtxoError::StringError(s.to_string())
     }
+
+    pub fn from_errors<E: fmt::Display>(errors: impl IntoIterator<Item = E>) -> WasmUtxoError {
+        let messages: Vec<String> = errors.into_iter().map(|e| e.to_string()).collect();
+        WasmUtxoError::StringError(format!(
+            "{} errors: {}",
+            messages.len(),
+            messages.join(", ")
+        ))
+    }
 }
 
 impl From<crate::address::AddressError> for WasmUtxoError {

--- a/packages/wasm-utxo/src/wasm/psbt.rs
+++ b/packages/wasm-utxo/src/wasm/psbt.rs
@@ -425,9 +425,7 @@ impl WrapPsbt {
         let key = bip32::Xpriv::from_str(&xprv).map_err(|_| WasmUtxoError::new("Invalid xprv"))?;
         self.0
             .sign(&key, &Secp256k1::new())
-            .map_err(|(_, errors)| {
-                WasmUtxoError::new(&format!("{} errors: {:?}", errors.len(), errors))
-            })
+            .map_err(|(_, errors)| WasmUtxoError::from_errors(errors.into_values()))
             .and_then(|r| r.try_to_js_value())
     }
 
@@ -437,9 +435,7 @@ impl WrapPsbt {
         let secp = Secp256k1::new();
         self.0
             .sign(&SingleKeySigner::from_privkey(privkey, &secp), &secp)
-            .map_err(|(_r, errors)| {
-                WasmUtxoError::new(&format!("{} errors: {:?}", errors.len(), errors))
-            })
+            .map_err(|(_r, errors)| WasmUtxoError::from_errors(errors.into_values()))
             .and_then(|r| r.try_to_js_value())
     }
 
@@ -457,9 +453,7 @@ impl WrapPsbt {
         let xpriv = key.to_xpriv()?;
         self.0
             .sign(&xpriv, &Secp256k1::new())
-            .map_err(|(_, errors)| {
-                WasmUtxoError::new(&format!("{} errors: {:?}", errors.len(), errors))
-            })
+            .map_err(|(_, errors)| WasmUtxoError::from_errors(errors.into_values()))
             .and_then(|r| r.try_to_js_value())
     }
 
@@ -479,9 +473,7 @@ impl WrapPsbt {
         let private_key = PrivateKey::new(privkey, miniscript::bitcoin::network::Network::Bitcoin);
         self.0
             .sign(&SingleKeySigner::from_privkey(private_key, &secp), &secp)
-            .map_err(|(_r, errors)| {
-                WasmUtxoError::new(&format!("{} errors: {:?}", errors.len(), errors))
-            })
+            .map_err(|(_r, errors)| WasmUtxoError::from_errors(errors.into_values()))
             .and_then(|r| r.try_to_js_value())
     }
 
@@ -596,9 +588,7 @@ impl WrapPsbt {
     pub fn finalize_mut(&mut self) -> Result<(), WasmUtxoError> {
         self.0
             .finalize_mut(&Secp256k1::verification_only())
-            .map_err(|vec_err| {
-                WasmUtxoError::new(&format!("{} errors: {:?}", vec_err.len(), vec_err))
-            })
+            .map_err(WasmUtxoError::from_errors)
     }
 
     /// Extract the final transaction from a finalized PSBT


### PR DESCRIPTION
Add `from_errors` helper to WasmUtxoError for consistent error
formatting. Replace debug formatting with display formatting for
better error messages in PSBT signing and finalization.

Issue: BTC-0

Co-authored-by: llm-git <llm-git@ttll.de>