### PR TITLE
chore(wasm-utxo): ignore RUSTSEC-2026-0105 for core2 unmaintained advisory

### DIFF
--- a/packages/wasm-utxo/deny.toml
+++ b/packages/wasm-utxo/deny.toml
@@ -1,3 +1,8 @@
+[advisories]
+# core2 is unmaintained (RUSTSEC-2026-0105) but no safe upgrade is available;
+# it's a transitive dependency of zcash crates (zcash_encoding, zcash_primitives, zebra-chain).
+ignore = [{ id = "RUSTSEC-2026-0105" }]
+
 # Deny multiple versions of dependencies
 [bans]
 multiple-versions = "deny"


### PR DESCRIPTION
Add advisory exception for core2 unmaintained warning as it's a
transitive dependency of zcash crates with no safe upgrade path
available.

Co-authored-by: llm-git <llm-git@ttll.de>

Issue: BTC-0