### PR TITLE
fix(wasm-mps): add typesVersions for ./web subpath

### DIFF
--- a/packages/wasm-mps/package.json
+++ b/packages/wasm-mps/package.json
@@ -33,6 +33,13 @@
   "main": "./dist/cjs/js/index.js",
   "module": "./dist/esm/js/index.js",
   "types": "./dist/esm/js/index.d.ts",
+  "typesVersions": {
+    "*": {
+      "web": [
+        "./dist/web/js/wasm/wasm_mps.d.ts"
+      ]
+    }
+  },
   "sideEffects": [
     "./dist/esm/js/wasm/wasm_mps.js",
     "./dist/cjs/js/wasm/wasm_mps.js"


### PR DESCRIPTION
Adds typesVersions so TypeScript can resolve @bitgo/wasm-mps/web under moduleResolution: node, as used by some CommonJS projects. The exports ./web entry is understood by modern Node-style TypeScript resolution modes such as node16/nodenext/bundler, while typesVersions provides a compatible fallback for legacy resolution.

Allows consumers to use typeof import("@bitgo/wasm-mps/web") without a local type shim.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

Ticket: WCI-250