### PR TITLE
ci: add dynamic package detection for pull requests

### DIFF
--- a/.github/scripts/detect-changes.mjs
+++ b/.github/scripts/detect-changes.mjs
@@ -1,0 +1,38 @@
+#!/usr/bin/env node
+import { execSync } from 'child_process';
+import { appendFileSync } from 'fs';
+
+const ALL_PACKAGES = ['wasm-bip32', 'wasm-mps', 'wasm-utxo', 'wasm-solana', 'wasm-dot', 'wasm-ton'];
+
+function setOutput(packages) {
+  const value = JSON.stringify(packages);
+  appendFileSync(process.env.GITHUB_OUTPUT, `packages=${value}\n`);
+  console.log(`Packages to test: ${value}`);
+}
+
+// Non-PR events (push to master, workflow_dispatch): run everything
+if (process.env.GITHUB_EVENT_NAME !== 'pull_request') {
+  setOutput(ALL_PACKAGES);
+  process.exit(0);
+}
+
+const base = process.env.BASE_SHA;
+const head = process.env.HEAD_SHA;
+
+const changedFiles = execSync(`git diff --name-only ${base} ${head}`)
+  .toString().trim().split('\n').filter(Boolean);
+
+// Shared infrastructure changes → run all packages
+const sharedChanged = changedFiles.some(f =>
+  /^(\.github\/|package\.json$|lerna\.json$|package-lock\.json$)/.test(f)
+);
+if (sharedChanged) {
+  setOutput(ALL_PACKAGES);
+  process.exit(0);
+}
+
+// Per-package detection; fall back to all if nothing package-specific changed
+const changed = ALL_PACKAGES.filter(pkg =>
+  changedFiles.some(f => f.startsWith(`packages/${pkg}/`))
+);
+setOutput(changed.length > 0 ? changed : ALL_PACKAGES);

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -20,6 +20,25 @@ env:
   WASM_OPT_VERSION: 0.116.1
 
 jobs:
+  detect-changes:
+    name: "Detect Changes"
+    runs-on: ubuntu-latest
+    outputs:
+      packages: ${{ steps.set-matrix.outputs.packages }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          fetch-depth: 0
+
+      - name: Determine changed packages
+        id: set-matrix
+        env:
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: node .github/scripts/detect-changes.mjs
+
   build:
     name: "Build"
     runs-on: ubuntu-latest
@@ -112,12 +131,12 @@ jobs:
 
   test:
     name: "Test ${{ matrix.package }}"
-    needs: build
+    needs: [detect-changes, build]
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        package: [wasm-bip32, wasm-mps, wasm-utxo, wasm-solana, wasm-dot, wasm-ton]
+        package: ${{ fromJson(needs.detect-changes.outputs.packages) }}
         include:
           - package: wasm-utxo
             needs-wasm-pack: true


### PR DESCRIPTION
Introduce a detection script that analyzes changed files in PRs and
runs tests only for affected packages. Shared infrastructure changes
(GitHub workflows, root package files) trigger all tests. Non-PR
events still test everything.

This reduces CI time for focused changes while maintaining full
coverage when needed.

Issue: BTC-0

Co-authored-by: llm-git <llm-git@ttll.de>