### PR TITLE
fix(wasm-utxo): skip empty bip32Derivation when resolving PSBT input descriptors

### DIFF
--- a/packages/wasm-utxo/js/descriptorWallet/psbt/findDescriptors.ts
+++ b/packages/wasm-utxo/js/descriptorWallet/psbt/findDescriptors.ts
@@ -123,10 +123,10 @@ type WithBip32Derivation = { bip32Derivation?: { path: string }[] };
 type WithTapBip32Derivation = { tapBip32Derivation?: { path: string }[] };
 
 function getDerivationPaths(v: WithBip32Derivation | WithTapBip32Derivation): string[] | undefined {
-  if ("bip32Derivation" in v && v.bip32Derivation) {
+  if ("bip32Derivation" in v && v.bip32Derivation && v.bip32Derivation.length > 0) {
     return v.bip32Derivation.map((v) => v.path);
   }
-  if ("tapBip32Derivation" in v && v.tapBip32Derivation) {
+  if ("tapBip32Derivation" in v && v.tapBip32Derivation && v.tapBip32Derivation.length > 0) {
     return v.tapBip32Derivation.map((v) => v.path).filter((v) => v !== "" && v !== "m");
   }
   return undefined;

--- a/packages/wasm-utxo/test/descriptorWallet/psbt/findDescriptors.ts
+++ b/packages/wasm-utxo/test/descriptorWallet/psbt/findDescriptors.ts
@@ -70,6 +70,24 @@ describe("descriptorWallet/psbt/findDescriptors", () => {
       assert.strictEqual(result.index, 10);
     });
 
+    it("should find derivable descriptor using tapBip32Derivation when bip32Derivation is empty", () => {
+      const descriptor = Descriptor.fromStringDetectType(derivableDescriptor);
+      const derivedScript = descriptor.atDerivationIndex(7).scriptPubkey();
+
+      const descriptorMap = toDescriptorMap([{ name: "derivable", value: derivableDescriptor }]);
+
+      const input: PsbtInput = {
+        witnessUtxo: { script: derivedScript, value: 100000n },
+        bip32Derivation: [],
+        tapBip32Derivation: [{ path: "m/0/7" }],
+      };
+
+      const result = findDescriptorForInput(input, descriptorMap);
+
+      assert.ok(result);
+      assert.strictEqual(result.index, 7);
+    });
+
     it("should return undefined when no matching descriptor", () => {
       const descriptorMap = toDescriptorMap([{ name: "wpkh", value: wpkhDescriptor }]);
 


### PR DESCRIPTION
Empty bip32Derivation arrays are truthy in JavaScript, so getDerivationPaths
previously returned no paths instead of checking tapBip32Derivation. Skip empty
derivation arrays and continue to the next source.