### PR TITLE
chore(wasm-utxo): bump zebra-chain 7→10, drop proc-macro-error2

### DIFF
--- a/packages/wasm-utxo/Cargo.lock
+++ b/packages/wasm-utxo/Cargo.lock
@@ -920,13 +920,13 @@ dependencies = [
 
 [[package]]
 name = "ed25519-zebra"
-version = "4.1.0"
+version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0017d969298eec91e3db7a2985a8cab4df6341d86e6f3a6f5878b13fb7846bc9"
+checksum = "775765289f7c6336c18d3d66127527820dd45ffd9eb3b6b8ee4708590e6c20f5"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
- "hashbrown 0.15.5",
+ "hashbrown 0.16.1",
  "pkcs8",
  "rand_core",
  "serde",
@@ -1060,9 +1060,9 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
-version = "0.1.5"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "fpe"
@@ -1217,11 +1217,10 @@ dependencies = [
 
 [[package]]
 name = "getset"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cf0fc11e47561d47397154977bc219f4cf809b2974facc3ccb3b89e2436f912"
+checksum = "6cf442baaabe4213ce7d1239afc26c039180b6456da2cededa316ae2c8a77a77"
 dependencies = [
- "proc-macro-error2",
  "proc-macro2",
  "quote",
  "syn",
@@ -1247,9 +1246,9 @@ dependencies = [
 
 [[package]]
 name = "halo2_gadgets"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45824ce0dd12e91ec0c68ebae2a7ed8ae19b70946624c849add59f1d1a62a143"
+checksum = "fb2a697cad929f706b7987fe804ad57d43622cd37463ba7e4d662a926fdcfea3"
 dependencies = [
  "arrayvec",
  "bitvec",
@@ -1318,20 +1317,14 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.5"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash",
 ]
-
-[[package]]
-name = "hashbrown"
-version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
 name = "hashlink"
@@ -1796,9 +1789,9 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "orchard"
-version = "0.13.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "497e74492624a1d1cc8c9675a7afb17b430d32fd9efc171513d0840140b5f0c7"
+checksum = "a54f8d29bfb1e76a9d4e868a1a08cce2e57dd2bdc66232982822ad3114b91ab3"
 dependencies = [
  "aes",
  "bitvec",
@@ -2041,28 +2034,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
 dependencies = [
  "toml_edit 0.23.9",
-]
-
-[[package]]
-name = "proc-macro-error-attr2"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
-dependencies = [
- "proc-macro2",
- "quote",
-]
-
-[[package]]
-name = "proc-macro-error2"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
-dependencies = [
- "proc-macro-error-attr2",
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -3500,9 +3471,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_address"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "355f3db1087875052b5ad0f9e7179a7e7794f0ae9cb1d6ab2b7db29f7b9a9b0b"
+checksum = "58342d0aaa8e2fa98849636f52800ac4bf020574c944c974742fc933db58cac2"
 dependencies = [
  "bech32",
  "bs58",
@@ -3549,9 +3520,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_primitives"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a59f418f8b1274a526d57dfa3b1a7b3724f04926c84712a27c1602e4b44bfacd"
+checksum = "c69e07f5eb3f682a6467b4b08ee4956f1acd1e886d70b21c4766953b3a1beba2"
 dependencies = [
  "blake2b_simd",
  "block-buffer 0.11.0-rc.3",
@@ -3580,9 +3551,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_protocol"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79ef3de16a4464a574591aa3e4ea875116372638307d7ae04415279ec187ba88"
+checksum = "5bec496a0bd62dae98c4b26f51c5dab112d0c5350bbc2ccfdfd05bb3454f714d"
 dependencies = [
  "corez",
  "document-features",
@@ -3593,9 +3564,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_script"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "774d808ab619b0f1887d7b90cd815c356101698d16aa681f3d2d9dea063de475"
+checksum = "2f872800287d118be71bdf6fe8c869c6a6ff6fb0a5762f68fb2af54c97edf0f2"
 dependencies = [
  "bip32",
  "bitflags",
@@ -3619,9 +3590,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_transparent"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e9ad72051b49432acd56d44ab301bb6467bd70eb23faab3f35539e4ecf2733d"
+checksum = "15df1908b428d4edeb7c7caae5692e05e2e92e5c38007a40b20ac098efdffd96"
 dependencies = [
  "bip32",
  "bs58",
@@ -3644,9 +3615,9 @@ dependencies = [
 
 [[package]]
 name = "zebra-chain"
-version = "7.0.0"
+version = "10.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99160b5cb49188c44bcba2ae56d0a85d2ba592243247451458bdf50ac3fd596d"
+checksum = "db447036d6c325d9b303b7583cfa1c96f09d3bd3e6eca452dfc48ee2e1ed0e14"
 dependencies = [
  "bech32",
  "bitflags",

--- a/packages/wasm-utxo/Cargo.toml
+++ b/packages/wasm-utxo/Cargo.toml
@@ -48,7 +48,7 @@ rstest = "0.26.1"
 pastey = "0.1"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
-zebra-chain = { version = "7.0", default-features = false }
+zebra-chain = { version = "10.0", default-features = false }
 
 [build-dependencies]
 serde_json = "1.0"

--- a/packages/wasm-utxo/deny.toml
+++ b/packages/wasm-utxo/deny.toml
@@ -1,8 +1,3 @@
-[advisories]
-# core2 is unmaintained (RUSTSEC-2026-0105) but no safe upgrade is available;
-# it's a transitive dependency of zcash crates (zcash_encoding, zcash_primitives, zebra-chain).
-ignore = [{ id = "RUSTSEC-2026-0105" }]
-
 # Deny multiple versions of dependencies
 [bans]
 multiple-versions = "deny"

--- a/packages/wasm-utxo/src/zcash/mod.rs
+++ b/packages/wasm-utxo/src/zcash/mod.rs
@@ -93,10 +93,7 @@ impl NetworkUpgrade {
                 testnet_activation_height: 3536500,
             },
             // NU6.2: emergency hard fork re-enabling Orchard with the corrected circuit
-            // after GHSA-ghc3-g8w4-whf9. Values match ZcashFoundation/zebra
-            // `network_upgrade.rs` (CONSENSUS_BRANCH_IDS) / `constants::activation_heights`.
-            // Not yet in the pinned zebra-chain 7.0 dependency, so the parity tests below
-            // skip Nu6_2 and it is guarded by `test_nu6_2_constants` until the dep is bumped (T1-3519).
+            // after GHSA-ghc3-g8w4-whf9.
             NetworkUpgrade::Nu6_2 => UpgradeParams {
                 branch_id: 0x5437f330,
                 mainnet_activation_height: 3364600,
@@ -168,22 +165,6 @@ mod tests {
         }
     }
 
-    /// NU6.2 is not yet in the pinned zebra-chain dependency (see T1-3519), so it is
-    /// excluded from the parity tests below. Guard its hardcoded constants here instead.
-    /// Source: ZcashFoundation/zebra network_upgrade.rs + constants::activation_heights.
-    #[test]
-    fn test_nu6_2_constants() {
-        assert_eq!(NetworkUpgrade::Nu6_2.branch_id(), 0x5437f330);
-        assert_eq!(NetworkUpgrade::Nu6_2.mainnet_activation_height(), 3_364_600);
-        assert_eq!(NetworkUpgrade::Nu6_2.testnet_activation_height(), 4_052_000);
-        // Heights at/after activation resolve to NU6.2; the block before stays NU6.1.
-        assert_eq!(branch_id_for_height(3_364_600, true), Some(0x5437f330));
-        assert_eq!(
-            branch_id_for_height(3_364_599, true),
-            Some(NetworkUpgrade::Nu6_1.branch_id())
-        );
-    }
-
     /// Tests that verify our constants match zebra-chain crate.
     /// These tests are exhaustive - they verify ALL upgrades in zebra-chain
     /// and will fail if we're missing any.
@@ -195,11 +176,9 @@ mod tests {
         };
 
         /// Map our NetworkUpgrade to zebra-chain's NetworkUpgrade.
-        /// Returns `None` for upgrades not yet present in the pinned zebra-chain
-        /// dependency (currently NU6.2 — see T1-3519). The match is otherwise exhaustive,
-        /// so a new upgrade added here without a mapping will fail to compile.
-        fn to_zebra_upgrade(upgrade: NetworkUpgrade) -> Option<ZebraNetworkUpgrade> {
-            Some(match upgrade {
+        /// This match is exhaustive — a new upgrade added here without a mapping will fail to compile.
+        fn to_zebra_upgrade(upgrade: NetworkUpgrade) -> ZebraNetworkUpgrade {
+            match upgrade {
                 NetworkUpgrade::Overwinter => ZebraNetworkUpgrade::Overwinter,
                 NetworkUpgrade::Sapling => ZebraNetworkUpgrade::Sapling,
                 NetworkUpgrade::Blossom => ZebraNetworkUpgrade::Blossom,
@@ -208,9 +187,8 @@ mod tests {
                 NetworkUpgrade::Nu5 => ZebraNetworkUpgrade::Nu5,
                 NetworkUpgrade::Nu6 => ZebraNetworkUpgrade::Nu6,
                 NetworkUpgrade::Nu6_1 => ZebraNetworkUpgrade::Nu6_1,
-                // NU6.2 is not in pinned zebra-chain 7.0; validated by test_nu6_2_constants.
-                NetworkUpgrade::Nu6_2 => return None,
-            })
+                NetworkUpgrade::Nu6_2 => ZebraNetworkUpgrade::Nu6_2,
+            }
         }
 
         /// Map zebra-chain's NetworkUpgrade to ours.
@@ -227,6 +205,7 @@ mod tests {
                 ZebraNetworkUpgrade::Nu5 => Some(NetworkUpgrade::Nu5),
                 ZebraNetworkUpgrade::Nu6 => Some(NetworkUpgrade::Nu6),
                 ZebraNetworkUpgrade::Nu6_1 => Some(NetworkUpgrade::Nu6_1),
+                ZebraNetworkUpgrade::Nu6_2 => Some(NetworkUpgrade::Nu6_2),
                 #[cfg(any(test, feature = "zebra-test"))]
                 ZebraNetworkUpgrade::Nu7 => None,
                 #[cfg(zcash_unstable = "zfuture")]
@@ -263,18 +242,15 @@ mod tests {
                 // Verify round-trip (zebra-known upgrades always map back to Some)
                 assert_eq!(
                     to_zebra_upgrade(our_upgrade),
-                    Some(zebra_upgrade),
+                    zebra_upgrade,
                     "Round-trip failed for {:?}",
                     zebra_upgrade
                 );
             }
 
             // Verify every upgrade in our ALL list maps to zebra.
-            // NU6.2 is not yet in the pinned zebra-chain (T1-3519), so it is skipped here.
             for &our_upgrade in NetworkUpgrade::ALL {
-                let Some(zebra_upgrade) = to_zebra_upgrade(our_upgrade) else {
-                    continue;
-                };
+                let zebra_upgrade = to_zebra_upgrade(our_upgrade);
                 assert!(
                     zebra_upgrade.branch_id().is_some(),
                     "{:?} should have a branch ID",
@@ -286,9 +262,7 @@ mod tests {
         #[test]
         fn test_branch_ids_match_zebra() {
             for &upgrade in NetworkUpgrade::ALL {
-                let Some(zebra_upgrade) = to_zebra_upgrade(upgrade) else {
-                    continue; // NU6.2 not in pinned zebra-chain (T1-3519)
-                };
+                let zebra_upgrade = to_zebra_upgrade(upgrade);
                 let expected = zebra_upgrade
                     .branch_id()
                     .map(u32::from)
@@ -309,9 +283,7 @@ mod tests {
         fn test_mainnet_heights_match_zebra() {
             let network = ZebraNetwork::Mainnet;
             for &upgrade in NetworkUpgrade::ALL {
-                let Some(zebra_upgrade) = to_zebra_upgrade(upgrade) else {
-                    continue; // NU6.2 not in pinned zebra-chain (T1-3519)
-                };
+                let zebra_upgrade = to_zebra_upgrade(upgrade);
                 let expected = zebra_upgrade
                     .activation_height(&network)
                     .map(|h| h.0)
@@ -332,9 +304,7 @@ mod tests {
         fn test_testnet_heights_match_zebra() {
             let network = ZebraNetwork::new_default_testnet();
             for &upgrade in NetworkUpgrade::ALL {
-                let Some(zebra_upgrade) = to_zebra_upgrade(upgrade) else {
-                    continue; // NU6.2 not in pinned zebra-chain (T1-3519)
-                };
+                let zebra_upgrade = to_zebra_upgrade(upgrade);
                 let expected = zebra_upgrade
                     .activation_height(&network)
                     .map(|h| h.0)


### PR DESCRIPTION
Bump `zebra-chain` dev-dependency from 7.0 → 10.0 to fix the `cargo deny` CI failure ([RUSTSEC-2026-0173](https://rustsec.org/advisories/RUSTSEC-2026-0173): `proc-macro-error2` unmaintained).

## Changes

- **`Cargo.toml`**: `zebra-chain` 7.0 → 10.0 (dev-dependency only — used in Zcash parity tests)
- **`Cargo.lock`**: resolves `orchard` 0.14.0, `zcash_primitives` 0.28.0, `zcash_transparent` 0.8.0, `getset` 0.1.7 (which drops `proc-macro-error2` entirely)
- **`deny.toml`**: remove the `[advisories]` ignore block — no unmaintained advisories remain
- **`src/zcash/mod.rs`**: `Nu6_2` is now in zebra-chain 10.0, so wire it up fully in both mapping functions; simplify `to_zebra_upgrade` to return non-`Option`; remove all "not in pinned zebra-chain (T1-3519)" workarounds and the standalone `test_nu6_2_constants` guard test — parity tests now cover Nu6_2 directly

Refs: T1-3598