### PR TITLE
feat(wasm-utxo): add max_fee_rate param to PSBT extract_transaction

### DIFF
--- a/packages/wasm-utxo/js/fixedScriptWallet/BitGoPsbt.ts
+++ b/packages/wasm-utxo/js/fixedScriptWallet/BitGoPsbt.ts
@@ -959,12 +959,15 @@ export class BitGoPsbt extends PsbtBase<WasmBitGoPsbt> implements IPsbtWithAddre
   /**
    * Extract the final transaction from a finalized PSBT
    *
+   * @param maxFeeRate Optional maximum fee rate in **sat/vB**. `Infinity` skips
+   *   the absurd-fee check; `undefined` uses rust-bitcoin's default check.
+   *   Callers holding sat/kB thresholds must divide by 1000 before passing.
    * @returns The extracted transaction instance
    * @throws Error if the PSBT is not fully finalized or extraction fails
    */
-  extractTransaction(): ITransaction {
+  extractTransaction(maxFeeRate?: number): ITransaction {
     const networkType = this._wasm.get_network_type();
-    const wasm: unknown = this._wasm.extract_transaction();
+    const wasm: unknown = this._wasm.extract_transaction(maxFeeRate);
 
     switch (networkType) {
       case "dash":

--- a/packages/wasm-utxo/js/fixedScriptWallet/ZcashBitGoPsbt.ts
+++ b/packages/wasm-utxo/js/fixedScriptWallet/ZcashBitGoPsbt.ts
@@ -283,10 +283,13 @@ export class ZcashBitGoPsbt extends BitGoPsbt {
   /**
    * Extract the final Zcash transaction from a finalized PSBT
    *
+   * @param maxFeeRate Optional maximum fee rate in **sat/vB**. `Infinity` skips
+   *   the absurd-fee check; `undefined` uses rust-bitcoin's default check.
+   *   Callers holding sat/kB thresholds must divide by 1000 before passing.
    * @returns The extracted Zcash transaction instance
    * @throws Error if the PSBT is not fully finalized or extraction fails
    */
-  override extractTransaction(): ZcashTransaction {
-    return ZcashTransaction.fromWasm(this.wasm.extract_zcash_transaction());
+  override extractTransaction(maxFeeRate?: number): ZcashTransaction {
+    return ZcashTransaction.fromWasm(this.wasm.extract_zcash_transaction(maxFeeRate));
   }
 }

--- a/packages/wasm-utxo/src/fixed_script_wallet/bitgo_psbt/mod.rs
+++ b/packages/wasm-utxo/src/fixed_script_wallet/bitgo_psbt/mod.rs
@@ -16,7 +16,7 @@ pub mod zcash_psbt;
 
 use crate::Network;
 pub use dash_psbt::DashBitGoPsbt;
-use miniscript::bitcoin::{psbt::Psbt, secp256k1, CompressedPublicKey, Txid};
+use miniscript::bitcoin::{psbt::Psbt, secp256k1, CompressedPublicKey, FeeRate, Txid};
 pub use propkv::{
     find_kv, get_zec_consensus_branch_id, BitGoKeyValue, ProprietaryKeySubtype,
     WasmUtxoVersionInfo, BITGO,
@@ -337,6 +337,45 @@ pub(crate) fn make_psbt_with_xpubs(
     }
     psbt.xpub = xpub_map;
     psbt
+}
+
+/// Fee-rate policy applied during PSBT extraction.
+///
+/// Controls how rust-bitcoin's absurd-fee-rate guard behaves when extracting a
+/// finalized transaction. This is pure plumbing — it carries no per-coin
+/// policy; callers that want a coin-aware default must resolve it themselves
+/// and pass [`ExtractFeePolicy::Limited`] or [`ExtractFeePolicy::Unchecked`].
+///
+/// All fee rates here are in **sat/vB** (rust-bitcoin's `FeeRate` unit). The
+/// wasm/JS boundary also uses **sat/vB**; callers holding sat/kB thresholds
+/// must convert (÷ 1000) before calling. See `fee_policy_from_js`.
+#[derive(Debug, Clone, Copy)]
+pub enum ExtractFeePolicy {
+    /// Use rust-bitcoin's stock absurd-fee-rate check (`Psbt::extract_tx`).
+    Default,
+    /// Skip the absurd-fee-rate check entirely (`Psbt::extract_tx_unchecked_fee_rate`).
+    Unchecked,
+    /// Enforce a maximum fee rate in **sat/vB**
+    /// (`Psbt::extract_tx_with_fee_rate_limit`).
+    Limited(FeeRate),
+}
+
+/// Extract a `Transaction` from a rust-bitcoin `Psbt` applying an
+/// [`ExtractFeePolicy`]. Shared by the `BitcoinLike` and `Dash` branches,
+/// which both hold an inner `Psbt`.
+fn extract_inner_with_fee_policy(
+    psbt: Psbt,
+    policy: ExtractFeePolicy,
+) -> Result<miniscript::bitcoin::Transaction, String> {
+    match policy {
+        ExtractFeePolicy::Default => psbt
+            .extract_tx()
+            .map_err(|e| format!("Failed to extract transaction: {}", e)),
+        ExtractFeePolicy::Unchecked => Ok(psbt.extract_tx_unchecked_fee_rate()),
+        ExtractFeePolicy::Limited(max_fee_rate_sat_per_vb) => psbt
+            .extract_tx_with_fee_rate_limit(max_fee_rate_sat_per_vb)
+            .map_err(|e| format!("Failed to extract transaction: {}", e)),
+    }
 }
 
 impl BitGoPsbt {
@@ -1371,16 +1410,30 @@ impl BitGoPsbt {
     /// * `Ok(Vec<u8>)` - The serialized transaction bytes
     /// * `Err(String)` - If transaction extraction fails
     pub fn extract_tx(self) -> Result<Vec<u8>, String> {
+        self.extract_tx_with_fee_policy(ExtractFeePolicy::Default)
+    }
+
+    /// Extract the fully-signed transaction from a finalized PSBT with an
+    /// explicit fee-rate [`policy`][ExtractFeePolicy].
+    ///
+    /// This method consumes the PSBT since the underlying `extract_tx()` requires ownership.
+    ///
+    /// # Requirements
+    /// All inputs must be finalized before calling this method.
+    ///
+    /// # Returns
+    /// * `Ok(Vec<u8>)` - The serialized transaction bytes
+    /// * `Err(String)` - If transaction extraction fails (including absurd-fee
+    ///   rejection when a [`Limited`][ExtractFeePolicy::Limited] policy is enforced)
+    pub fn extract_tx_with_fee_policy(self, policy: ExtractFeePolicy) -> Result<Vec<u8>, String> {
         use miniscript::bitcoin::consensus::serialize;
 
         match self {
             BitGoPsbt::Zcash(zcash_psbt, _) => zcash_psbt
-                .extract_tx()
+                .extract_tx_with_fee_policy(policy)
                 .map_err(|e| format!("Failed to extract transaction: {}", e)),
             BitGoPsbt::BitcoinLike(psbt, _) | BitGoPsbt::Dash(DashBitGoPsbt { psbt, .. }, _) => {
-                let tx = psbt
-                    .extract_tx()
-                    .map_err(|e| format!("Failed to extract transaction: {}", e))?;
+                let tx = extract_inner_with_fee_policy(psbt, policy)?;
                 Ok(serialize(&tx))
             }
         }
@@ -1392,10 +1445,21 @@ impl BitGoPsbt {
     /// * `Ok(Transaction)` - The extracted transaction
     /// * `Err(String)` - If not BitcoinLike or extraction fails
     pub fn extract_bitcoin_tx(self) -> Result<miniscript::bitcoin::Transaction, String> {
+        self.extract_bitcoin_tx_with_fee_policy(ExtractFeePolicy::Default)
+    }
+
+    /// Extract the Bitcoin transaction directly (for BitcoinLike networks only)
+    /// with an explicit fee-rate [`policy`][ExtractFeePolicy].
+    ///
+    /// # Returns
+    /// * `Ok(Transaction)` - The extracted transaction
+    /// * `Err(String)` - If not BitcoinLike or extraction fails
+    pub fn extract_bitcoin_tx_with_fee_policy(
+        self,
+        policy: ExtractFeePolicy,
+    ) -> Result<miniscript::bitcoin::Transaction, String> {
         match self {
-            BitGoPsbt::BitcoinLike(psbt, _) => psbt
-                .extract_tx()
-                .map_err(|e| format!("Failed to extract transaction: {}", e)),
+            BitGoPsbt::BitcoinLike(psbt, _) => extract_inner_with_fee_policy(psbt, policy),
             _ => Err("extract_bitcoin_tx only supported for BitcoinLike networks".to_string()),
         }
     }
@@ -1406,13 +1470,23 @@ impl BitGoPsbt {
     /// * `Ok(DashTransactionParts)` - The extracted transaction parts
     /// * `Err(String)` - If not Dash or extraction fails
     pub fn extract_dash_tx(self) -> Result<crate::dash::transaction::DashTransactionParts, String> {
+        self.extract_dash_tx_with_fee_policy(ExtractFeePolicy::Default)
+    }
+
+    /// Extract the Dash transaction parts directly with an explicit fee-rate
+    /// [`policy`][ExtractFeePolicy].
+    ///
+    /// # Returns
+    /// * `Ok(DashTransactionParts)` - The extracted transaction parts
+    /// * `Err(String)` - If not Dash or extraction fails
+    pub fn extract_dash_tx_with_fee_policy(
+        self,
+        policy: ExtractFeePolicy,
+    ) -> Result<crate::dash::transaction::DashTransactionParts, String> {
         use miniscript::bitcoin::consensus::serialize;
         match self {
             BitGoPsbt::Dash(dash_psbt, _) => {
-                let tx = dash_psbt
-                    .psbt
-                    .extract_tx()
-                    .map_err(|e| format!("Failed to extract transaction: {}", e))?;
+                let tx = extract_inner_with_fee_policy(dash_psbt.psbt, policy)?;
                 let tx_bytes = serialize(&tx);
                 crate::dash::transaction::decode_dash_transaction_parts(&tx_bytes)
                     .map_err(|e| format!("Failed to decode Dash transaction: {}", e))
@@ -1429,10 +1503,23 @@ impl BitGoPsbt {
     pub fn extract_zcash_tx(
         self,
     ) -> Result<crate::zcash::transaction::ZcashTransactionParts, String> {
+        self.extract_zcash_tx_with_fee_policy(ExtractFeePolicy::Default)
+    }
+
+    /// Extract the Zcash transaction parts directly with an explicit fee-rate
+    /// [`policy`][ExtractFeePolicy].
+    ///
+    /// # Returns
+    /// * `Ok(ZcashTransactionParts)` - The extracted transaction parts
+    /// * `Err(String)` - If not Zcash or extraction fails
+    pub fn extract_zcash_tx_with_fee_policy(
+        self,
+        policy: ExtractFeePolicy,
+    ) -> Result<crate::zcash::transaction::ZcashTransactionParts, String> {
         match self {
             BitGoPsbt::Zcash(zcash_psbt, _) => {
                 let bytes = zcash_psbt
-                    .extract_tx()
+                    .extract_tx_with_fee_policy(policy)
                     .map_err(|e| format!("Failed to extract transaction: {}", e))?;
                 crate::zcash::transaction::decode_zcash_transaction_parts(&bytes)
                     .map_err(|e| format!("Failed to decode Zcash transaction: {}", e))
@@ -4118,6 +4205,67 @@ mod tests {
             "Extracted transaction should match"
         );
     });
+
+    /// `extract_tx_with_fee_policy` must produce byte-identical output to the
+    /// default `extract_tx()` for a normal-fee PSBT across all three policies
+    /// (`Default`, `Unchecked`, `Limited`). This pins the param plumbing added
+    /// in this change without depending on per-coin fee policy.
+    #[test]
+    fn test_extract_tx_with_fee_policy_matches_default() {
+        use crate::fixed_script_wallet::test_utils::fixtures::{
+            self, FixtureNamespace, SignatureState, TxFormat,
+        };
+        use crate::Network;
+
+        let network = Network::Bitcoin;
+        let fixture = fixtures::load_psbt_fixture_with_format_and_namespace(
+            network.to_utxolib_name(),
+            SignatureState::Fullsigned,
+            TxFormat::Psbt,
+            FixtureNamespace::UtxolibCompat,
+        )
+        .expect("Failed to load fixture");
+        let mut bitgo_psbt = fixture
+            .to_bitgo_psbt(network)
+            .expect("Failed to convert to BitGo PSBT");
+
+        let secp = crate::bitcoin::secp256k1::Secp256k1::new();
+        bitgo_psbt
+            .finalize_mut(&secp)
+            .expect("Failed to finalize PSBT");
+
+        let default_bytes = bitgo_psbt.clone().extract_tx().expect("default extract");
+
+        // A high sat/vB ceiling that no normal-fee tx would trip.
+        let high_limit_sat_per_vb = ExtractFeePolicy::Limited(
+            miniscript::bitcoin::FeeRate::from_sat_per_vb_unchecked(1_000_000_000),
+        );
+
+        assert_eq!(
+            bitgo_psbt
+                .clone()
+                .extract_tx_with_fee_policy(ExtractFeePolicy::Default)
+                .expect("Default policy"),
+            default_bytes,
+            "Default policy must match extract_tx()"
+        );
+        assert_eq!(
+            bitgo_psbt
+                .clone()
+                .extract_tx_with_fee_policy(ExtractFeePolicy::Unchecked)
+                .expect("Unchecked policy"),
+            default_bytes,
+            "Unchecked policy must match extract_tx() on a normal-fee PSBT"
+        );
+        assert_eq!(
+            bitgo_psbt
+                .clone()
+                .extract_tx_with_fee_policy(high_limit_sat_per_vb)
+                .expect("Limited policy"),
+            default_bytes,
+            "Limited policy with a high sat/vB ceiling must match extract_tx()"
+        );
+    }
 
     /// Test extract_half_signed_legacy_tx for p2ms-based script types
     fn test_extract_half_signed_legacy_tx_for_script_type(

--- a/packages/wasm-utxo/src/fixed_script_wallet/bitgo_psbt/zcash_psbt.rs
+++ b/packages/wasm-utxo/src/fixed_script_wallet/bitgo_psbt/zcash_psbt.rs
@@ -161,6 +161,17 @@ impl ZcashBitGoPsbt {
     ///
     /// This method consumes the PSBT to avoid cloning.
     pub fn extract_tx(self) -> Result<Vec<u8>, super::DeserializeError> {
+        self.extract_tx_with_fee_policy(super::ExtractFeePolicy::Default)
+    }
+
+    /// Extract the finalized Zcash transaction bytes from the PSBT with an
+    /// explicit fee-rate [`policy`][super::ExtractFeePolicy].
+    ///
+    /// This method consumes the PSBT to avoid cloning.
+    pub fn extract_tx_with_fee_policy(
+        self,
+        policy: super::ExtractFeePolicy,
+    ) -> Result<Vec<u8>, super::DeserializeError> {
         use miniscript::bitcoin::psbt::ExtractTxError;
 
         // Capture Zcash-specific fields before consuming psbt
@@ -170,7 +181,7 @@ impl ZcashBitGoPsbt {
         let expiry_height = self.expiry_height.unwrap_or(0);
         let sapling_fields = self.sapling_fields;
 
-        let tx = self.psbt.extract_tx().map_err(|e| match e {
+        let map_extract_err = |e: ExtractTxError| match e {
             ExtractTxError::AbsurdFeeRate { .. } => {
                 super::DeserializeError::Network(format!("Absurd fee rate: {}", e))
             }
@@ -181,7 +192,16 @@ impl ZcashBitGoPsbt {
                 super::DeserializeError::Network(format!("Sending too much: {}", e))
             }
             _ => super::DeserializeError::Network(format!("Failed to extract transaction: {}", e)),
-        })?;
+        };
+
+        let tx = match policy {
+            super::ExtractFeePolicy::Default => self.psbt.extract_tx().map_err(map_extract_err)?,
+            super::ExtractFeePolicy::Unchecked => self.psbt.extract_tx_unchecked_fee_rate(),
+            super::ExtractFeePolicy::Limited(max_fee_rate_sat_per_vb) => self
+                .psbt
+                .extract_tx_with_fee_rate_limit(max_fee_rate_sat_per_vb)
+                .map_err(map_extract_err)?,
+        };
 
         let parts = crate::zcash::transaction::ZcashTransactionParts {
             transaction: tx,

--- a/packages/wasm-utxo/src/wasm/fixed_script_wallet/mod.rs
+++ b/packages/wasm-utxo/src/wasm/fixed_script_wallet/mod.rs
@@ -9,6 +9,7 @@ use wasm_bindgen::JsValue;
 
 use crate::address::networks::AddressFormat;
 use crate::error::WasmUtxoError;
+use crate::fixed_script_wallet::bitgo_psbt::ExtractFeePolicy;
 use crate::fixed_script_wallet::wallet_scripts::{chain_index_path, OutputScriptType};
 use crate::fixed_script_wallet::{Chain, Scope, WalletScripts};
 use crate::utxolib_compat::UtxolibNetwork;
@@ -22,14 +23,39 @@ use crate::wasm::wallet_keys::WasmRootWalletKeys;
 
 /// Parse a network from a string that can be either a utxolib name or a coin name
 fn parse_network(network_str: &str) -> Result<crate::networks::Network, WasmUtxoError> {
-    crate::networks::Network::from_utxolib_name(network_str)
-        .or_else(|| crate::networks::Network::from_coin_name(network_str))
+    crate::networks::Network::from_utxolib_name(network_str)        .or_else(|| crate::networks::Network::from_coin_name(network_str))
         .ok_or_else(|| {
             WasmUtxoError::new(&format!(
                 "Unknown network '{}'. Expected a utxolib name (e.g., 'bitcoin', 'testnet') or coin name (e.g., 'btc', 'tbtc')",
                 network_str
             ))
         })
+}
+
+/// Convert a JS-side `maxFeeRate` (sat/vB, `number | undefined | Infinity`)
+/// into an [`ExtractFeePolicy`] for the Rust extract path.
+///
+/// The wasm/JS boundary carries **sat/vB** — the same unit as rust-bitcoin's
+/// `FeeRate` — so no conversion happens inside wasm-utxo. Callers that hold
+/// sat/kB thresholds (e.g. wallet-platform's `maxFeeRateSatPerKB`) must divide
+/// by 1000 before calling.
+///
+/// - `undefined` / `None` → [`ExtractFeePolicy::Default`] (rust-bitcoin's stock
+///   absurd-fee check).
+/// - `Infinity` → [`ExtractFeePolicy::Unchecked`] (skip the check).
+/// - finite non-negative → [`ExtractFeePolicy::Limited`] (sat/vB passed through).
+/// - `NaN` / negative → [`ExtractFeePolicy::Default`] (defensive fallback).
+fn fee_policy_from_js(max_fee_rate_sat_per_vb: Option<f64>) -> ExtractFeePolicy {
+    use miniscript::bitcoin::FeeRate;
+
+    match max_fee_rate_sat_per_vb {
+        None => ExtractFeePolicy::Default,
+        Some(sat_per_vb) if sat_per_vb.is_infinite() => ExtractFeePolicy::Unchecked,
+        Some(sat_per_vb) if sat_per_vb.is_finite() && sat_per_vb >= 0.0 => {
+            ExtractFeePolicy::Limited(FeeRate::from_sat_per_vb_unchecked(sat_per_vb as u64))
+        }
+        _ => ExtractFeePolicy::Default,
+    }
 }
 
 #[wasm_bindgen]
@@ -1857,14 +1883,18 @@ impl BitGoPsbt {
     /// # Returns
     /// - `Ok(JsValue)` containing the WASM transaction instance
     /// - `Err(WasmUtxoError)` if the PSBT is not fully finalized or extraction fails
-    pub fn extract_transaction(&self) -> Result<JsValue, WasmUtxoError> {
+    pub fn extract_transaction(
+        &self,
+        max_fee_rate_sat_per_vb: Option<f64>,
+    ) -> Result<JsValue, WasmUtxoError> {
         use crate::fixed_script_wallet::bitgo_psbt::BitGoPsbt as InnerBitGoPsbt;
+        let policy = fee_policy_from_js(max_fee_rate_sat_per_vb);
         match &self.psbt {
             InnerBitGoPsbt::BitcoinLike(..) => {
                 let tx = self
                     .psbt
                     .clone()
-                    .extract_bitcoin_tx()
+                    .extract_bitcoin_tx_with_fee_policy(policy)
                     .map_err(|e| WasmUtxoError::new(&e))?;
                 Ok(crate::wasm::transaction::WasmTransaction::from_tx(tx).into())
             }
@@ -1872,7 +1902,7 @@ impl BitGoPsbt {
                 let parts = self
                     .psbt
                     .clone()
-                    .extract_dash_tx()
+                    .extract_dash_tx_with_fee_policy(policy)
                     .map_err(|e| WasmUtxoError::new(&e))?;
                 Ok(crate::wasm::dash_transaction::WasmDashTransaction::from_parts(parts).into())
             }
@@ -1880,7 +1910,7 @@ impl BitGoPsbt {
                 let parts = self
                     .psbt
                     .clone()
-                    .extract_zcash_tx()
+                    .extract_zcash_tx_with_fee_policy(policy)
                     .map_err(|e| WasmUtxoError::new(&e))?;
                 Ok(crate::wasm::transaction::WasmZcashTransaction::from_parts(parts).into())
             }
@@ -1893,11 +1923,12 @@ impl BitGoPsbt {
     /// Only valid for Bitcoin-like networks (not Dash or Zcash).
     pub fn extract_bitcoin_transaction(
         &self,
+        max_fee_rate_sat_per_vb: Option<f64>,
     ) -> Result<crate::wasm::transaction::WasmTransaction, WasmUtxoError> {
         let tx = self
             .psbt
             .clone()
-            .extract_bitcoin_tx()
+            .extract_bitcoin_tx_with_fee_policy(fee_policy_from_js(max_fee_rate_sat_per_vb))
             .map_err(|e| WasmUtxoError::new(&e))?;
         Ok(crate::wasm::transaction::WasmTransaction::from_tx(tx))
     }
@@ -1908,11 +1939,12 @@ impl BitGoPsbt {
     /// Only valid for Dash networks.
     pub fn extract_dash_transaction(
         &self,
+        max_fee_rate_sat_per_vb: Option<f64>,
     ) -> Result<crate::wasm::dash_transaction::WasmDashTransaction, WasmUtxoError> {
         let parts = self
             .psbt
             .clone()
-            .extract_dash_tx()
+            .extract_dash_tx_with_fee_policy(fee_policy_from_js(max_fee_rate_sat_per_vb))
             .map_err(|e| WasmUtxoError::new(&e))?;
         Ok(crate::wasm::dash_transaction::WasmDashTransaction::from_parts(parts))
     }
@@ -1923,11 +1955,12 @@ impl BitGoPsbt {
     /// Only valid for Zcash networks.
     pub fn extract_zcash_transaction(
         &self,
+        max_fee_rate_sat_per_vb: Option<f64>,
     ) -> Result<crate::wasm::transaction::WasmZcashTransaction, WasmUtxoError> {
         let parts = self
             .psbt
             .clone()
-            .extract_zcash_tx()
+            .extract_zcash_tx_with_fee_policy(fee_policy_from_js(max_fee_rate_sat_per_vb))
             .map_err(|e| WasmUtxoError::new(&e))?;
         Ok(crate::wasm::transaction::WasmZcashTransaction::from_parts(
             parts,


### PR DESCRIPTION
## Summary

Adds an optional `max_fee_rate` parameter to the PSBT extract path in `wasm-utxo` so callers can override rust-bitcoin's BTC-calibrated absurd-fee-rate guard, which rejects valid high-fee transactions on low-unit coins like Dogecoin (T1-3656).

This is **pure plumbing** — no per-coin fee policy is introduced here. The per-coin default thresholds and `fees` namespace land in a follow-up that builds on this.

### Changes

- **Rust:** new `ExtractFeePolicy` enum (`Default` | `Unchecked` | `Limited(FeeRate)`) plus `extract_tx_with_fee_policy` / `extract_bitcoin_tx_with_fee_policy` / `extract_dash_tx_with_fee_policy` / `extract_zcash_tx_with_fee_policy`. The existing no-arg `extract_*_tx` methods delegate with `Default`, preserving current behavior.
- **wasm-bindgen:** `extract_transaction` (and the bitcoin/dash/zcash variants) take `max_fee_rate_sat_per_vb: Option<f64>`. `undefined` → `Default`, `Infinity` → `Unchecked` (skip the guard), finite → `Limited`.
- **JS wrappers:** `BitGoPsbt.extractTransaction(maxFeeRate?)` and `ZcashBitGoPsbt.extractTransaction(maxFeeRate?)` forward the value.

### Units

The entire API is in **sat/vB** — the same unit as rust-bitcoin's `FeeRate` — so no conversion happens inside `wasm-utxo`. Callers that hold sat/kB thresholds (e.g. wallet-platform's `maxFeeRateSatPerKB`) must divide by 1000 at the callsite before passing.

## Test plan

- [x] `cargo build`, `cargo fmt --check`, `cargo clippy --all-targets` clean
- [x] All 46 existing `extract*` tests pass (delegation is behavior-preserving)
- [x] New `test_extract_tx_with_fee_policy_matches_default` pins that `Default` / `Unchecked` / `Limited` produce byte-identical output to `extract_tx()` on a normal-fee PSBT
- [ ] Downstream: `ims-utxo` / `wallet-platform` callsites pass `maxFeeRateSatPerKB / 1000` (companion PR)

Refs: T1-3656
