### PR TITLE
ci: make per-package test matrix respect detect-changes

### DIFF
--- a/.github/scripts/detect-changes.mjs
+++ b/.github/scripts/detect-changes.mjs
@@ -1,18 +1,42 @@
 #!/usr/bin/env node
-import { execSync } from 'child_process';
-import { appendFileSync } from 'fs';
+import { execSync } from "child_process";
+import { appendFileSync } from "fs";
 
-const ALL_PACKAGES = ['wasm-bip32', 'wasm-mps', 'wasm-utxo', 'wasm-solana', 'wasm-dot', 'wasm-ton', 'wasm-privacy-coin'];
+// Per-package matrix entries. Each object becomes one `matrix.include`
+// combination in the `test` job. The flags gate steps there:
+//   - needs-wasm-pack:      download the build artifact (wasm .js/.wasm)
+//   - has-wasm-pack-tests:  run `npm run test:wasm-pack-{node,chrome}`
+// Keeping the flags here (instead of a static `include:` block in the
+// workflow) is what actually lets `detect-changes` shrink the matrix — a
+// workflow `include:` entry whose `package` conflicts with the base matrix
+// spawns a NEW job rather than being filtered out, which previously
+// re-added every package on every PR.
+const PACKAGE_CONFIG = [
+  { package: "wasm-utxo", "needs-wasm-pack": true, "has-wasm-pack-tests": true },
+  { package: "wasm-bip32", "needs-wasm-pack": false, "has-wasm-pack-tests": false },
+  { package: "wasm-mps", "needs-wasm-pack": false, "has-wasm-pack-tests": false },
+  { package: "wasm-solana", "needs-wasm-pack": false, "has-wasm-pack-tests": false },
+  { package: "wasm-dot", "needs-wasm-pack": false, "has-wasm-pack-tests": false },
+  { package: "wasm-ton", "needs-wasm-pack": false, "has-wasm-pack-tests": false },
+  { package: "wasm-privacy-coin", "needs-wasm-pack": false, "has-wasm-pack-tests": false },
+];
 
-function setOutput(packages) {
-  const value = JSON.stringify(packages);
+const ALL_PACKAGES = PACKAGE_CONFIG.map((p) => p.package);
+
+function setOutput(entries) {
+  const value = JSON.stringify(entries);
   appendFileSync(process.env.GITHUB_OUTPUT, `packages=${value}\n`);
   console.log(`Packages to test: ${value}`);
 }
 
+function entriesFor(pkgs) {
+  const wanted = new Set(pkgs);
+  return PACKAGE_CONFIG.filter((p) => wanted.has(p.package));
+}
+
 // Non-PR events (push to master, workflow_dispatch): run everything
-if (process.env.GITHUB_EVENT_NAME !== 'pull_request') {
-  setOutput(ALL_PACKAGES);
+if (process.env.GITHUB_EVENT_NAME !== "pull_request") {
+  setOutput(PACKAGE_CONFIG);
   process.exit(0);
 }
 
@@ -20,19 +44,22 @@ const base = process.env.BASE_SHA;
 const head = process.env.HEAD_SHA;
 
 const changedFiles = execSync(`git diff --name-only ${base} ${head}`)
-  .toString().trim().split('\n').filter(Boolean);
+  .toString()
+  .trim()
+  .split("\n")
+  .filter(Boolean);
 
 // Shared infrastructure changes → run all packages
-const sharedChanged = changedFiles.some(f =>
-  /^(\.github\/|package\.json$|lerna\.json$|package-lock\.json$)/.test(f)
+const sharedChanged = changedFiles.some((f) =>
+  /^(\.github\/|package\.json$|lerna\.json$|package-lock\.json$)/.test(f),
 );
 if (sharedChanged) {
-  setOutput(ALL_PACKAGES);
+  setOutput(PACKAGE_CONFIG);
   process.exit(0);
 }
 
 // Per-package detection; fall back to all if nothing package-specific changed
-const changed = ALL_PACKAGES.filter(pkg =>
-  changedFiles.some(f => f.startsWith(`packages/${pkg}/`))
+const changed = ALL_PACKAGES.filter((pkg) =>
+  changedFiles.some((f) => f.startsWith(`packages/${pkg}/`)),
 );
-setOutput(changed.length > 0 ? changed : ALL_PACKAGES);
+setOutput(changed.length > 0 ? entriesFor(changed) : PACKAGE_CONFIG);

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -155,29 +155,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        package: ${{ fromJson(needs.detect-changes.outputs.packages) }}
-        include:
-          - package: wasm-utxo
-            needs-wasm-pack: true
-            has-wasm-pack-tests: true
-          - package: wasm-bip32
-            needs-wasm-pack: false
-            has-wasm-pack-tests: false
-          - package: wasm-mps
-            needs-wasm-pack: false
-            has-wasm-pack-tests: false
-          - package: wasm-solana
-            needs-wasm-pack: false
-            has-wasm-pack-tests: false
-          - package: wasm-dot
-            needs-wasm-pack: false
-            has-wasm-pack-tests: false
-          - package: wasm-ton
-            needs-wasm-pack: false
-            has-wasm-pack-tests: false
-          - package: wasm-privacy-coin
-            needs-wasm-pack: false
-            has-wasm-pack-tests: false
+        # `detect-changes` emits an array of objects
+        # [{package, needs-wasm-pack, has-wasm-pack-tests}, ...] filtered to
+        # changed packages. Using `include:` here (not a static list keyed on
+        # `package`) is what makes the matrix actually shrink: a workflow
+        # `include:` entry whose `package` conflicts with the base matrix
+        # spawns a NEW job instead of being filtered, which previously
+        # re-added every package on every PR.
+        include: ${{ fromJson(needs.detect-changes.outputs.packages) }}
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Problem

Every `Test <package>` job ran on every PR, regardless of what changed. A PR touching only `packages/wasm-utxo/` still ran `Test wasm-privacy-coin` (and all 6 other package jobs).

Root cause: the `test` job's matrix used a dynamic base (`package: ${{ fromJson(detect-changes) }}`) **plus** a static `include:` block listing all 7 packages with their per-package flags. GitHub Actions spawns a **new** matrix combination for any `include:` entry whose `package` can't merge into the base (it would overwrite `package`), so the `include` block re-added every package as its own job — defeating `detect-changes`.

Evidence: for PR #306 (head `8feac80a`, only `packages/wasm-utxo/` files), `Detect Changes` logged `Packages to test: ["wasm-utxo"]`, yet all 7 `Test *` jobs ran.

## Fix

- Move the per-package flags (`needs-wasm-pack`, `has-wasm-pack-tests`) into `.github/scripts/detect-changes.mjs`, which now emits an array of objects `[{package, needs-wasm-pack, has-wasm-pack-tests}]` filtered to changed packages.
- Consume it with `matrix.include: ${{ fromJson(needs.detect-changes.outputs.packages) }}` — no base `package:` key, no static list.

Now only changed packages become test jobs. The non-PR / shared-infra (`.github/`, root `package.json`/`lerna.json`/`package-lock.json`) / no-op fallbacks still return all packages, so the matrix is never empty on PRs.

## Verification

Locally simulated the PR #306 scenario (`BASE_SHA=c744b64d HEAD_SHA=8feac80a`):

```
Packages to test: [{"package":"wasm-utxo","needs-wasm-pack":true,"has-wasm-pack-tests":true}]
```

→ matrix would spawn only `Test wasm-utxo` instead of all 7. prettier clean. (actionlint not run locally — nix unavailable; the repo's CI flake check validates it.)

## Notes

- The stable `test / Test` gate job (`needs: [build, test, finalize]`) remains the branch-protection check; per-package jobs are not required to run individually.
- The `build` job still builds all packages unconditionally (it produces one shared `build-output` artifact); this change only scopes the per-package **test** jobs. Making `build` per-package is a larger refactor, intentionally out of scope.
- No ticket — discovered while investigating PR #306.
