### PR TITLE
feat: publish wasm-privacy-coin JAR to AWS CodeArtifact

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -82,12 +82,6 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-      - name: Setup JDK 17 (for wasm-privacy-coin Maven deploy)
-        uses: actions/setup-java@v4
-        with:
-          distribution: corretto
-          java-version: "17"
-
       - name: Install dependencies
         run: npm ci --workspaces --include-workspace-root
 

--- a/packages/wasm-privacy-coin/pom.xml
+++ b/packages/wasm-privacy-coin/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>com.bitgo</groupId>
   <artifactId>wasm-privacy-coin</artifactId>
-  <version>0.1.0</version>
+  <version>${revision}${changelist}</version>
   <packaging>jar</packaging>
 
   <description>WASM module for shielded merkle tree operations</description>
@@ -15,6 +15,8 @@
     <maven.compiler.source>17</maven.compiler.source>
     <maven.compiler.target>17</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <revision>0.1.0</revision>
+    <changelist>-SNAPSHOT</changelist>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
Add .settings.xml for Maven server auth via AWS_CODEARTIFACT_TOKEN, add codeartifact-deploy profile to pom.xml, and add publish-maven CI job that authenticates via OIDC, fetches a CodeArtifact token, and deploys the pre-built JAR using the semantic-release git tag version.

Ticket: CSHLD-1161