### PR TITLE
fix(wasm-utxo): pin crossbeam-epoch to >=0.9.20 (RUSTSEC-2026-0204)

### DIFF
--- a/packages/wasm-utxo/Cargo.lock
+++ b/packages/wasm-utxo/Cargo.lock
@@ -662,9 +662,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -3164,6 +3164,7 @@ version = "0.1.0"
 dependencies = [
  "base64 0.22.1",
  "bech32",
+ "crossbeam-epoch",
  "getrandom 0.2.16",
  "hex",
  "js-sys",

--- a/packages/wasm-utxo/Cargo.toml
+++ b/packages/wasm-utxo/Cargo.toml
@@ -38,6 +38,9 @@ serde = { version = "1.0", features = ["derive"], optional = true }
 serde_json = { version = "1.0", optional = true }
 hex = { version = "0.4", optional = true }
 
+# Pinned to avoid RUSTSEC-2026-0204 (invalid pointer dereference in fmt::Pointer)
+crossbeam-epoch = ">=0.9.20"
+
 [dev-dependencies]
 base64 = "0.22.1"
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
## Summary

Pins `crossbeam-epoch` to `>=0.9.20` to fix a security advisory that is currently failing `cargo deny check` in CI.

## Changes

- Added `crossbeam-epoch = ">=0.9.20"` as a direct dependency in `wasm-utxo/Cargo.toml` to force the resolver to a safe version
- Updated `Cargo.lock` to reflect the resolved version (0.9.18 → 0.9.20)

## Advisory

**RUSTSEC-2026-0204**: Invalid pointer dereference in `fmt::Pointer` impl for `Atomic` and `Shared` when the underlying pointer is invalid (e.g. created with `Atomic::null` or `Shared::null`).

- Fix: https://github.com/crossbeam-rs/crossbeam/pull/1276
- Solution: upgrade to `>=0.9.20`

## Test Plan

- `cargo deny check` should pass in CI