### PR TITLE
CSHLD-1161: restore JDK 17 setup step in publish workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -82,6 +82,12 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
+      - name: Setup JDK 17 (for wasm-privacy-coin Maven deploy)
+        uses: actions/setup-java@v4
+        with:
+          distribution: corretto
+          java-version: "17"
+
       - name: Install dependencies
         run: npm ci --workspaces --include-workspace-root
 


### PR DESCRIPTION
## Summary

Restores the `setup-java` step that was inadvertently removed in 214fac4. The `mvn deploy:deploy-file` command in `packages/wasm-privacy-coin/.releaserc.json` requires Java on `PATH` to deploy the JAR to GitHub Packages during semantic-release.

**Jira**: [CSHLD-1161](https://linear.app/bitgo/issue/CSHLD-1161/publish-privacy-coin-wasm-jar-to-aws-codeartifact)

## Changes

- Restored `Setup JDK 17 (for wasm-privacy-coin Maven deploy)` step in `.github/workflows/publish.yaml`

## Test Plan

- Verify next semantic-release run for `wasm-privacy-coin` completes the Maven deploy step without Java-related errors

CLOSES TICKET: CSHLD-1161