### PR TITLE
feat(wasm-utxo): add Nu6_3 (Ironwood) consensus branch ID

### DIFF
--- a/packages/wasm-utxo/Cargo.lock
+++ b/packages/wasm-utxo/Cargo.lock
@@ -1789,9 +1789,9 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "orchard"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a54f8d29bfb1e76a9d4e868a1a08cce2e57dd2bdc66232982822ad3114b91ab3"
+checksum = "cca2ede6a4a77bd729eed3be9303d98a08b217edc85190dcf4dbe004086d5a65"
 dependencies = [
  "aes",
  "bitvec",
@@ -3472,9 +3472,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_address"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58342d0aaa8e2fa98849636f52800ac4bf020574c944c974742fc933db58cac2"
+checksum = "5a854b28c07dba372f4410ea8ad62b4bf7d5c2bf8be32fc4b31bc0db6521a975"
 dependencies = [
  "bech32",
  "bs58",
@@ -3497,9 +3497,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_history"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fde17bf53792f9c756b313730da14880257d7661b5bfc69d0571c3a7c11a76d"
+checksum = "69d2ed9a9fa7b466a7adedab1ad5a21f8330e4943756912fc776cf7f3beae32b"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -3521,9 +3521,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_primitives"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c69e07f5eb3f682a6467b4b08ee4956f1acd1e886d70b21c4766953b3a1beba2"
+checksum = "bdbeccc05bfe63b6dee9e989c6ff5027421741562a4853c36504dd621f6a81b1"
 dependencies = [
  "blake2b_simd",
  "block-buffer 0.11.0-rc.3",
@@ -3552,9 +3552,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_protocol"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bec496a0bd62dae98c4b26f51c5dab112d0c5350bbc2ccfdfd05bb3454f714d"
+checksum = "2973d210e74ebd81adc50828fbbb284ab6aaa099308097c42c47dc63cf3420fc"
 dependencies = [
  "corez",
  "document-features",
@@ -3591,9 +3591,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_transparent"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15df1908b428d4edeb7c7caae5692e05e2e92e5c38007a40b20ac098efdffd96"
+checksum = "72e0f8c142bed366ed5886dcfa8772ec90b5420cc127e6cdb76b6744c53a287b"
 dependencies = [
  "bip32",
  "bs58",
@@ -3616,9 +3616,9 @@ dependencies = [
 
 [[package]]
 name = "zebra-chain"
-version = "10.0.0"
+version = "11.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db447036d6c325d9b303b7583cfa1c96f09d3bd3e6eca452dfc48ee2e1ed0e14"
+checksum = "014adde138ea00b1cf6c873aaf56aacb5aa0d55b8e5451a3e3b1b06c461bd107"
 dependencies = [
  "bech32",
  "bitflags",

--- a/packages/wasm-utxo/Cargo.toml
+++ b/packages/wasm-utxo/Cargo.toml
@@ -51,7 +51,7 @@ rstest = "0.26.1"
 pastey = "0.1"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
-zebra-chain = { version = "10.0", default-features = false }
+zebra-chain = { version = "11", default-features = false }
 
 [build-dependencies]
 serde_json = "1.0"

--- a/packages/wasm-utxo/src/zcash/mod.rs
+++ b/packages/wasm-utxo/src/zcash/mod.rs
@@ -23,6 +23,7 @@ pub enum NetworkUpgrade {
     Nu6,
     Nu6_1,
     Nu6_2,
+    Nu6_3,
 }
 
 /// Parameters for a single network upgrade
@@ -45,6 +46,7 @@ impl NetworkUpgrade {
         NetworkUpgrade::Nu6,
         NetworkUpgrade::Nu6_1,
         NetworkUpgrade::Nu6_2,
+        NetworkUpgrade::Nu6_3,
     ];
 
     /// Get the parameters for this network upgrade
@@ -98,6 +100,12 @@ impl NetworkUpgrade {
                 branch_id: 0x5437f330,
                 mainnet_activation_height: 3364600,
                 testnet_activation_height: 4052000,
+            },
+            // https://zips.z.cash/zip-0255
+            NetworkUpgrade::Nu6_3 => UpgradeParams {
+                branch_id: 0x37a5165b,
+                mainnet_activation_height: 3428143,
+                testnet_activation_height: 4134000,
             },
         }
     }
@@ -188,6 +196,7 @@ mod tests {
                 NetworkUpgrade::Nu6 => ZebraNetworkUpgrade::Nu6,
                 NetworkUpgrade::Nu6_1 => ZebraNetworkUpgrade::Nu6_1,
                 NetworkUpgrade::Nu6_2 => ZebraNetworkUpgrade::Nu6_2,
+                NetworkUpgrade::Nu6_3 => ZebraNetworkUpgrade::Nu6_3,
             }
         }
 
@@ -206,6 +215,7 @@ mod tests {
                 ZebraNetworkUpgrade::Nu6 => Some(NetworkUpgrade::Nu6),
                 ZebraNetworkUpgrade::Nu6_1 => Some(NetworkUpgrade::Nu6_1),
                 ZebraNetworkUpgrade::Nu6_2 => Some(NetworkUpgrade::Nu6_2),
+                ZebraNetworkUpgrade::Nu6_3 => Some(NetworkUpgrade::Nu6_3),
                 #[cfg(any(test, feature = "zebra-test"))]
                 ZebraNetworkUpgrade::Nu7 => None,
                 #[cfg(zcash_unstable = "zfuture")]


### PR DESCRIPTION
Nu6_3 ("Ironwood") activated on Zcash mainnet at block 3,428,143
(branch ID `0x37a5165b`). Without this entry the sighash builder uses
the wrong consensus branch ID for any transaction signed above that
height, causing node rejection.

Also bumps the `zebra-chain` dev-dependency from `10.0` to `11` — 10.x
has no `Nu6_3` variant, so the parity test can only pass against 11.

Refs: T1-3705