### PR TITLE
CSHLD-785: remove unused jackson-databind test dependency

### DIFF
--- a/packages/wasm-privacy-coin/pom.xml
+++ b/packages/wasm-privacy-coin/pom.xml
@@ -41,12 +41,6 @@
       <version>5.10.3</version>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-databind</artifactId>
-      <version>2.17.0</version>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 
   <distributionManagement>


### PR DESCRIPTION
## Summary

Removes the `jackson-databind` test dependency from `wasm-privacy-coin/pom.xml`. It was added for JSON parsing in retention-flag tests, but those tests were refactored to use Rust-level unit tests instead and no longer reference Jackson.

**Jira**: [CSHLD-785](https://linear.app/bitgo/issue/CSHLD-785/merkle-tree-pruning)

## Changes

- Remove `com.fasterxml.jackson.core:jackson-databind:2.17.0` test-scoped dependency from `pom.xml`

## Test Plan

- `mvn test` passes (41/41 tests green)

CLOSES TICKET: CSHLD-785