### PR TITLE
feat(wasm-utxo-cli): add Pearl/Tpearl to CLI NetworkArg [CECHO-1749]

### DIFF
--- a/packages/wasm-utxo/cli/src/network.rs
+++ b/packages/wasm-utxo/cli/src/network.rs
@@ -25,6 +25,8 @@ pub enum NetworkArg {
     Tdoge,
     Zec,
     Tzec,
+    Pearl,
+    Tpearl,
 }
 
 impl From<NetworkArg> for Network {
@@ -49,6 +51,8 @@ impl From<NetworkArg> for Network {
             NetworkArg::Tdoge => Network::DogecoinTestnet,
             NetworkArg::Zec => Network::Zcash,
             NetworkArg::Tzec => Network::ZcashTestnet,
+            NetworkArg::Pearl => Network::Pearl,
+            NetworkArg::Tpearl => Network::PearlTestnet,
         }
     }
 }


### PR DESCRIPTION
## Summary
- PR #328 added `Pearl`/`PearlTestnet` to the library's `Network` enum but missed the CLI's separate `NetworkArg` clap enum
- This adds `Pearl` and `Tpearl` variants to `NetworkArg` and the corresponding `From<NetworkArg> for Network` match arms
- Enables `wasm-utxo-cli --network pearl` / `--network tpearl` for Pearl transaction construction

## Test plan
- [x] `cargo build --release -p wasm-utxo-cli` succeeds
- [x] `cargo clippy` passes (verified by pre-commit hook)
- [x] `psbt add-input --help` lists `pearl, tpearl` in network options

🤖 Generated with [Claude Code](https://claude.com/claude-code)