### PR TITLE
feat(wasm-utxo): expose v6 (Ironwood) PSBT flow via wasm + TS

### DIFF
--- a/packages/wasm-utxo/js/fixedScriptWallet/ZcashBitGoPsbt.ts
+++ b/packages/wasm-utxo/js/fixedScriptWallet/ZcashBitGoPsbt.ts
@@ -1,10 +1,24 @@
-import { BitGoPsbt as WasmBitGoPsbt, zcash_branch_id_for_height } from "../wasm/wasm_utxo.js";
+import {
+  BitGoPsbt as WasmBitGoPsbt,
+  zcash_branch_id_for_height,
+  zcash_ironwood_version_group_id,
+} from "../wasm/wasm_utxo.js";
 import { type WalletKeysArg, RootWalletKeys } from "./RootWalletKeys.js";
 import { BitGoPsbt, type CreateEmptyOptions, type HydrationUnspent } from "./BitGoPsbt.js";
 import { ZcashTransaction, type ITransaction } from "../transaction.js";
 
 /** Zcash network names */
 export type ZcashNetworkName = "zcash" | "zcashTest" | "zec" | "tzec";
+
+/**
+ * Zcash v6 (Ironwood) version group id (0xd884b698). Its presence marks a PSBT as v6 — see
+ * `ZcashIronwoodBitGoPsbt`.
+ *
+ * Read from the wasm layer rather than hard-coded, so it cannot drift from
+ * `ZCASH_IRONWOOD_VERSION_GROUP_ID` in `src/zcash/transaction.rs`: a divergence would make the
+ * v4/v6 discrimination in {@link ZcashBitGoPsbt.fromBytes} silently classify v6 bytes as v4.
+ */
+export const IRONWOOD_VERSION_GROUP_ID: number = zcash_ironwood_version_group_id();
 
 /** Options for creating an empty Zcash PSBT (preferred method using block height) */
 export type CreateEmptyZcashOptions = CreateEmptyOptions & {
@@ -137,11 +151,17 @@ export class ZcashBitGoPsbt extends BitGoPsbt {
    *
    * @param bytes - The PSBT bytes
    * @param network - Zcash network name ("zcash", "zcashTest", "zec", "tzec")
+   * @throws Error if the deserialized PSBT is a v6 (Ironwood) PSBT — use
+   *   {@link ZcashIronwoodBitGoPsbt.fromBytes} instead
    * @returns A ZcashBitGoPsbt instance
    */
   static override fromBytes(bytes: Uint8Array, network: ZcashNetworkName): ZcashBitGoPsbt {
     const wasm = WasmBitGoPsbt.from_bytes(bytes, network);
-    return new ZcashBitGoPsbt(wasm);
+    const psbt = new ZcashBitGoPsbt(wasm);
+    if (psbt.versionGroupId === IRONWOOD_VERSION_GROUP_ID) {
+      throw new Error("this is a v6 (Ironwood) PSBT: use ZcashIronwoodBitGoPsbt.fromBytes instead");
+    }
+    return psbt;
   }
 
   /**

--- a/packages/wasm-utxo/js/fixedScriptWallet/ZcashIronwoodBitGoPsbt.ts
+++ b/packages/wasm-utxo/js/fixedScriptWallet/ZcashIronwoodBitGoPsbt.ts
@@ -1,0 +1,252 @@
+import { BitGoPsbt as WasmBitGoPsbt } from "../wasm/wasm_utxo.js";
+import { type WalletKeysArg, RootWalletKeys } from "./RootWalletKeys.js";
+import {
+  IRONWOOD_VERSION_GROUP_ID,
+  ZcashBitGoPsbt,
+  type ZcashNetworkName,
+} from "./ZcashBitGoPsbt.js";
+
+/**
+ * Options for creating an empty Zcash v6 (Ironwood) shielding PSBT.
+ *
+ * Deliberately narrower than `CreateEmptyZcashOptions`: `version` and `versionGroupId` are fixed by
+ * the v6 format, so accepting them would only let a caller ask for something that is then ignored.
+ */
+export type CreateEmptyIronwoodOptions = {
+  /** Block height to determine the consensus branch ID automatically (at/after NU6.3 activation) */
+  blockHeight: number;
+  /** Lock time (default: 0) */
+  lockTime?: number;
+  /** Zcash transaction expiry height */
+  expiryHeight?: number;
+};
+
+/**
+ * Options for creating an empty Zcash v6 (Ironwood) shielding PSBT with an explicit consensus
+ * branch ID.
+ *
+ * Like {@link CreateEmptyIronwoodOptions}, this omits `version` and `versionGroupId` — both are
+ * fixed by the v6 format. The consensus branch ID is *not* fixed: it tracks the active network
+ * upgrade, so it stays a caller-supplied parameter exactly as it is for v4.
+ */
+export type CreateEmptyIronwoodWithConsensusBranchIdOptions = {
+  /** Zcash consensus branch ID (e.g. the NU6.3 branch ID) */
+  consensusBranchId: number;
+  /** Lock time (default: 0) */
+  lockTime?: number;
+  /** Zcash transaction expiry height */
+  expiryHeight?: number;
+};
+
+/**
+ * A fresh ZIP-302 "no memo" memo field: the `0xf6` marker byte followed by 511 zero bytes. The
+ * default for {@link ZcashIronwoodBitGoPsbt.addShieldedOutput}'s `memo` option.
+ *
+ * Not the same as an all-zeros memo, which decodes as a *text* memo holding the empty string and is
+ * rendered as such by wallets. Exported so callers can pass it explicitly, and so the distinction is
+ * visible rather than buried in a default.
+ *
+ * A function rather than a shared constant: a module-level `Uint8Array` is mutable, so one caller
+ * writing into it would silently change the default memo for every later output.
+ */
+export function zip302NoMemo(): Uint8Array {
+  const memo = new Uint8Array(512);
+  memo[0] = 0xf6;
+  return memo;
+}
+
+/**
+ * A Zcash **v6 (Ironwood / NU6.3)** shielding PSBT.
+ *
+ * Distinct from the generic `ZcashBitGoPsbt` (v4/Sapling-shaped transactions): a v6 PSBT carries
+ * its shielded side as an orchard PCZT in the proprietary map rather than Sapling fields, and its
+ * lifecycle mirrors the microservice build → sign → combine flow rather than the v4 ZIP-243
+ * signing path.
+ *
+ * Method names carry no `ironwood` prefix — the class name already says it. They follow the base
+ * `BitGoPsbt` vocabulary (`createEmpty`, `fromBytes`, `addOutput`-style adders, `getId`) so the v6
+ * surface reads the same as the v4 one; the wasm bindings keep their `ironwood_v6_*` names because
+ * they live on the single flat `BitGoPsbt` struct, where the prefix is what disambiguates them.
+ *
+ * @example
+ * ```typescript
+ * const psbt = ZcashIronwoodBitGoPsbt.createEmpty("zcash", walletKeys, { blockHeight });
+ * psbt.addWalletInput(...);
+ * psbt.addWalletOutput(...);
+ * psbt.addShieldedOutput(recipient, amount, { anchor });
+ * const sighash = psbt.transparentSighash(0);
+ * // ... sign sighash externally, then:
+ * psbt.addTransparentSignature(0, pubkey, sig);
+ * const tx = psbt.combineProof(proof);
+ * ```
+ */
+export class ZcashIronwoodBitGoPsbt extends ZcashBitGoPsbt {
+  /**
+   * Create an empty Zcash **v6 (Ironwood)** shielding PSBT, with the consensus branch ID
+   * determined from block height.
+   *
+   * Add transparent inputs/outputs with the usual `addWalletInput` / `addWalletOutput`, the
+   * shielded output with {@link addShieldedOutput}, then sign the transparent inputs over
+   * {@link transparentSighash} and finish with {@link combineProof}.
+   *
+   * @param network - Zcash network name ("zcash", "zcashTest", "zec", "tzec")
+   * @param walletKeys - The wallet's root keys (sets global xpubs in the PSBT)
+   * @param options - Options including blockHeight (at/after NU6.3 activation)
+   */
+  static override createEmpty(
+    network: ZcashNetworkName,
+    walletKeys: WalletKeysArg,
+    options: CreateEmptyIronwoodOptions,
+  ): ZcashIronwoodBitGoPsbt {
+    const keys = RootWalletKeys.from(walletKeys);
+    const wasm = WasmBitGoPsbt.create_empty_zcash_v6_at_height(
+      network,
+      keys.wasm,
+      options.blockHeight,
+      options.lockTime,
+      options.expiryHeight,
+    );
+    return new ZcashIronwoodBitGoPsbt(wasm);
+  }
+
+  /**
+   * Create an empty Zcash **v6 (Ironwood)** shielding PSBT with an explicit consensus branch ID.
+   *
+   * **Advanced use only.** Prefer {@link createEmpty}, which derives the branch ID from a block
+   * height and rejects heights before NU6.3 activation. Reach for this only when you already know
+   * the branch ID — regtest, a future upgrade, or replaying a known-good value.
+   *
+   * Only the *version group ID* is fixed by the v6 format; the consensus branch ID tracks the active
+   * network upgrade and remains caller-supplied, exactly as for v4.
+   *
+   * @param network - Zcash network name ("zcash", "zcashTest", "zec", "tzec")
+   * @param walletKeys - The wallet's root keys (sets global xpubs in the PSBT)
+   * @param options - Options including the required consensusBranchId
+   */
+  static override createEmptyWithConsensusBranchId(
+    network: ZcashNetworkName,
+    walletKeys: WalletKeysArg,
+    options: CreateEmptyIronwoodWithConsensusBranchIdOptions,
+  ): ZcashIronwoodBitGoPsbt {
+    const keys = RootWalletKeys.from(walletKeys);
+    const wasm = WasmBitGoPsbt.create_empty_zcash_v6(
+      network,
+      keys.wasm,
+      options.consensusBranchId,
+      options.lockTime,
+      options.expiryHeight,
+    );
+    return new ZcashIronwoodBitGoPsbt(wasm);
+  }
+
+  /**
+   * Not applicable to v6, and not implementable: a broadcast v6 transaction carries the shielded
+   * side as a proof plus a binding signature, while every v6 operation here needs the PCZT — which
+   * holds witness data (`rseed`, `rcv`, `alpha`, the note plaintext) that is deliberately *not*
+   * recoverable from the transaction. Decoding the transparent skeleton alone would yield a PSBT
+   * that `getId`, `transparentSighash`, `combineProof`, and even `serialize`/{@link fromBytes} all
+   * reject. Inherited only because JS statics are inherited.
+   */
+  static override fromNetworkFormat(): never {
+    throw new Error(
+      "not supported for v6 (Ironwood): the PCZT witness data cannot be recovered from a broadcast " +
+        "transaction; rebuild the PSBT with createEmpty",
+    );
+  }
+
+  /**
+   * Not applicable to v6: the legacy half-signed format is a v4-era p2ms encoding with no way to
+   * carry the PCZT, and no v6 transaction has ever been produced in it. Inherited only because JS
+   * statics are inherited.
+   */
+  static override fromHalfSignedLegacyTransaction(): never {
+    throw new Error(
+      "not supported for v6 (Ironwood): the legacy half-signed format is v4-only; " +
+        "rebuild the PSBT with createEmpty",
+    );
+  }
+
+  /**
+   * Deserialize a v6 (Ironwood) Zcash PSBT from bytes.
+   *
+   * @param bytes - The PSBT bytes
+   * @param network - Zcash network name ("zcash", "zcashTest", "zec", "tzec")
+   * @throws Error if the deserialized PSBT is not a v6 (Ironwood) PSBT
+   * @returns A ZcashIronwoodBitGoPsbt instance
+   */
+  static override fromBytes(bytes: Uint8Array, network: ZcashNetworkName): ZcashIronwoodBitGoPsbt {
+    const wasm = WasmBitGoPsbt.from_bytes(bytes, network);
+    const psbt = new ZcashIronwoodBitGoPsbt(wasm);
+    if (psbt.versionGroupId !== IRONWOOD_VERSION_GROUP_ID) {
+      throw new Error(
+        "not a v6 (Ironwood) PSBT: use ZcashBitGoPsbt.fromBytes for v4/Sapling-shaped PSBTs",
+      );
+    }
+    return psbt;
+  }
+
+  /**
+   * Add the shielded output (Constructor role). Stores the orchard PCZT in the PSBT.
+   *
+   * Named for the shielded/transparent split rather than the note type, leaving room for a
+   * transparent-output variant alongside the inherited `addOutput` / `addWalletOutput`.
+   *
+   * @param recipient - 43-byte raw Orchard/Ironwood address
+   * @param amount - note value in zatoshi
+   * @param options.anchor - 32-byte Ironwood note-commitment-tree root
+   * @param options.memo - optional 512-byte memo (defaults to the ZIP-302 "no memo" encoding)
+   * @param options.ovk - optional 32-byte outgoing viewing key (omit for a keyless build)
+   */
+  addShieldedOutput(
+    recipient: Uint8Array,
+    amount: bigint,
+    options: { anchor: Uint8Array; memo?: Uint8Array; ovk?: Uint8Array },
+  ): void {
+    const memo = options.memo ?? zip302NoMemo();
+    this.wasm.add_ironwood_output(recipient, amount, options.ovk, options.anchor, memo);
+  }
+
+  /**
+   * The canonical (display-order) ZIP-244 v6 txid as a lowercase hex string, matching
+   * `ITransaction.getId()`. Defined once the transparent inputs/outputs and the shielded output are
+   * in place; unchanged by signing or proving.
+   */
+  getId(): string {
+    return this.wasm.ironwood_v6_txid();
+  }
+
+  /**
+   * The ZIP-244 per-input transparent sighash (32 bytes) the key controlling transparent input
+   * `index` must sign.
+   */
+  transparentSighash(index: number): Uint8Array {
+    return this.wasm.ironwood_v6_transparent_sighash(index);
+  }
+
+  /**
+   * Ingest a transparent-input signature returned by the client/HSM, after verifying it against
+   * {@link transparentSighash} for that input.
+   *
+   * @param index - transparent input index
+   * @param pubkey - the signing public key
+   * @param sig - DER ECDSA signature with the trailing SIGHASH_ALL byte (as in a scriptSig)
+   */
+  addTransparentSignature(index: number, pubkey: Uint8Array, sig: Uint8Array): void {
+    this.wasm.add_ironwood_v6_signature(index, pubkey, sig);
+  }
+
+  /**
+   * Transaction Extractor role: given the external prover's `proof` bytes, finalize the
+   * transparent inputs, apply the shielded binding signature, and return the broadcast-ready v6
+   * transaction bytes. Requires every transparent input to be signed via
+   * {@link addTransparentSignature}.
+   *
+   * Terminal: the wasm binding drops the stored PCZT on success, so any later v6 call on this PSBT
+   * throws — including after a `serialize`/{@link fromBytes} round-trip, since the PCZT is gone
+   * from the bytes too. Build a fresh PSBT instead. On failure nothing is dropped, so a call that
+   * errors (bad proof, unsigned input) leaves the PSBT retryable.
+   */
+  combineProof(proof: Uint8Array): Uint8Array {
+    return this.wasm.combine_ironwood_proof(proof);
+  }
+}

--- a/packages/wasm-utxo/js/fixedScriptWallet/index.ts
+++ b/packages/wasm-utxo/js/fixedScriptWallet/index.ts
@@ -44,7 +44,16 @@ export {
   ZcashBitGoPsbt,
   type ZcashNetworkName,
   type CreateEmptyZcashOptions,
+  IRONWOOD_VERSION_GROUP_ID,
 } from "./ZcashBitGoPsbt.js";
+
+// Zcash v6 (Ironwood / NU6.3) shielding PSBT
+export {
+  ZcashIronwoodBitGoPsbt,
+  zip302NoMemo,
+  type CreateEmptyIronwoodOptions,
+  type CreateEmptyIronwoodWithConsensusBranchIdOptions,
+} from "./ZcashIronwoodBitGoPsbt.js";
 
 // Zcash ZIP-316 Unified Address
 export { ZcashUnifiedAddress } from "./ZcashUnifiedAddress.js";

--- a/packages/wasm-utxo/src/fixed_script_wallet/bitgo_psbt/mod.rs
+++ b/packages/wasm-utxo/src/fixed_script_wallet/bitgo_psbt/mod.rs
@@ -497,6 +497,33 @@ impl BitGoPsbt {
         ))
     }
 
+    /// Create an empty Zcash **v6 (Ironwood)** shielding PSBT with an explicit consensus branch id.
+    /// Delegates to [`ZcashBitGoPsbt::new_v6`].
+    ///
+    /// The version group id is fixed by the v6 format, but the consensus branch id is not — it
+    /// tracks the active network upgrade, so it stays a caller-supplied parameter here just as it is
+    /// for v4 in [`Self::new_zcash`]. Prefer [`Self::new_zcash_v6_at_height`], which derives it and
+    /// checks the height is at/after NU6.3 activation; this is the escape hatch for callers that
+    /// already know the branch id (regtest, a future upgrade, replaying a known-good value).
+    pub fn new_zcash_v6(
+        network: Network,
+        wallet_keys: &crate::fixed_script_wallet::RootWalletKeys,
+        consensus_branch_id: u32,
+        lock_time: Option<u32>,
+        expiry_height: Option<u32>,
+    ) -> Self {
+        BitGoPsbt::Zcash(
+            ZcashBitGoPsbt::new_v6(
+                network,
+                wallet_keys,
+                consensus_branch_id,
+                lock_time,
+                expiry_height,
+            ),
+            network,
+        )
+    }
+
     /// Create an empty Zcash **v6 (Ironwood)** shielding PSBT with the consensus branch id resolved
     /// from block height. Delegates to [`ZcashBitGoPsbt::new_v6_at_height`].
     ///
@@ -1374,8 +1401,20 @@ impl BitGoPsbt {
     /// For all other coins the bitcoin PSBT deserializer is used.
     ///
     /// Copies per input: partial_sigs, tap_key_sig, tap_script_sigs, proprietary.
+    ///
+    /// Not supported for Zcash v6 (Ironwood) PSBTs: `deserialize_stripped` exists to accept an HSM
+    /// response that has dropped everything but the signatures, but v6 bytes route to
+    /// `deserialize_v6`, which requires the consensus branch id and the PCZT — so a stripped v6
+    /// response would fail with a "missing its Ironwood PCZT" error describing a corrupt PSBT
+    /// rather than an unsupported path. v6 ingests signatures via
+    /// [`ZcashBitGoPsbt::add_v6_transparent_signature`] instead.
     pub fn combine_inputs(&mut self, other_bytes: &[u8]) -> Result<(), String> {
         let raw: Psbt = match self {
+            BitGoPsbt::Zcash(z, _) if z.is_ironwood_v6() => {
+                return Err("combine_inputs is not supported for v6 (Ironwood) PSBTs; \
+                     use add_v6_transparent_signature to ingest transparent signatures"
+                    .to_string());
+            }
             BitGoPsbt::Zcash(_, network) => {
                 ZcashBitGoPsbt::deserialize_stripped(other_bytes, *network)
                     .map(|z| z.psbt)

--- a/packages/wasm-utxo/src/fixed_script_wallet/bitgo_psbt/propkv.rs
+++ b/packages/wasm-utxo/src/fixed_script_wallet/bitgo_psbt/propkv.rs
@@ -322,6 +322,21 @@ pub fn get_ironwood_pczt(psbt: &miniscript::bitcoin::psbt::Psbt) -> Option<Vec<u
     get_zec_v6(psbt, ZecV6KeySubtype::IronwoodPczt)
 }
 
+/// Remove the serialized Ironwood (v6) PCZT bundle, returning whether one was present.
+///
+/// Used to make extraction terminal: once `combine_ironwood_proof` has produced the broadcast-ready
+/// transaction, dropping the PCZT means any further Ironwood operation on that PSBT — including
+/// after a `serialize`/`deserialize` round-trip — fails loudly instead of silently re-running
+/// against state that has already been spent.
+pub fn take_ironwood_pczt(psbt: &mut miniscript::bitcoin::psbt::Psbt) -> bool {
+    let key = miniscript::bitcoin::psbt::raw::ProprietaryKey {
+        prefix: BITGO_ZEC_V6.to_vec(),
+        subtype: ZecV6KeySubtype::IronwoodPczt as u8,
+        key: vec![],
+    };
+    psbt.proprietary.remove(&key).is_some()
+}
+
 /// Store the Zcash v6 (Ironwood) header params — `version_group_id` and `expiry_height` — under the
 /// `BITGO_ZEC_V6` namespace. `version_group_id`'s presence marks the PSBT as v6; `expiry_height` is
 /// always written too (even when 0, a valid "no expiry" value, so it can be told apart from absent).

--- a/packages/wasm-utxo/src/fixed_script_wallet/bitgo_psbt/zcash_psbt.rs
+++ b/packages/wasm-utxo/src/fixed_script_wallet/bitgo_psbt/zcash_psbt.rs
@@ -265,6 +265,22 @@ impl ZcashBitGoPsbt {
         network: crate::Network,
         require_branch_id: bool,
     ) -> Result<Self, super::DeserializeError> {
+        // A v6 (Ironwood) PSBT is a plain PSBT carrying the transparent skeleton, so it parses
+        // directly; the presence of the ZecV6Params proprietary key distinguishes it from the v4
+        // path (whose embedded overwintered tx a plain PSBT decoder cannot parse). Both share the
+        // `psbt\xff` magic, so a failed parse here is not conclusive — fall through to the v4 path
+        // and let it report the real error.
+        //
+        // Delegate to `deserialize_v6` rather than constructing the struct inline: it validates the
+        // declared version group id, the consensus branch id and the PCZT. Trusting them would let a
+        // PSBT that carries ZecV6Params but a non-Ironwood version group id through with
+        // `is_ironwood_v6() == false`, which then routes `serialize()` back down the v4 path.
+        if let Ok(psbt) = Psbt::deserialize(bytes) {
+            if super::propkv::get_zec_v6_params(&psbt).is_some() {
+                return Self::deserialize_v6(bytes, network);
+            }
+        }
+
         let mut r = bytes;
 
         // Read magic bytes
@@ -432,6 +448,12 @@ impl ZcashBitGoPsbt {
 
     /// Serialize the Zcash PSBT back to bytes, including Zcash-specific fields
     pub fn serialize(&self) -> Result<Vec<u8>, super::DeserializeError> {
+        // A v6 (Ironwood) PSBT keeps its transparent skeleton in the PSBT's own tx and its shielded
+        // state in the proprietary map, so it serializes as a plain PSBT.
+        if self.is_ironwood_v6() {
+            return Ok(self.serialize_v6());
+        }
+
         // First serialize as standard Bitcoin PSBT
         let bitcoin_psbt_bytes = self.psbt.serialize();
 
@@ -668,11 +690,11 @@ impl ZcashBitGoPsbt {
     /// overwrite of the first note (whose value the transparent side would still be funding).
     pub fn add_ironwood_output<R: rand::RngCore + rand::CryptoRng>(
         &mut self,
-        recipient: &[u8; crate::zcash::ironwood_build::ORCHARD_ADDRESS_SIZE],
+        recipient: &crate::zcash::ironwood_build::OrchardAddressBytes,
         amount: u64,
-        ovk: Option<[u8; 32]>,
-        anchor: &[u8; 32],
-        memo: &[u8; 512],
+        ovk: Option<crate::zcash::ironwood_build::OvkBytes>,
+        anchor: &crate::zcash::ironwood_build::AnchorBytes,
+        memo: &crate::zcash::ironwood_build::MemoBytes,
         rng: R,
     ) -> Result<(), String> {
         if super::propkv::get_ironwood_pczt(&self.psbt).is_some() {
@@ -943,6 +965,17 @@ impl ZcashBitGoPsbt {
 
         let tx = self.to_v6_transaction(transparent, Some(full_bundle))?;
         crate::zcash::v6::encode_v6_transaction(&tx).map_err(|e| e.to_string())
+    }
+
+    /// Mark this v6 PSBT as extracted by dropping its PCZT, making [`Self::combine_ironwood_proof`]
+    /// terminal for callers that cannot consume the PSBT by value (the wasm bindings, which must
+    /// clone). Any later Ironwood operation then fails with "no Ironwood PCZT stored in PSBT"
+    /// instead of silently re-running against already-extracted state — and because the PCZT is
+    /// gone from the bytes too, that holds across a `serialize`/`deserialize` round-trip.
+    ///
+    /// Returns whether a PCZT was present.
+    pub fn mark_ironwood_extracted(&mut self) -> bool {
+        super::propkv::take_ironwood_pczt(&mut self.psbt)
     }
 
     /// Serialize a v6 PSBT to bytes: a plain PSBT carrying the transparent skeleton in
@@ -1341,6 +1374,39 @@ mod ironwood_v6_tests {
         assert!(err.contains("already present"), "unexpected error: {err}");
     }
 
+    /// `mark_ironwood_extracted` makes extraction terminal for callers that must clone rather than
+    /// consume the PSBT (the wasm bindings): the PCZT is gone, so every later Ironwood operation
+    /// fails loudly instead of silently re-running against already-extracted state — and because the
+    /// PCZT is absent from the serialized bytes too, a round-trip cannot launder it back.
+    #[test]
+    fn mark_ironwood_extracted_is_terminal() {
+        let mut z = build_shield_psbt("v6_extracted");
+        assert!(z.v6_txid().is_ok(), "usable before extraction");
+
+        assert!(z.mark_ironwood_extracted(), "a PCZT was present");
+        assert!(!z.mark_ironwood_extracted(), "second call is a no-op");
+
+        // Every operation that reads the shielded state now fails. (`combine_ironwood_proof` is not
+        // listed because its transparent-signature check fires first on this unsigned PSBT; it reads
+        // the PCZT via the same `ironwood_pczt()` accessor as these.)
+        for err in [
+            z.v6_txid().unwrap_err(),
+            z.v6_transparent_sighash(0).unwrap_err(),
+            z.ironwood_action_data().unwrap_err(),
+        ] {
+            assert!(err.contains("no Ironwood PCZT"), "unexpected error: {err}");
+        }
+
+        // The serialized bytes no longer carry a PCZT, and `deserialize` rejects that outright.
+        let err = ZcashBitGoPsbt::deserialize(&z.serialize().unwrap(), Network::ZcashTestnet)
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("missing its Ironwood PCZT"),
+            "unexpected error: {err}"
+        );
+    }
+
     /// A signature from a key outside the input's redeem script is rejected at ingest, rather than
     /// being silently dropped at finalization.
     #[test]
@@ -1448,11 +1514,14 @@ mod ironwood_v6_tests {
 
     /// The v4 code paths refuse a v6 PSBT instead of emitting a v4-shaped transaction (which would
     /// be unbroadcastable) or a ZIP-243 signature (which could never verify).
+    ///
+    /// `serialize()` is deliberately excluded: it is v6-aware (routes to `serialize_v6()` when
+    /// `is_ironwood_v6()`), so a v6 PSBT round-trips through the standard `serialize`/`fromBytes`
+    /// path without the v4 tx-replacement dance — see `serialize()`'s doc comment.
     #[test]
     fn v4_paths_reject_a_v6_psbt() {
         let z = build_shield_psbt("v6_v4_guard");
         for err in [
-            z.serialize().unwrap_err().to_string(),
             z.extract_unsigned_zcash_transaction()
                 .unwrap_err()
                 .to_string(),
@@ -1464,6 +1533,11 @@ mod ironwood_v6_tests {
                 "unexpected error: {err}"
             );
         }
+
+        // `serialize()` succeeds for v6 (v6-aware) and round-trips via `deserialize()`.
+        let bytes = z.serialize().unwrap();
+        let round = ZcashBitGoPsbt::deserialize(&bytes, Network::ZcashTestnet).unwrap();
+        assert!(round.is_ironwood_v6());
 
         // The generic sign path refuses too, so no ZIP-243 signature can reach `partial_sigs`.
         let mut generic = BitGoPsbt::Zcash(z, Network::ZcashTestnet);
@@ -1480,6 +1554,33 @@ mod ironwood_v6_tests {
         );
     }
 
+    /// `combine_inputs` refuses a v6 PSBT outright.
+    ///
+    /// It parses the incoming bytes with `deserialize_stripped`, whose whole purpose is to accept an
+    /// HSM response that has dropped everything but the signatures. v6 bytes short-circuit to
+    /// `deserialize_v6`, which requires the branch id and the PCZT, so a stripped v6 response would
+    /// otherwise fail with "missing its Ironwood PCZT" — an error describing a corrupt PSBT rather
+    /// than an unsupported code path.
+    #[test]
+    fn combine_inputs_rejects_a_v6_psbt() {
+        let z = build_shield_psbt("v6_combine_inputs");
+        // A stripped response: the same PSBT with the shielded state removed, as an HSM would return.
+        let mut stripped = z.clone();
+        stripped.mark_ironwood_extracted();
+        let stripped_bytes = stripped.serialize_v6();
+
+        let mut generic = BitGoPsbt::Zcash(z, Network::ZcashTestnet);
+        let err = generic.combine_inputs(&stripped_bytes).unwrap_err();
+        assert!(
+            err.contains("not supported for v6 (Ironwood)"),
+            "unexpected error: {err}"
+        );
+        assert!(
+            err.contains("add_v6_transparent_signature"),
+            "the error names the supported path: {err}"
+        );
+    }
+
     /// `deserialize_v6` validates the version group id rather than trusting it — an unchecked value
     /// would leave `is_ironwood_v6()` false and route `serialize` back down the v4 path.
     #[test]
@@ -1491,6 +1592,27 @@ mod ironwood_v6_tests {
             0,
         );
         let err = ZcashBitGoPsbt::deserialize_v6(&z.serialize_v6(), Network::ZcashTestnet)
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("expected the Ironwood id"),
+            "unexpected error: {err}"
+        );
+    }
+
+    /// The *general* `deserialize` entry point routes v6-shaped bytes through `deserialize_v6`, so
+    /// it inherits that validation. Without the delegation a PSBT carrying ZecV6Params but a
+    /// non-Ironwood version group id would deserialize with `is_ironwood_v6() == false` and then
+    /// serialize back down the v4 path.
+    #[test]
+    fn deserialize_rejects_a_v6_psbt_with_a_non_ironwood_version_group_id() {
+        let mut z = build_shield_psbt("v6_bad_vgid_general");
+        crate::fixed_script_wallet::bitgo_psbt::propkv::set_zec_v6_params(
+            &mut z.psbt,
+            ZCASH_SAPLING_VERSION_GROUP_ID,
+            0,
+        );
+        let err = ZcashBitGoPsbt::deserialize(&z.serialize_v6(), Network::ZcashTestnet)
             .unwrap_err()
             .to_string();
         assert!(

--- a/packages/wasm-utxo/src/wasm/fixed_script_wallet/mod.rs
+++ b/packages/wasm-utxo/src/wasm/fixed_script_wallet/mod.rs
@@ -307,6 +307,30 @@ pub struct BitGoPsbt {
     pub(crate) first_rounds: HashMap<(usize, String), musig2::FirstRound>,
 }
 
+impl BitGoPsbt {
+    /// Borrow the inner `ZcashBitGoPsbt`, erroring if this is not a Zcash PSBT.
+    fn zcash(
+        &self,
+    ) -> Result<&crate::fixed_script_wallet::bitgo_psbt::ZcashBitGoPsbt, WasmUtxoError> {
+        use crate::fixed_script_wallet::bitgo_psbt::BitGoPsbt as InnerBitGoPsbt;
+        match &self.psbt {
+            InnerBitGoPsbt::Zcash(z, _) => Ok(z),
+            _ => Err(WasmUtxoError::new("not a Zcash PSBT")),
+        }
+    }
+
+    /// Mutably borrow the inner `ZcashBitGoPsbt`, erroring if this is not a Zcash PSBT.
+    fn zcash_mut(
+        &mut self,
+    ) -> Result<&mut crate::fixed_script_wallet::bitgo_psbt::ZcashBitGoPsbt, WasmUtxoError> {
+        use crate::fixed_script_wallet::bitgo_psbt::BitGoPsbt as InnerBitGoPsbt;
+        match &mut self.psbt {
+            InnerBitGoPsbt::Zcash(z, _) => Ok(z),
+            _ => Err(WasmUtxoError::new("not a Zcash PSBT")),
+        }
+    }
+}
+
 #[wasm_bindgen]
 impl BitGoPsbt {
     /// Deserialize a PSBT from bytes with network-specific logic
@@ -437,6 +461,161 @@ impl BitGoPsbt {
             psbt,
             first_rounds: HashMap::new(),
         })
+    }
+
+    // ---- Zcash v6 (Ironwood / NU6.3) shielding ----
+
+    /// Create an empty Zcash **v6 (Ironwood)** shielding PSBT with an explicit consensus branch id.
+    ///
+    /// The version group id is fixed by the v6 format, but the consensus branch id tracks the active
+    /// network upgrade and stays caller-supplied — the v6 analogue of `create_empty_zcash`. Prefer
+    /// `create_empty_zcash_v6_at_height`, which derives it from a block height and rejects heights
+    /// before NU6.3 activation; this is the escape hatch for callers that already know the value.
+    pub fn create_empty_zcash_v6(
+        network: &str,
+        wallet_keys: &WasmRootWalletKeys,
+        consensus_branch_id: u32,
+        lock_time: Option<u32>,
+        expiry_height: Option<u32>,
+    ) -> Result<BitGoPsbt, WasmUtxoError> {
+        let network = parse_network(network)?;
+        let wallet_keys = wallet_keys.inner();
+        let psbt = crate::fixed_script_wallet::bitgo_psbt::BitGoPsbt::new_zcash_v6(
+            network,
+            wallet_keys,
+            consensus_branch_id,
+            lock_time,
+            expiry_height,
+        );
+        Ok(BitGoPsbt {
+            psbt,
+            first_rounds: HashMap::new(),
+        })
+    }
+
+    /// Create an empty Zcash **v6 (Ironwood)** shielding PSBT, with the consensus branch id
+    /// resolved from `block_height`. Transparent inputs/outputs are added with the usual
+    /// `add_wallet_input` / `add_wallet_output`; the shielded output and the v6 sign/combine
+    /// steps use the dedicated `add_ironwood_output` / `ironwood_v6_*` / `combine_ironwood_proof`
+    /// methods.
+    pub fn create_empty_zcash_v6_at_height(
+        network: &str,
+        wallet_keys: &WasmRootWalletKeys,
+        block_height: u32,
+        lock_time: Option<u32>,
+        expiry_height: Option<u32>,
+    ) -> Result<BitGoPsbt, WasmUtxoError> {
+        let network = parse_network(network)?;
+        let wallet_keys = wallet_keys.inner();
+        let psbt = crate::fixed_script_wallet::bitgo_psbt::BitGoPsbt::new_zcash_v6_at_height(
+            network,
+            wallet_keys,
+            block_height,
+            lock_time,
+            expiry_height,
+        )
+        .map_err(|e| WasmUtxoError::new(&e))?;
+        Ok(BitGoPsbt {
+            psbt,
+            first_rounds: HashMap::new(),
+        })
+    }
+
+    /// Constructor: add the shielded Ironwood output as an orchard PCZT stored in the PSBT.
+    ///
+    /// * `recipient` - raw Orchard/Ironwood address ([`ORCHARD_ADDRESS_SIZE`] bytes)
+    /// * `amount` - note value in zatoshi
+    /// * `ovk` - optional outgoing viewing key ([`OVK_SIZE`] bytes; `None` for a keyless build)
+    /// * `anchor` - Ironwood note-commitment-tree root ([`ANCHOR_SIZE`] bytes)
+    /// * `memo` - ZIP-302 memo field ([`MEMO_SIZE`] bytes)
+    ///
+    /// [`ORCHARD_ADDRESS_SIZE`]: crate::zcash::ironwood_build::ORCHARD_ADDRESS_SIZE
+    /// [`OVK_SIZE`]: crate::zcash::ironwood_build::OVK_SIZE
+    /// [`ANCHOR_SIZE`]: crate::zcash::ironwood_build::ANCHOR_SIZE
+    /// [`MEMO_SIZE`]: crate::zcash::ironwood_build::MEMO_SIZE
+    pub fn add_ironwood_output(
+        &mut self,
+        recipient: &[u8],
+        amount: u64,
+        ovk: Option<Vec<u8>>,
+        anchor: &[u8],
+        memo: &[u8],
+    ) -> Result<(), WasmUtxoError> {
+        use crate::zcash::ironwood_build::{
+            AnchorBytes, MemoBytes, OrchardAddressBytes, OvkBytes, ANCHOR_SIZE, MEMO_SIZE,
+            ORCHARD_ADDRESS_SIZE, OVK_SIZE,
+        };
+
+        /// Length-check a boundary byte string, naming the field and its expected size in the error.
+        fn fixed<const N: usize>(bytes: &[u8], field: &str) -> Result<[u8; N], WasmUtxoError> {
+            bytes.try_into().map_err(|_| {
+                WasmUtxoError::new(&format!("{field} must be {N} bytes, got {}", bytes.len()))
+            })
+        }
+
+        let recipient: OrchardAddressBytes = fixed::<ORCHARD_ADDRESS_SIZE>(recipient, "recipient")?;
+        let anchor: AnchorBytes = fixed::<ANCHOR_SIZE>(anchor, "anchor")?;
+        let memo: MemoBytes = fixed::<MEMO_SIZE>(memo, "memo")?;
+        let ovk: Option<OvkBytes> = ovk.map(|v| fixed::<OVK_SIZE>(&v, "ovk")).transpose()?;
+        self.zcash_mut()?
+            .add_ironwood_output(&recipient, amount, ovk, &anchor, &memo, rand::rngs::OsRng)
+            .map_err(|e| WasmUtxoError::new(&e))
+    }
+
+    /// The canonical (display-order) ZIP-244 v6 txid as a lowercase hex string, matching the
+    /// `getId()` convention used elsewhere (see [`crate::wasm::zcash::ZcashV6Transaction::get_id`]).
+    pub fn ironwood_v6_txid(&self) -> Result<String, WasmUtxoError> {
+        use miniscript::bitcoin::hashes::Hash;
+        let txid = self
+            .zcash()?
+            .v6_txid()
+            .map_err(|e| WasmUtxoError::new(&e))?;
+        Ok(miniscript::bitcoin::Txid::from_byte_array(txid).to_string())
+    }
+
+    /// The ZIP-244 per-input transparent sighash (32 bytes) that the key controlling transparent
+    /// input `index` must sign.
+    pub fn ironwood_v6_transparent_sighash(&self, index: usize) -> Result<Vec<u8>, WasmUtxoError> {
+        self.zcash()?
+            .v6_transparent_sighash(index)
+            .map(|h| h.to_vec())
+            .map_err(|e| WasmUtxoError::new(&e))
+    }
+
+    /// Ingest a transparent-input signature (`sig`: DER ECDSA with the trailing SIGHASH_ALL byte)
+    /// after verifying it against `ironwood_v6_transparent_sighash(index)`.
+    pub fn add_ironwood_v6_signature(
+        &mut self,
+        index: usize,
+        pubkey: &[u8],
+        sig: &[u8],
+    ) -> Result<(), WasmUtxoError> {
+        let pk = miniscript::bitcoin::PublicKey::from_slice(pubkey)
+            .map_err(|e| WasmUtxoError::new(&format!("invalid pubkey: {e}")))?;
+        self.zcash_mut()?
+            .add_v6_transparent_signature(index, pk, sig)
+            .map_err(|e| WasmUtxoError::new(&e))
+    }
+
+    /// Transaction Extractor: given the external prover's `proof` bytes, finalize the transparent
+    /// inputs, apply the shielded binding signature, and return the broadcast-ready v6 transaction
+    /// bytes. Requires the transparent inputs to be signed (via `add_ironwood_v6_signature`).
+    ///
+    /// Terminal: on success the stored PCZT is dropped, so a second call — or any other Ironwood
+    /// operation, including after a `serialize`/`from_bytes` round-trip — fails rather than silently
+    /// re-running against already-extracted state. Build a fresh PSBT instead. On failure nothing is
+    /// dropped, so a call that errors (bad proof, unsigned input) leaves the PSBT retryable.
+    pub fn combine_ironwood_proof(&mut self, proof: &[u8]) -> Result<Vec<u8>, WasmUtxoError> {
+        // The inner `combine_ironwood_proof` takes `self` by value (it is a consuming Extractor
+        // step), which does not translate across the wasm boundary — so clone, and mark this
+        // instance spent only once the clone has actually produced a transaction.
+        let tx = self
+            .zcash()?
+            .clone()
+            .combine_ironwood_proof(proof.to_vec(), rand::rngs::OsRng)
+            .map_err(|e| WasmUtxoError::new(&e))?;
+        self.zcash_mut()?.mark_ironwood_extracted();
+        Ok(tx)
     }
 
     /// Convert a half-signed legacy transaction to a psbt-lite.

--- a/packages/wasm-utxo/src/wasm/zcash.rs
+++ b/packages/wasm-utxo/src/wasm/zcash.rs
@@ -32,6 +32,16 @@ pub fn zcash_branch_id_for_height(
     Ok(crate::zcash::branch_id_for_height(height, is_mainnet))
 }
 
+/// The Zcash v6 (Ironwood / NU6.3) version group id.
+///
+/// Exported so the TypeScript layer can derive its `IRONWOOD_VERSION_GROUP_ID` from the Rust
+/// constant instead of hard-coding a second copy: the two are used together to tell v6 PSBTs from
+/// v4/Sapling ones, and a silent divergence would route v6 bytes down the v4 path.
+#[wasm_bindgen]
+pub fn zcash_ironwood_version_group_id() -> u32 {
+    crate::zcash::transaction::ZCASH_IRONWOOD_VERSION_GROUP_ID
+}
+
 /// A parsed ZIP-316 Unified Address.
 ///
 /// Decode once with [`ZcashUnifiedAddress::parse`], then read each component through

--- a/packages/wasm-utxo/src/zcash/ironwood_build.rs
+++ b/packages/wasm-utxo/src/zcash/ironwood_build.rs
@@ -40,6 +40,21 @@ use super::v6::{IronwoodAction, IronwoodBundle};
 
 /// Length of a raw Orchard/Ironwood receiver (`Address`) in bytes.
 pub const ORCHARD_ADDRESS_SIZE: usize = 43;
+/// Length of an Ironwood note-commitment-tree root (`Anchor`) in bytes.
+pub const ANCHOR_SIZE: usize = 32;
+/// Length of an outgoing viewing key in bytes.
+pub const OVK_SIZE: usize = 32;
+/// Length of the ZIP-302 memo field in bytes.
+pub const MEMO_SIZE: usize = 512;
+
+/// A raw Orchard/Ironwood receiver.
+pub type OrchardAddressBytes = [u8; ORCHARD_ADDRESS_SIZE];
+/// An Ironwood note-commitment-tree root.
+pub type AnchorBytes = [u8; ANCHOR_SIZE];
+/// A raw outgoing viewing key.
+pub type OvkBytes = [u8; OVK_SIZE];
+/// A ZIP-302 memo field.
+pub type MemoBytes = [u8; MEMO_SIZE];
 
 /// Errors produced while constructing or combining an Ironwood shielded bundle.
 ///
@@ -101,11 +116,11 @@ crate::impl_wasm_error_code!(IronwoodBuildError);
 /// The returned PCZT carries no signatures or proof yet; run [`finalize_shield_io`] once the sighash
 /// is known, then hand it to the prover and [`combine`].
 pub fn construct_shield_pczt<R: RngCore + CryptoRng>(
-    recipient: &[u8; ORCHARD_ADDRESS_SIZE],
+    recipient: &OrchardAddressBytes,
     amount: u64,
-    ovk: Option<[u8; 32]>,
-    anchor: &[u8; 32],
-    memo: &[u8; 512],
+    ovk: Option<OvkBytes>,
+    anchor: &AnchorBytes,
+    memo: &MemoBytes,
     rng: R,
 ) -> Result<PcztBundle, IronwoodBuildError> {
     let recipient = Option::from(Address::from_raw_address_bytes(recipient))

--- a/packages/wasm-utxo/test/fixedScript/zcashIronwoodPsbt.ts
+++ b/packages/wasm-utxo/test/fixedScript/zcashIronwoodPsbt.ts
@@ -1,0 +1,291 @@
+import assert from "node:assert";
+import { describe, it } from "mocha";
+
+import {
+  ZcashIronwoodBitGoPsbt,
+  zip302NoMemo,
+} from "../../js/fixedScriptWallet/ZcashIronwoodBitGoPsbt.js";
+import {
+  IRONWOOD_VERSION_GROUP_ID,
+  ZcashBitGoPsbt,
+} from "../../js/fixedScriptWallet/ZcashBitGoPsbt.js";
+import { getWalletKeysForSeed } from "../../js/testutils/index.js";
+
+// NU6.3 (Ironwood) testnet activation height.
+const NU6_3_TESTNET_HEIGHT = 4134000;
+
+// A valid raw Orchard/Ironwood receiver (43 bytes), derived in Rust from
+// SpendingKey([7u8; 32]) → FullViewingKey → address_at(0, External).
+const RECIPIENT = Buffer.from(
+  "4559029c0b5dbf941c5ad181a5fe8f45b34630f29d0c8dd8dc1cc3573386f416cb324133156d723df5e62d",
+  "hex",
+);
+
+const SCRIPT_ID = { chain: 0, index: 0 } as const;
+
+describe("ZcashIronwoodBitGoPsbt v6 (Ironwood)", function () {
+  const walletKeys = getWalletKeysForSeed("ironwood-ts");
+
+  function buildShieldPsbt(): ZcashIronwoodBitGoPsbt {
+    const psbt = ZcashIronwoodBitGoPsbt.createEmpty("zcashTest", walletKeys, {
+      blockHeight: NU6_3_TESTNET_HEIGHT,
+    });
+    // One 2-of-3 P2SH transparent input (2 ZEC) and a transparent change output.
+    psbt.addWalletInput({ txid: "11".repeat(32), vout: 0, value: 200_000_000n }, walletKeys, {
+      scriptId: SCRIPT_ID,
+      signPath: { signer: "user", cosigner: "bitgo" },
+    });
+    psbt.addWalletOutput(walletKeys, { chain: 1, index: 0, value: 99_900_000n });
+    // Shielded Ironwood output (1 ZEC). Any valid Pallas base element is a usable build-time
+    // anchor (validity against a real tree is a prover concern), so all-zeros works.
+    psbt.addShieldedOutput(RECIPIENT, 100_000_000n, { anchor: new Uint8Array(32) });
+    return psbt;
+  }
+
+  /** The user pubkey in the input's 2-of-3 redeem script (derivation prefix `m/0/0`, then chain/index). */
+  function userPubkeyForInput(): Uint8Array {
+    return walletKeys.userKey().derivePath(`0/0/${SCRIPT_ID.chain}/${SCRIPT_ID.index}`).publicKey;
+  }
+
+  it("creates an Ironwood PSBT with the Ironwood version group id", function () {
+    const psbt = buildShieldPsbt();
+    assert.strictEqual(psbt.versionGroupId, IRONWOOD_VERSION_GROUP_ID);
+  });
+
+  it("computes a canonical v6 txid and 32-byte per-input sighash that survive a serialize round-trip", function () {
+    const psbt = buildShieldPsbt();
+    const txid = psbt.getId();
+    assert.match(txid, /^[0-9a-f]{64}$/, "canonical (display-order) hex txid");
+    const sighash = psbt.transparentSighash(0);
+    assert.strictEqual(sighash.length, 32);
+
+    // serialize → fromBytes preserves the v6 state (transparent skeleton + PCZT + params).
+    const bytes = psbt.serialize();
+    const round = ZcashIronwoodBitGoPsbt.fromBytes(bytes, "zcashTest");
+    assert.strictEqual(round.versionGroupId, IRONWOOD_VERSION_GROUP_ID);
+    assert.strictEqual(round.getId(), txid);
+    assert.deepStrictEqual(round.transparentSighash(0), sighash);
+  });
+
+  it("rejects a well-formed signature that does not verify against the v6 sighash", function () {
+    const psbt = buildShieldPsbt();
+    // A pubkey the redeem script actually contains, so the failure comes from verification against
+    // the v6 sighash rather than from the pubkey checks below.
+    // Minimal well-formed DER encoding of (r, s) = (1, 1) plus the SIGHASH_ALL byte: parses as a
+    // signature, cannot verify against any message.
+    const sig = Buffer.from("3006020101020101" + "01", "hex");
+    assert.throws(
+      () => psbt.addTransparentSignature(0, userPubkeyForInput(), sig),
+      /does not verify/i,
+    );
+  });
+
+  it("rejects a signature whose sighash type is not SIGHASH_ALL", function () {
+    const psbt = buildShieldPsbt();
+    // Same DER body, SIGHASH_NONE (0x02) type byte.
+    const sig = Buffer.from("3006020101020101" + "02", "hex");
+    assert.throws(
+      () => psbt.addTransparentSignature(0, userPubkeyForInput(), sig),
+      /must be SIGHASH_ALL/,
+    );
+  });
+
+  it("rejects a malformed pubkey", function () {
+    const psbt = buildShieldPsbt();
+    // All-zeros is not a valid secp256k1 point, so this fails before any sighash comparison.
+    assert.throws(
+      () => psbt.addTransparentSignature(0, new Uint8Array(33), new Uint8Array(72)),
+      /invalid pubkey/,
+    );
+  });
+
+  it("rejects a valid pubkey that is not in the input's redeem script", function () {
+    const psbt = buildShieldPsbt();
+    const stranger = getWalletKeysForSeed("not-this-wallet").userKey().publicKey;
+    assert.throws(
+      () => psbt.addTransparentSignature(0, stranger, new Uint8Array(72)),
+      /not one of the redeem script's keys/,
+    );
+  });
+
+  it("rejects an out-of-range transparent input index", function () {
+    const psbt = buildShieldPsbt();
+    assert.throws(() => psbt.transparentSighash(5), /out of range/);
+  });
+
+  describe("addShieldedOutput byte-length validation", function () {
+    // Each field is validated at the wasm boundary, before the orchard builder is touched.
+    const anchor = new Uint8Array(32);
+    const cases: Array<[string, () => void, RegExp]> = [
+      [
+        "recipient",
+        () => buildShieldPsbt().addShieldedOutput(new Uint8Array(10), 1n, { anchor }),
+        /recipient must be 43 bytes/,
+      ],
+      [
+        "anchor",
+        () => buildShieldPsbt().addShieldedOutput(RECIPIENT, 1n, { anchor: new Uint8Array(31) }),
+        /anchor must be 32 bytes/,
+      ],
+      [
+        "memo",
+        () =>
+          buildShieldPsbt().addShieldedOutput(RECIPIENT, 1n, { anchor, memo: new Uint8Array(511) }),
+        /memo must be 512 bytes/,
+      ],
+      [
+        "ovk",
+        () =>
+          buildShieldPsbt().addShieldedOutput(RECIPIENT, 1n, { anchor, ovk: new Uint8Array(31) }),
+        /ovk must be 32 bytes/,
+      ],
+    ];
+    for (const [field, run, expected] of cases) {
+      it(`rejects a ${field} of the wrong length`, function () {
+        assert.throws(run, expected);
+      });
+    }
+  });
+
+  it("rejects a second Ironwood output", function () {
+    const psbt = buildShieldPsbt();
+    assert.throws(
+      () => psbt.addShieldedOutput(RECIPIENT, 1n, { anchor: new Uint8Array(32) }),
+      /already present/,
+    );
+  });
+
+  describe("combineProof", function () {
+    // The Rust `combine_ironwood_proof` consumes `self`, so the wasm binding clones and only calls
+    // `mark_ironwood_extracted()` after the clone has actually produced a transaction. That ordering
+    // is a property of the binding, not of the Rust function it wraps (a consuming call has no
+    // "after failure" state to be in), so it is only observable — and only pinned — from here.
+
+    it("leaves the PSBT usable when it fails, so the call is retryable", function () {
+      const psbt = buildShieldPsbt();
+      const txid = psbt.getId();
+
+      // The transparent input is unsigned, so finalization fails before the proof is ever used.
+      assert.throws(() => psbt.combineProof(new Uint8Array(192)));
+
+      // Nothing was dropped: the PCZT is still in the proprietary map, so every v6 read still works
+      // and returns what it did before. A transient prover failure must not brick the PSBT.
+      assert.strictEqual(psbt.getId(), txid);
+      assert.strictEqual(psbt.transparentSighash(0).length, 32);
+
+      // ...and it survives a round-trip, which `deserialize_v6` would reject if the PCZT were gone.
+      const round = ZcashIronwoodBitGoPsbt.fromBytes(psbt.serialize(), "zcashTest");
+      assert.strictEqual(round.getId(), txid);
+    });
+
+    it("reports the missing transparent signatures rather than a proof error", function () {
+      // Finalization runs before the (expensive) shielded combine, so an under-signed PSBT fails
+      // fast and the message points at the signatures, not at the placeholder proof bytes.
+      assert.throws(() => buildShieldPsbt().combineProof(new Uint8Array(192)), /signature/i);
+    });
+  });
+
+  it("the default memo is the ZIP-302 no-memo encoding, not all zeros", function () {
+    // `addShieldedOutput` defaults `memo` to this. Asserted on the encoding rather than by comparing
+    // txids across two builds: `construct_shield_pczt` draws a random rseed, so two separately-built
+    // PSBTs have different note ciphertexts (hence different txids) whatever their memos.
+    const memo = zip302NoMemo();
+    assert.strictEqual(memo.length, 512);
+    assert.strictEqual(memo[0], 0xf6, "ZIP-302 no-memo marker byte");
+    assert.ok(
+      memo.slice(1).every((b: number) => b === 0),
+      "remaining bytes are zero padding",
+    );
+  });
+
+  it("zip302NoMemo returns a fresh array, so a caller cannot poison the default", function () {
+    const mine = zip302NoMemo();
+    mine[0] = 0x00;
+    assert.strictEqual(zip302NoMemo()[0], 0xf6);
+  });
+
+  describe("createEmptyWithConsensusBranchId", function () {
+    // Only the *version group id* is fixed by the v6 format; the consensus branch id tracks the
+    // active network upgrade, so it stays caller-supplied exactly as it is for v4.
+    const NU6_3_TESTNET_BRANCH_ID = ZcashBitGoPsbt.branchIdForHeight(
+      "zcashTest",
+      NU6_3_TESTNET_HEIGHT,
+    );
+    assert.ok(NU6_3_TESTNET_BRANCH_ID !== undefined, "NU6.3 testnet branch id is known");
+
+    it("builds a v6 PSBT equivalent to the block-height factory", function () {
+      const explicit = ZcashIronwoodBitGoPsbt.createEmptyWithConsensusBranchId(
+        "zcashTest",
+        walletKeys,
+        { consensusBranchId: NU6_3_TESTNET_BRANCH_ID },
+      );
+      const byHeight = ZcashIronwoodBitGoPsbt.createEmpty("zcashTest", walletKeys, {
+        blockHeight: NU6_3_TESTNET_HEIGHT,
+      });
+      assert.strictEqual(explicit.versionGroupId, IRONWOOD_VERSION_GROUP_ID);
+      assert.strictEqual(explicit.consensusBranchId, byHeight.consensusBranchId);
+      assert.strictEqual(explicit.versionGroupId, byHeight.versionGroupId);
+    });
+
+    it("returns the Ironwood subclass, not a v4-shaped base instance", function () {
+      const psbt = ZcashIronwoodBitGoPsbt.createEmptyWithConsensusBranchId(
+        "zcashTest",
+        walletKeys,
+        { consensusBranchId: NU6_3_TESTNET_BRANCH_ID },
+      );
+      assert.ok(psbt instanceof ZcashIronwoodBitGoPsbt);
+      // The v6-only surface is reachable, which it would not be on a base `ZcashBitGoPsbt`.
+      psbt.addShieldedOutput(RECIPIENT, 100_000_000n, { anchor: new Uint8Array(32) });
+      assert.strictEqual(psbt.transparentSighash.length, 1);
+    });
+
+    it("accepts an arbitrary branch id, unlike the height factory", function () {
+      // The escape hatch does no activation check — that is the point of it.
+      const psbt = ZcashIronwoodBitGoPsbt.createEmptyWithConsensusBranchId(
+        "zcashTest",
+        walletKeys,
+        { consensusBranchId: 0x12345678, expiryHeight: 99 },
+      );
+      assert.strictEqual(psbt.consensusBranchId, 0x12345678);
+      assert.strictEqual(psbt.expiryHeight, 99);
+      assert.strictEqual(psbt.versionGroupId, IRONWOOD_VERSION_GROUP_ID);
+    });
+  });
+
+  describe("factories that v6 cannot implement are fenced off", function () {
+    // Inherited because JS statics are inherited; each would hand back a v4-shaped
+    // `ZcashBitGoPsbt` (they construct the base class directly), so each must refuse instead.
+    // Unlike `createEmptyWithConsensusBranchId`, these two are not merely unwired — a broadcast v6
+    // transaction cannot yield the PCZT witness data every v6 operation needs.
+    const cases: Array<[string, () => void]> = [
+      ["fromNetworkFormat", () => ZcashIronwoodBitGoPsbt.fromNetworkFormat()],
+      [
+        "fromHalfSignedLegacyTransaction",
+        () => ZcashIronwoodBitGoPsbt.fromHalfSignedLegacyTransaction(),
+      ],
+    ];
+    for (const [name, run] of cases) {
+      it(`${name} throws`, function () {
+        assert.throws(run, /not supported for v6/);
+      });
+    }
+  });
+
+  it("ZcashBitGoPsbt.fromBytes rejects a v6 (Ironwood) PSBT", function () {
+    const bytes = buildShieldPsbt().serialize();
+    assert.throws(() => ZcashBitGoPsbt.fromBytes(bytes, "zcashTest"), /Ironwood/);
+  });
+
+  it("ZcashIronwoodBitGoPsbt.fromBytes rejects a non-v6 (v4/Sapling) PSBT", function () {
+    const v4Psbt = ZcashBitGoPsbt.createEmpty("zcashTest", walletKeys, {
+      blockHeight: NU6_3_TESTNET_HEIGHT,
+    });
+    v4Psbt.addWalletInput({ txid: "11".repeat(32), vout: 0, value: 200_000_000n }, walletKeys, {
+      scriptId: SCRIPT_ID,
+      signPath: { signer: "user", cosigner: "bitgo" },
+    });
+    v4Psbt.addWalletOutput(walletKeys, { chain: 1, index: 0, value: 199_900_000n });
+    const bytes = v4Psbt.serialize();
+    assert.throws(() => ZcashIronwoodBitGoPsbt.fromBytes(bytes, "zcashTest"), /not a v6/);
+  });
+});


### PR DESCRIPTION
Surface the dedicated ZcashBitGoPsbt v6 methods through the wasm bindings and the TypeScript ZcashBitGoPsbt wrapper.

wasm (src/wasm/fixed_script_wallet): add create_empty_zcash_v6_at_height, add_ironwood_output, ironwood_v6_txid, ironwood_v6_transparent_sighash, add_ironwood_v6_signature, and combine_ironwood_proof, plus private zcash()/zcash_mut() helpers to reach the Zcash arm. Byte-length validation for recipient (43) / anchor (32) / memo (512) / ovk (32) happens at the boundary; randomness uses OsRng (getrandom js).

zcash_psbt: make the internal serialize()/deserialize() v6-aware so the standard from_bytes/serialize path round-trips a v6 PSBT (plain PSBT carrying the transparent skeleton + PCZT + ZecV6Params) without the v4 tx-replacement dance.

TS (ZcashBitGoPsbt.ts): add createIronwood, addIronwoodOutput, ironwoodTxid, ironwoodTransparentSighash, addIronwoodSignature, and combineIronwoodProof.

Test (test/fixedScript/zcashIronwoodPsbt.ts): drive the bindings from TypeScript — build a shield PSBT, assert the Ironwood version group id, compute a 32-byte v6 txid + per-input sighash that survive a serialize round-trip, and check the signature/recipient validation error paths. (Full sign→combine runtime behavior is covered by the native Rust test in PR4.) A small getrandom shim lets the bundler-target wasm source randomness under the Node/mocha harness; production bundler/browser and nodejs-target builds don't need it.