### PR TITLE
chore: add coinsshield as codeowner for wasm privacy coin and zec paths

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,3 +5,11 @@
 # These owners and first officers will be the default owners for everything in the repo.
 *   @BitGo/btc-team
 packages/wasm-mps @BitGo/hsm
+packages/wasm-privacy-coin @BitGo/coinsshield
+
+# Zcash-specific paths in wasm-utxo
+packages/wasm-utxo/src/zcash/ @BitGo/coinsshield
+packages/wasm-utxo/src/wasm/zcash.rs @BitGo/coinsshield
+packages/wasm-utxo/src/fixed_script_wallet/bitgo_psbt/zcash_psbt.rs @BitGo/coinsshield
+packages/wasm-utxo/js/fixedScriptWallet/Zcash*.ts @BitGo/coinsshield
+packages/wasm-utxo/test/fixedScript/zcash*.ts @BitGo/coinsshield


### PR DESCRIPTION
Scope @BitGo/coinsshield CODEOWNERS to the Zcash/privacy-coin paths the
Coins Shield team maintains, so PRs touching them auto-request their
review while shared PSBT files stay under the default @BitGo/btc-team.

Covered paths:
- packages/wasm-privacy-coin (whole module)
- packages/wasm-utxo/src/zcash/ (ironwood_pczt, ironwood_build, v6,
  blake2b, transaction, unified_address)
- packages/wasm-utxo/src/wasm/zcash.rs (wasm binding)
- packages/wasm-utxo/src/fixed_script_wallet/bitgo_psbt/zcash_psbt.rs
  (Zcash PSBT; touched by the Ironwood PR #342/#343 stack)
- packages/wasm-utxo/js/fixedScriptWallet/Zcash*.ts (TS wrappers)
- packages/wasm-utxo/test/fixedScript/zcash*.ts (TS tests)