### PR TITLE
fix(webui): add tpearlreg after CoinName expansion

### DIFF
--- a/packages/webui/src/wasm-utxo/addresses/index.ts
+++ b/packages/webui/src/wasm-utxo/addresses/index.ts
@@ -38,6 +38,7 @@ const ALL_COINS: CoinName[] = [
   "tzec",
   "pearl",
   "tpearl",
+  "tpearlreg",
 ];
 
 // Coins that support cashaddr format
@@ -69,6 +70,7 @@ const COIN_NAMES: Record<CoinName, string> = {
   tzec: "Zcash Testnet",
   pearl: "Pearl",
   tpearl: "Pearl Testnet",
+  tpearlreg: "Pearl Regtest",
 };
 
 interface ConversionResult {

--- a/packages/webui/src/wasm-utxo/parser/index.ts
+++ b/packages/webui/src/wasm-utxo/parser/index.ts
@@ -55,6 +55,7 @@ const networkLabels: Record<CoinName, string> = {
   tzec: "Zcash Testnet",
   pearl: "Pearl",
   tpearl: "Pearl Testnet",
+  tpearlreg: "Pearl Regtest",
 };
 
 /**


### PR DESCRIPTION
## Summary
- PR #344 added `tpearlreg` to `CoinName` but did not update webui label maps
- Auto-merge landed before `test / Build` finished; Build then failed with TS2741 on `addresses/index.ts` and `parser/index.ts`
- Add `tpearlreg` / "Pearl Regtest" so webui typechecks again

## Test plan
- [ ] CI `test / Build` passes
- [ ] Confirm address converter and PSBT parser network lists include Pearl Regtest


Made with [Cursor](https://cursor.com)