### PR TITLE
fix(wasm-utxo): make isShielded nullable and preserve Unified Address on shielded outputs

### DIFF
--- a/packages/wasm-utxo/cli/src/psbt/add_shielded_output.rs
+++ b/packages/wasm-utxo/cli/src/psbt/add_shielded_output.rs
@@ -15,6 +15,7 @@ pub fn handle_add_shielded_output_command(
     anchor: String,
     ovk: Option<String>,
     memo: Option<String>,
+    unified_address: Option<String>,
 ) -> Result<()> {
     let raw_bytes = read_input_bytes(&path, "PSBT")?;
     let bytes = decode_input(&raw_bytes)?;
@@ -45,9 +46,17 @@ pub fn handle_add_shielded_output_command(
         None => [0u8; 512],
     };
 
-    psbt.add_ironwood_output(&recipient, value, ovk, &anchor, &memo, OsRng)
-        .map_err(|e| anyhow!(e))
-        .context("failed to add shielded output")?;
+    psbt.add_ironwood_output(
+        &recipient,
+        value,
+        ovk,
+        &anchor,
+        &memo,
+        unified_address.as_deref(),
+        OsRng,
+    )
+    .map_err(|e| anyhow!(e))
+    .context("failed to add shielded output")?;
 
     println!("{}", hex::encode(psbt.serialize().map_err(|e| anyhow!(e))?));
     Ok(())

--- a/packages/wasm-utxo/cli/src/psbt/mod.rs
+++ b/packages/wasm-utxo/cli/src/psbt/mod.rs
@@ -133,6 +133,11 @@ pub enum PsbtCommand {
         /// Memo field, hex-encoded (512 bytes; default: all-zero)
         #[arg(long)]
         memo: Option<String>,
+        /// Full Unified Address this output was addressed to, if known. Its Orchard receiver must
+        /// match --recipient. Stored verbatim so it survives a serialize/deserialize round-trip
+        /// instead of being reconstructed as a single-receiver UA when the PSBT is later parsed.
+        #[arg(long)]
+        unified_address: Option<String>,
     },
     /// Sign one transparent input of a v6 PSBT with a single private key, over the ZIP-244
     /// transparent sighash. Call once per required signature (2-of-3). Prints the updated PSBT
@@ -244,6 +249,7 @@ pub fn handle_command(command: PsbtCommand) -> Result<()> {
             anchor,
             ovk,
             memo,
+            unified_address,
         } => add_shielded_output::handle_add_shielded_output_command(
             path,
             network.into(),
@@ -252,6 +258,7 @@ pub fn handle_command(command: PsbtCommand) -> Result<()> {
             anchor,
             ovk,
             memo,
+            unified_address,
         ),
         PsbtCommand::SignV6Input {
             path,

--- a/packages/wasm-utxo/js/fixedScriptWallet/BitGoPsbt.ts
+++ b/packages/wasm-utxo/js/fixedScriptWallet/BitGoPsbt.ts
@@ -61,8 +61,10 @@ export type ParsedOutput = {
    * necessarily byte-identical to whatever multi-receiver UA the sender originally pasted in (a
    * UA with a transparent/Sapling receiver too would round-trip to a different string carrying
    * only the Orchard one). `script` holds the same receiver as raw 43 bytes.
+   *
+   * `null` for coins that don't support shielded outputs (i.e. anything but Zcash).
    */
-  isShielded: boolean;
+  isShielded: boolean | null;
 };
 
 export type ParsedTransaction = {

--- a/packages/wasm-utxo/js/fixedScriptWallet/BitGoPsbt.ts
+++ b/packages/wasm-utxo/js/fixedScriptWallet/BitGoPsbt.ts
@@ -53,23 +53,11 @@ export type ParsedOutput = {
   paygo: boolean;
   /** Full BIP32 derivation path from the wallet xpub (e.g. "0/1"). Null for external outputs. */
   derivationPath: string | null;
-  /**
-   * True for a shielded (Orchard/Ironwood) output. Such an output has no `unsigned_tx` entry of
-   * its own — it lives in the PSBT's proprietary-map PCZT, read from its plaintext (not
-   * encrypted/decrypted) recipient field. `address` is a single-receiver ZIP-316 unified address
-   * (`u1...`/`utest1...`) encoding that receiver — a real, usable Zcash address, though not
-   * necessarily byte-identical to whatever multi-receiver UA the sender originally pasted in (a
-   * UA with a transparent/Sapling receiver too would round-trip to a different string carrying
-   * only the Orchard one). `script` holds the same receiver as raw 43 bytes.
-   *
-   * `null` for coins that don't support shielded outputs (i.e. anything but Zcash).
-   */
-  isShielded: boolean | null;
 };
 
-export type ParsedTransaction = {
+export type ParsedTransaction<TOutput extends ParsedOutput = ParsedOutput> = {
   inputs: ParsedInput[];
-  outputs: ParsedOutput[];
+  outputs: TOutput[];
   spendAmount: bigint;
   minerFee: bigint;
   virtualSize: number;
@@ -147,7 +135,10 @@ export type HydrationUnspent =
   | { chain: number; index: number; value: bigint } // wallet input
   | { pubkey: Uint8Array; value: bigint }; // P2SH-P2PK replay protection input
 
-export class BitGoPsbt extends PsbtBase<WasmBitGoPsbt> implements IPsbtWithAddress {
+export class BitGoPsbt<TOutput extends ParsedOutput = ParsedOutput>
+  extends PsbtBase<WasmBitGoPsbt>
+  implements IPsbtWithAddress
+{
   protected constructor(wasm: WasmBitGoPsbt) {
     super(wasm);
   }
@@ -628,7 +619,7 @@ export class BitGoPsbt extends PsbtBase<WasmBitGoPsbt> implements IPsbtWithAddre
   parseTransactionWithWalletKeys(
     walletKeys: WalletKeysArg,
     options: ParseTransactionOptions,
-  ): ParsedTransaction {
+  ): ParsedTransaction<TOutput> {
     const keys = RootWalletKeys.from(walletKeys);
     const rp = ReplayProtection.from(options.replayProtection, this._wasm.network());
     const pubkeys = options.payGoPubkeys?.map((arg) => ECPair.from(arg).wasm);
@@ -636,7 +627,7 @@ export class BitGoPsbt extends PsbtBase<WasmBitGoPsbt> implements IPsbtWithAddre
       keys.wasm,
       rp.wasm,
       pubkeys,
-    ) as ParsedTransaction;
+    ) as ParsedTransaction<TOutput>;
   }
 
   /**
@@ -652,13 +643,10 @@ export class BitGoPsbt extends PsbtBase<WasmBitGoPsbt> implements IPsbtWithAddre
    * @returns Array of parsed outputs
    * @note This method does NOT validate wallet inputs. It only parses outputs.
    */
-  parseOutputsWithWalletKeys(
-    walletKeys: WalletKeysArg,
-    options?: ParseOutputsOptions,
-  ): ParsedOutput[] {
+  parseOutputsWithWalletKeys(walletKeys: WalletKeysArg, options?: ParseOutputsOptions): TOutput[] {
     const keys = RootWalletKeys.from(walletKeys);
     const pubkeys = options?.payGoPubkeys?.map((arg) => ECPair.from(arg).wasm);
-    return this._wasm.parse_outputs_with_wallet_keys(keys.wasm, pubkeys) as ParsedOutput[];
+    return this._wasm.parse_outputs_with_wallet_keys(keys.wasm, pubkeys) as TOutput[];
   }
 
   /**

--- a/packages/wasm-utxo/js/fixedScriptWallet/ZcashBitGoPsbt.ts
+++ b/packages/wasm-utxo/js/fixedScriptWallet/ZcashBitGoPsbt.ts
@@ -4,11 +4,29 @@ import {
   zcash_ironwood_version_group_id,
 } from "../wasm/wasm_utxo.js";
 import { type WalletKeysArg, RootWalletKeys } from "./RootWalletKeys.js";
-import { BitGoPsbt, type CreateEmptyOptions, type HydrationUnspent } from "./BitGoPsbt.js";
+import {
+  BitGoPsbt,
+  type CreateEmptyOptions,
+  type HydrationUnspent,
+  type ParsedOutput,
+} from "./BitGoPsbt.js";
 import { ZcashTransaction, type ITransaction } from "../transaction.js";
 
 /** Zcash network names */
 export type ZcashNetworkName = "zcash" | "zcashTest" | "zec" | "tzec";
+
+export type ZcashParsedOutput = ParsedOutput & {
+  /**
+   * True for a shielded (Orchard/Ironwood) output. Such an output has no `unsigned_tx` entry of
+   * its own — it lives in the PSBT's proprietary-map PCZT, read from its plaintext (not
+   * encrypted/decrypted) recipient field. `address` is a single-receiver ZIP-316 unified address
+   * (`u1...`/`utest1...`) encoding that receiver — a real, usable Zcash address, though not
+   * necessarily byte-identical to whatever multi-receiver UA the sender originally pasted in (a
+   * UA with a transparent/Sapling receiver too would round-trip to a different string carrying
+   * only the Orchard one). `script` holds the same receiver as raw 43 bytes.
+   */
+  isShielded: boolean;
+};
 
 /**
  * Zcash v6 (Ironwood) version group id (0xd884b698). Its presence marks a PSBT as v6 — see
@@ -62,7 +80,7 @@ export type CreateEmptyZcashWithConsensusBranchIdOptions = CreateEmptyOptions & 
  * const psbt = ZcashBitGoPsbt.fromBytes(bytes, "zcash");
  * ```
  */
-export class ZcashBitGoPsbt extends BitGoPsbt {
+export class ZcashBitGoPsbt extends BitGoPsbt<ZcashParsedOutput> {
   /**
    * Create an empty Zcash PSBT with consensus branch ID determined from block height
    *

--- a/packages/wasm-utxo/js/fixedScriptWallet/ZcashIronwoodBitGoPsbt.ts
+++ b/packages/wasm-utxo/js/fixedScriptWallet/ZcashIronwoodBitGoPsbt.ts
@@ -198,14 +198,27 @@ export class ZcashIronwoodBitGoPsbt extends ZcashBitGoPsbt {
    * @param options.anchor - 32-byte Ironwood note-commitment-tree root
    * @param options.memo - optional 512-byte memo (defaults to the ZIP-302 "no memo" encoding)
    * @param options.ovk - optional 32-byte outgoing viewing key (omit for a keyless build)
+   * @param options.unifiedAddress - optional full Unified Address string this output was addressed
+   *   to. Its Orchard receiver must equal `recipient`. The PCZT itself only carries the raw 43-byte
+   *   receiver — a lossy encoding for a multi-receiver UA, since any transparent/Sapling receiver
+   *   can't be recovered from it — so passing this stores the original UA verbatim, letting a later
+   *   `parseOutputsWithWalletKeys`/`parseTransactionWithWalletKeys` (even after a
+   *   serialize/deserialize round-trip) return it in full instead of a re-encoded single-receiver UA.
    */
   addShieldedOutput(
     recipient: Uint8Array,
     amount: bigint,
-    options: { anchor: Uint8Array; memo?: Uint8Array; ovk?: Uint8Array },
+    options: { anchor: Uint8Array; memo?: Uint8Array; ovk?: Uint8Array; unifiedAddress?: string },
   ): void {
     const memo = options.memo ?? zip302NoMemo();
-    this.wasm.add_ironwood_output(recipient, amount, options.ovk, options.anchor, memo);
+    this.wasm.add_ironwood_output(
+      recipient,
+      amount,
+      options.ovk,
+      options.anchor,
+      memo,
+      options.unifiedAddress,
+    );
   }
 
   /**

--- a/packages/wasm-utxo/js/fixedScriptWallet/index.ts
+++ b/packages/wasm-utxo/js/fixedScriptWallet/index.ts
@@ -43,6 +43,7 @@ export { BitGoKeySubtype, type PsbtKvKey } from "./BitGoKeySubtype.js";
 export {
   ZcashBitGoPsbt,
   type ZcashNetworkName,
+  type ZcashParsedOutput,
   type CreateEmptyZcashOptions,
   IRONWOOD_VERSION_GROUP_ID,
 } from "./ZcashBitGoPsbt.js";

--- a/packages/wasm-utxo/src/fixed_script_wallet/bitgo_psbt/mod.rs
+++ b/packages/wasm-utxo/src/fixed_script_wallet/bitgo_psbt/mod.rs
@@ -2755,11 +2755,17 @@ impl BitGoPsbt {
         else {
             return Ok(None);
         };
-        let address = crate::zcash::unified_address::encode_orchard_receiver(
-            &recipient,
-            self.network().to_coin_name(),
-        )
-        .map_err(|e| ParseTransactionError::ShieldedOutput(e.to_string()))?;
+        // Prefer the caller's original Unified Address (if `add_ironwood_output` was given one):
+        // it may carry a transparent/Sapling receiver alongside the Orchard one, which a
+        // single-receiver reconstruction from `recipient` alone cannot recover.
+        let address = match propkv::get_ironwood_unified_address(&z.psbt) {
+            Some(ua) => ua,
+            None => crate::zcash::unified_address::encode_orchard_receiver(
+                &recipient,
+                self.network().to_coin_name(),
+            )
+            .map_err(|e| ParseTransactionError::ShieldedOutput(e.to_string()))?,
+        };
         Ok(Some((
             ParsedOutput {
                 address: Some(address),
@@ -2771,7 +2777,7 @@ impl BitGoPsbt {
                 script_id: None,
                 paygo: false,
                 derivation_path: None,
-                is_shielded: true,
+                is_shielded: Some(true),
             },
             amount,
         )))

--- a/packages/wasm-utxo/src/fixed_script_wallet/bitgo_psbt/propkv.rs
+++ b/packages/wasm-utxo/src/fixed_script_wallet/bitgo_psbt/propkv.rs
@@ -271,6 +271,13 @@ pub enum ZecV6KeySubtype {
     /// happened, not just "no shielded output was ever added"). Persists even though the PCZT
     /// itself is gone, so a later read can tell the two "no PCZT" states apart.
     IronwoodExtracted = 0x04,
+    /// The full ZIP-316 Unified Address string (UTF-8) the shielded output was addressed to, if
+    /// the caller supplied one to [`crate::fixed_script_wallet::bitgo_psbt::zcash_psbt`]'s
+    /// `add_ironwood_output`. The PCZT itself only carries the raw 43-byte Orchard receiver, which
+    /// is lossy for a multi-receiver UA (transparent/Sapling receivers can't be recovered from it);
+    /// storing the original string here lets output parsing return the exact UA the caller passed,
+    /// receivers and all, after a serialize/deserialize round-trip.
+    UnifiedAddress = 0x05,
 }
 
 fn set_zec_v6(
@@ -290,6 +297,15 @@ fn get_zec_v6(psbt: &miniscript::bitcoin::psbt::Psbt, subtype: ZecV6KeySubtype) 
     find_kv_iter(&psbt.proprietary, BITGO_ZEC_V6, Some(subtype as u8))
         .next()
         .map(|(_, v)| v.clone())
+}
+
+fn remove_zec_v6(psbt: &mut miniscript::bitcoin::psbt::Psbt, subtype: ZecV6KeySubtype) {
+    let key = ProprietaryKey {
+        prefix: BITGO_ZEC_V6.to_vec(),
+        subtype: subtype as u8,
+        key: vec![],
+    };
+    psbt.proprietary.remove(&key);
 }
 
 fn set_zec_v6_u32(
@@ -375,6 +391,36 @@ pub fn get_zec_v6_params(psbt: &miniscript::bitcoin::psbt::Psbt) -> Option<(u32,
     let vgid = get_zec_v6_u32(psbt, ZecV6KeySubtype::VersionGroupId)?;
     let expiry = get_zec_v6_u32(psbt, ZecV6KeySubtype::ExpiryHeight)?;
     Some((vgid, expiry))
+}
+
+/// Store the full Unified Address string the Ironwood shielded output was addressed to, so it
+/// survives a serialize/deserialize round-trip verbatim (receivers and all) instead of being
+/// rebuilt from just the raw Orchard receiver. Overwrites any existing value.
+pub fn set_ironwood_unified_address(psbt: &mut miniscript::bitcoin::psbt::Psbt, ua: &str) {
+    set_zec_v6(
+        psbt,
+        ZecV6KeySubtype::UnifiedAddress,
+        ua.as_bytes().to_vec(),
+    );
+}
+
+/// Fetch the Unified Address string stored by [`set_ironwood_unified_address`], if present and
+/// valid UTF-8.
+pub fn get_ironwood_unified_address(psbt: &miniscript::bitcoin::psbt::Psbt) -> Option<String> {
+    let bytes = get_zec_v6(psbt, ZecV6KeySubtype::UnifiedAddress)?;
+    String::from_utf8(bytes).ok()
+}
+
+/// Remove the Unified Address string set by [`set_ironwood_unified_address`], if present.
+///
+/// Callers that build a shielded output without a `unified_address` must call this rather than
+/// simply not calling [`set_ironwood_unified_address`]: `add_ironwood_output` can be called again
+/// on a PSBT whose PCZT was previously extracted (see `take_ironwood_pczt`/
+/// `mark_ironwood_extracted`, which drop only the PCZT key, not this one), and without an explicit
+/// removal a UA stored for an earlier shielded output would otherwise survive and be silently
+/// misattributed to the new one.
+pub fn remove_ironwood_unified_address(psbt: &mut miniscript::bitcoin::psbt::Psbt) {
+    remove_zec_v6(psbt, ZecV6KeySubtype::UnifiedAddress);
 }
 
 #[cfg(test)]

--- a/packages/wasm-utxo/src/fixed_script_wallet/bitgo_psbt/psbt_wallet_output.rs
+++ b/packages/wasm-utxo/src/fixed_script_wallet/bitgo_psbt/psbt_wallet_output.rs
@@ -16,9 +16,10 @@ pub struct ParsedOutput {
     /// `None` for outputs that do not belong to this wallet.
     pub derivation_path: Option<DerivationPath>,
     /// Whether this output is a shielded (Orchard/Ironwood) output rather than a transparent one.
-    /// Always `false` for outputs parsed from `tx_output`/`psbt_output` — set by the caller when
-    /// synthesizing a `ParsedOutput` for the shielded side of a v6 (Ironwood) transaction.
-    pub is_shielded: bool,
+    /// `None` for coins that don't support shielded outputs. Always `Some(false)` for outputs
+    /// parsed from `tx_output`/`psbt_output` on a Zcash PSBT — set to `Some(true)` by the caller
+    /// when synthesizing a `ParsedOutput` for the shielded side of a v6 (Ironwood) transaction.
+    pub is_shielded: Option<bool>,
 }
 
 impl ParsedOutput {
@@ -63,7 +64,7 @@ impl ParsedOutput {
             script_id,
             paygo,
             derivation_path,
-            is_shielded: false,
+            is_shielded: matches!(network, Network::Zcash | Network::ZcashTestnet).then_some(false),
         })
     }
 

--- a/packages/wasm-utxo/src/fixed_script_wallet/bitgo_psbt/zcash_psbt.rs
+++ b/packages/wasm-utxo/src/fixed_script_wallet/bitgo_psbt/zcash_psbt.rs
@@ -724,6 +724,13 @@ impl ZcashBitGoPsbt {
     ///
     /// Exactly one shielded output is supported; calling this twice is an error rather than a silent
     /// overwrite of the first note (whose value the transparent side would still be funding).
+    ///
+    /// `unified_address`, if supplied, must be a Unified Address whose Orchard receiver is exactly
+    /// `recipient` — it is stored verbatim in the proprietary map (see
+    /// [`super::propkv::set_ironwood_unified_address`]) so that output parsing can later return the
+    /// original multi-receiver UA rather than reconstructing a single-receiver one from `recipient`
+    /// alone, which drops any transparent/Sapling receiver the caller's UA carried.
+    #[allow(clippy::too_many_arguments)]
     pub fn add_ironwood_output<R: rand::RngCore + rand::CryptoRng>(
         &mut self,
         recipient: &crate::zcash::ironwood_build::OrchardAddressBytes,
@@ -731,12 +738,32 @@ impl ZcashBitGoPsbt {
         ovk: Option<crate::zcash::ironwood_build::OvkBytes>,
         anchor: &crate::zcash::ironwood_build::AnchorBytes,
         memo: &crate::zcash::ironwood_build::MemoBytes,
+        unified_address: Option<&str>,
         rng: R,
     ) -> Result<(), String> {
         if super::propkv::get_ironwood_pczt(&self.psbt).is_some() {
             return Err(
                 "an Ironwood shielded output is already present; only one is supported".to_string(),
             );
+        }
+        if let Some(ua) = unified_address {
+            let parsed = crate::zcash::unified_address::UnifiedAddress::parse(
+                ua,
+                self.network.to_coin_name(),
+            )
+            .map_err(|e| format!("invalid unified_address: {e}"))?;
+            let orchard = parsed
+                .orchard_receiver()
+                .map_err(|e| format!("invalid unified_address: {e}"))?
+                .ok_or_else(|| {
+                    "unified_address has no Orchard receiver, but recipient is an Orchard address"
+                        .to_string()
+                })?;
+            if orchard.as_slice() != recipient.as_slice() {
+                return Err(
+                    "unified_address's Orchard receiver does not match recipient".to_string(),
+                );
+            }
         }
         let pczt = crate::zcash::ironwood_build::construct_shield_pczt(
             recipient, amount, ovk, anchor, memo, rng,
@@ -745,6 +772,14 @@ impl ZcashBitGoPsbt {
         let bytes =
             crate::zcash::ironwood_pczt::serialize_pczt(&pczt).map_err(|e| e.to_string())?;
         super::propkv::set_ironwood_pczt(&mut self.psbt, bytes);
+        // Set-or-remove, not set-only: this can run again on a PSBT whose PCZT was previously
+        // extracted (mark_ironwood_extracted/take_ironwood_pczt drop only the PCZT key, not this
+        // one), so a `None` here must clear any UA left over from an earlier shielded output rather
+        // than leaving it to be silently misattributed to this one.
+        match unified_address {
+            Some(ua) => super::propkv::set_ironwood_unified_address(&mut self.psbt, ua),
+            None => super::propkv::remove_ironwood_unified_address(&mut self.psbt),
+        }
         Ok(())
     }
 
@@ -1602,6 +1637,7 @@ mod ironwood_v6_tests {
             None,
             &Anchor::empty_tree().to_bytes(),
             &[0u8; 512],
+            None, // unified_address
             OsRng,
         )
         .unwrap();
@@ -1711,6 +1747,7 @@ mod ironwood_v6_tests {
             None,
             &Anchor::empty_tree().to_bytes(),
             &[0u8; 512],
+            None, // unified_address
             OsRng,
         )
         .unwrap();
@@ -1826,6 +1863,7 @@ mod ironwood_v6_tests {
                 None, // keyless: the server never sees an ovk
                 &Anchor::empty_tree().to_bytes(),
                 &[0u8; 512],
+                None, // unified_address
                 OsRng,
             )
             .unwrap();
@@ -1988,6 +2026,7 @@ mod ironwood_v6_tests {
             None,
             &Anchor::empty_tree().to_bytes(),
             &[0u8; 512],
+            None, // unified_address
             OsRng,
         )
         .unwrap();
@@ -2363,6 +2402,7 @@ mod ironwood_v6_tests {
                 None,
                 &Anchor::empty_tree().to_bytes(),
                 &[0u8; 512],
+                None, // unified_address
                 OsRng,
             )
             .unwrap_err();
@@ -2653,6 +2693,7 @@ mod ironwood_v6_tests {
             None,
             &Anchor::empty_tree().to_bytes(),
             &[0u8; 512],
+            None, // unified_address
             OsRng,
         )
         .unwrap();
@@ -2674,6 +2715,164 @@ mod ironwood_v6_tests {
         let (value, got_recipient) = z.ironwood_shielded_output_info().unwrap().unwrap();
         assert_eq!(value, 100_000_000);
         assert_eq!(got_recipient, recipient);
+    }
+
+    /// `add_ironwood_output`'s optional `unified_address` is stored verbatim in the proprietary map
+    /// and survives a `serialize_v6`/`deserialize_v6` round-trip, so a caller who supplies the UA
+    /// they built the output from gets it back byte-for-byte later — unlike the raw 43-byte
+    /// `recipient`, which alone cannot reconstruct a multi-receiver UA.
+    #[test]
+    fn add_ironwood_output_unified_address_round_trips() {
+        let wallet_keys = RootWalletKeys::new(get_test_wallet_keys("v6_ua_roundtrip"));
+        let mut psbt = BitGoPsbt::new_zcash_v6_at_height(
+            Network::ZcashTestnet,
+            &wallet_keys,
+            NetworkUpgrade::Nu6_3.testnet_activation_height(),
+            None,
+            None,
+        )
+        .unwrap();
+        psbt.add_wallet_input(
+            Txid::from_byte_array([0x55u8; 32]),
+            0,
+            200_000_000,
+            &wallet_keys,
+            ScriptId { chain: 0, index: 0 },
+            WalletInputOptions::default(),
+        )
+        .unwrap();
+        psbt.add_wallet_output(0, 1, 99_900_000, &wallet_keys)
+            .unwrap();
+        let BitGoPsbt::Zcash(mut z, _) = psbt else {
+            panic!("expected Zcash PSBT");
+        };
+
+        let recipient = test_recipient();
+        let ua =
+            crate::zcash::unified_address::encode_orchard_receiver(&recipient, "tzec").unwrap();
+        z.add_ironwood_output(
+            &recipient,
+            100_000_000,
+            None,
+            &Anchor::empty_tree().to_bytes(),
+            &[0u8; 512],
+            Some(&ua),
+            OsRng,
+        )
+        .unwrap();
+        assert_eq!(
+            crate::fixed_script_wallet::bitgo_psbt::propkv::get_ironwood_unified_address(&z.psbt),
+            Some(ua.clone())
+        );
+
+        // Survives serialize/deserialize, not just in-memory state.
+        let round =
+            ZcashBitGoPsbt::deserialize_v6(&z.serialize_v6(), Network::ZcashTestnet).unwrap();
+        assert_eq!(
+            crate::fixed_script_wallet::bitgo_psbt::propkv::get_ironwood_unified_address(
+                &round.psbt
+            ),
+            Some(ua)
+        );
+    }
+
+    /// `add_ironwood_output` rejects a `unified_address` whose Orchard receiver doesn't match
+    /// `recipient` — a caller passing mismatched values is a bug, not something to silently store.
+    #[test]
+    fn add_ironwood_output_rejects_mismatched_unified_address() {
+        let mut z = build_shield_psbt("v6_ua_mismatch");
+        // Force a second call attempt by clearing the PCZT the helper already added, so we can
+        // exercise the mismatch path in isolation (the "already present" guard would otherwise fire
+        // first).
+        z.mark_ironwood_extracted();
+        assert!(
+            crate::fixed_script_wallet::bitgo_psbt::propkv::get_ironwood_pczt(&z.psbt).is_none()
+        );
+
+        let other_recipient = {
+            let sk = Option::<SpendingKey>::from(SpendingKey::from_bytes([9u8; 32])).unwrap();
+            FullViewingKey::from(&sk)
+                .address_at(0u32, Scope::External)
+                .to_raw_address_bytes()
+        };
+        let mismatched_ua =
+            crate::zcash::unified_address::encode_orchard_receiver(&other_recipient, "tzec")
+                .unwrap();
+
+        let err = z
+            .add_ironwood_output(
+                &test_recipient(),
+                100_000_000,
+                None,
+                &Anchor::empty_tree().to_bytes(),
+                &[0u8; 512],
+                Some(&mismatched_ua),
+                OsRng,
+            )
+            .unwrap_err();
+        assert!(
+            err.contains("does not match recipient"),
+            "unexpected error: {err}"
+        );
+    }
+
+    /// A stored `unified_address` must not survive onto a *different* shielded output added later
+    /// in the PSBT's lifetime. `mark_ironwood_extracted`/`take_ironwood_pczt` drop only the PCZT
+    /// key, not the UA key, so `add_ironwood_output` is reachable a second time on the same PSBT
+    /// (exactly as in `add_ironwood_output_rejects_mismatched_unified_address` above); a `None`
+    /// `unified_address` on that second call must clear the first call's UA rather than leaving it
+    /// to be silently misattributed to the new recipient.
+    #[test]
+    fn add_ironwood_output_clears_stale_unified_address_on_reuse() {
+        let mut z = build_shield_psbt("v6_ua_stale");
+        z.mark_ironwood_extracted();
+        assert!(
+            crate::fixed_script_wallet::bitgo_psbt::propkv::get_ironwood_pczt(&z.psbt).is_none()
+        );
+
+        let recipient_a = test_recipient();
+        let ua_a =
+            crate::zcash::unified_address::encode_orchard_receiver(&recipient_a, "tzec").unwrap();
+        z.add_ironwood_output(
+            &recipient_a,
+            100_000_000,
+            None,
+            &Anchor::empty_tree().to_bytes(),
+            &[0u8; 512],
+            Some(&ua_a),
+            OsRng,
+        )
+        .unwrap();
+        assert_eq!(
+            crate::fixed_script_wallet::bitgo_psbt::propkv::get_ironwood_unified_address(&z.psbt),
+            Some(ua_a.clone())
+        );
+
+        // Reuse the PSBT for a second (different) shielded output, without a unified_address.
+        z.mark_ironwood_extracted();
+        let recipient_b = {
+            let sk = Option::<SpendingKey>::from(SpendingKey::from_bytes([13u8; 32])).unwrap();
+            FullViewingKey::from(&sk)
+                .address_at(0u32, Scope::External)
+                .to_raw_address_bytes()
+        };
+        assert_ne!(recipient_a, recipient_b);
+        z.add_ironwood_output(
+            &recipient_b,
+            100_000_000,
+            None,
+            &Anchor::empty_tree().to_bytes(),
+            &[0u8; 512],
+            None, // unified_address
+            OsRng,
+        )
+        .unwrap();
+
+        // The stale UA from recipient_a must be gone, not silently attributed to recipient_b.
+        assert_eq!(
+            crate::fixed_script_wallet::bitgo_psbt::propkv::get_ironwood_unified_address(&z.psbt),
+            None
+        );
     }
 
     /// `combine_inputs` refuses a v6 PSBT outright.
@@ -2866,6 +3065,7 @@ mod ironwood_v6_tests {
             None,
             &Anchor::empty_tree().to_bytes(),
             &[0u8; 512],
+            None, // unified_address
             OsRng,
         )
         .unwrap();

--- a/packages/wasm-utxo/src/inspect/psbt.rs
+++ b/packages/wasm-utxo/src/inspect/psbt.rs
@@ -824,6 +824,7 @@ mod ironwood_v6_tests {
             None,
             &Anchor::empty_tree().to_bytes(),
             &[0u8; 512],
+            None, // unified_address
             OsRng,
         )
         .unwrap();

--- a/packages/wasm-utxo/src/wasm/fixed_script_wallet/mod.rs
+++ b/packages/wasm-utxo/src/wasm/fixed_script_wallet/mod.rs
@@ -528,6 +528,10 @@ impl BitGoPsbt {
     /// * `ovk` - optional outgoing viewing key ([`OVK_SIZE`] bytes; `None` for a keyless build)
     /// * `anchor` - Ironwood note-commitment-tree root ([`ANCHOR_SIZE`] bytes)
     /// * `memo` - ZIP-302 memo field ([`MEMO_SIZE`] bytes)
+    /// * `unified_address` - optional full Unified Address the output was addressed to; if given,
+    ///   its Orchard receiver must match `recipient`, and it is stored verbatim so output parsing
+    ///   can later return it in full (transparent/Sapling receivers included) instead of
+    ///   reconstructing a single-receiver UA from `recipient` alone
     ///
     /// [`ORCHARD_ADDRESS_SIZE`]: crate::zcash::ironwood_build::ORCHARD_ADDRESS_SIZE
     /// [`OVK_SIZE`]: crate::zcash::ironwood_build::OVK_SIZE
@@ -540,6 +544,7 @@ impl BitGoPsbt {
         ovk: Option<Vec<u8>>,
         anchor: &[u8],
         memo: &[u8],
+        unified_address: Option<String>,
     ) -> Result<(), WasmUtxoError> {
         use crate::zcash::ironwood_build::{
             AnchorBytes, MemoBytes, OrchardAddressBytes, OvkBytes, ANCHOR_SIZE, MEMO_SIZE,
@@ -558,7 +563,15 @@ impl BitGoPsbt {
         let memo: MemoBytes = fixed::<MEMO_SIZE>(memo, "memo")?;
         let ovk: Option<OvkBytes> = ovk.map(|v| fixed::<OVK_SIZE>(&v, "ovk")).transpose()?;
         self.zcash_mut()?
-            .add_ironwood_output(&recipient, amount, ovk, &anchor, &memo, rand::rngs::OsRng)
+            .add_ironwood_output(
+                &recipient,
+                amount,
+                ovk,
+                &anchor,
+                &memo,
+                unified_address.as_deref(),
+                rand::rngs::OsRng,
+            )
             .map_err(|e| WasmUtxoError::new(&e))
     }
 

--- a/packages/wasm-utxo/src/wasm/try_into_js_value.rs
+++ b/packages/wasm-utxo/src/wasm/try_into_js_value.rs
@@ -398,7 +398,7 @@ impl TryIntoJsValue for crate::fixed_script_wallet::bitgo_psbt::ParsedOutput {
             "scriptId" => self.script_id,
             "paygo" => self.paygo,
             "derivationPath" => self.derivation_path.clone(),
-            "isShielded" => self.is_shielded
+            ? "isShielded" => self.is_shielded
         )
     }
 }

--- a/packages/wasm-utxo/src/wasm/try_into_js_value.rs
+++ b/packages/wasm-utxo/src/wasm/try_into_js_value.rs
@@ -16,11 +16,17 @@ pub(crate) trait TryIntoJsValue {
 }
 
 macro_rules! js_obj {
-    ( $( $key:expr => $value:expr ),* ) => {{
+    ( $( $key:expr => $value:expr ),* $(, ? $optional_key:expr => $optional_value:expr)* $(,)? ) => {{
         let obj = js_sys::Object::new();
         $(
             js_sys::Reflect::set(&obj, &$key.into(), &$value.try_to_js_value()?.into())
                 .map_err(|_| WasmUtxoError::new("Failed to set object property"))?;
+        )*
+        $(
+            if let Some(value) = &$optional_value {
+                js_sys::Reflect::set(&obj, &$optional_key.into(), &value.try_to_js_value()?.into())
+                    .map_err(|_| WasmUtxoError::new("Failed to set object property"))?;
+            }
         )*
         Ok(Into::<JsValue>::into(obj)) as Result<JsValue, WasmUtxoError>
     }};
@@ -586,4 +592,32 @@ pub fn collect_partial_signatures(input: &Input) -> Vec<PartialSignature> {
     }
 
     signatures
+}
+
+#[cfg(all(test, target_arch = "wasm32"))]
+mod tests {
+    use super::*;
+    use wasm_bindgen_test::*;
+
+    fn optional_properties_object() -> Result<JsValue, WasmUtxoError> {
+        js_obj!(
+            "required" => true,
+            ? "present" => Some(true),
+            ? "absent" => Option::<bool>::None
+        )
+    }
+
+    #[wasm_bindgen_test]
+    fn js_obj_omits_none_optional_properties() {
+        let object = optional_properties_object().unwrap();
+
+        assert!(js_sys::Reflect::has(&object, &"required".into()).unwrap());
+        assert_eq!(
+            js_sys::Reflect::get(&object, &"present".into())
+                .unwrap()
+                .as_bool(),
+            Some(true)
+        );
+        assert!(!js_sys::Reflect::has(&object, &"absent".into()).unwrap());
+    }
 }

--- a/packages/wasm-utxo/test/fixedScript/parseTransactionWithWalletKeys.ts
+++ b/packages/wasm-utxo/test/fixedScript/parseTransactionWithWalletKeys.ts
@@ -181,6 +181,22 @@ describe("parseTransactionWithWalletKeys", function () {
               } else {
                 assert.ok(output.value > 0n, `Output ${i} value should be > 0`);
               }
+
+              // isShielded is only meaningful for Zcash (Orchard/Ironwood); every other coin
+              // reports null since it has no concept of a shielded output.
+              if (networkName === "zec") {
+                assert.strictEqual(
+                  output.isShielded,
+                  false,
+                  `Output ${i} isShielded should be false for a transparent Zcash output`,
+                );
+              } else {
+                assert.strictEqual(
+                  output.isShielded,
+                  null,
+                  `Output ${i} isShielded should be null for a non-Zcash coin`,
+                );
+              }
             });
 
             // Verify spend amount: AcidTest uses other wallet (800) + null wallet (700) = 1500

--- a/packages/wasm-utxo/test/fixedScript/parseTransactionWithWalletKeys.ts
+++ b/packages/wasm-utxo/test/fixedScript/parseTransactionWithWalletKeys.ts
@@ -183,7 +183,7 @@ describe("parseTransactionWithWalletKeys", function () {
               }
 
               // isShielded is only meaningful for Zcash (Orchard/Ironwood); every other coin
-              // reports null since it has no concept of a shielded output.
+              // omits it since it has no concept of a shielded output.
               if (networkName === "zec") {
                 assert.strictEqual(
                   output.isShielded,
@@ -193,8 +193,8 @@ describe("parseTransactionWithWalletKeys", function () {
               } else {
                 assert.strictEqual(
                   output.isShielded,
-                  null,
-                  `Output ${i} isShielded should be null for a non-Zcash coin`,
+                  undefined,
+                  `Output ${i} isShielded should be absent for a non-Zcash coin`,
                 );
               }
             });

--- a/packages/wasm-utxo/test/fixedScript/zcashIronwoodPsbt.ts
+++ b/packages/wasm-utxo/test/fixedScript/zcashIronwoodPsbt.ts
@@ -11,7 +11,9 @@ import {
 import {
   IRONWOOD_VERSION_GROUP_ID,
   ZcashBitGoPsbt,
+  type ZcashParsedOutput,
 } from "../../js/fixedScriptWallet/ZcashBitGoPsbt.js";
+import type { ParsedTransaction } from "../../js/fixedScriptWallet/BitGoPsbt.js";
 import { getKeyTriple, getWalletKeysForSeed } from "../../js/testutils/index.js";
 import { ZcashUnifiedAddress } from "../../js/fixedScriptWallet/ZcashUnifiedAddress.js";
 
@@ -163,9 +165,12 @@ describe("ZcashIronwoodBitGoPsbt v6 (Ironwood)", function () {
     // surfaced explicitly via `isShielded`.
     it("surfaces the shielded output as isShielded and folds its value into fee/spend accounting", function () {
       const psbt = buildShieldPsbt();
-      const parsed = psbt.parseTransactionWithWalletKeys(walletKeys, {
-        replayProtection: { publicKeys: [] },
-      });
+      const parsed: ParsedTransaction<ZcashParsedOutput> = psbt.parseTransactionWithWalletKeys(
+        walletKeys,
+        {
+          replayProtection: { publicKeys: [] },
+        },
+      );
 
       assert.strictEqual(parsed.outputs.length, 2);
       const shielded = parsed.outputs.filter((o) => o.isShielded);
@@ -214,7 +219,7 @@ describe("ZcashIronwoodBitGoPsbt v6 (Ironwood)", function () {
     // belonging to a different wallet than the inputs) would silently miss the shielded note.
     it("surfaces the shielded output alongside the transparent change output", function () {
       const psbt = buildShieldPsbt();
-      const outputs = psbt.parseOutputsWithWalletKeys(walletKeys);
+      const outputs: ZcashParsedOutput[] = psbt.parseOutputsWithWalletKeys(walletKeys);
 
       assert.strictEqual(outputs.length, 2);
       const shielded = outputs.filter((o) => o.isShielded);

--- a/packages/wasm-utxo/test/fixedScript/zcashIronwoodPsbt.ts
+++ b/packages/wasm-utxo/test/fixedScript/zcashIronwoodPsbt.ts
@@ -1,4 +1,7 @@
 import assert from "node:assert";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
 import { describe, it } from "mocha";
 
 import {
@@ -23,6 +26,20 @@ const RECIPIENT = Buffer.from(
 );
 
 const SCRIPT_ID = { chain: 0, index: 0 } as const;
+
+// The testnet fixture UA carries *two* receivers — transparent and Orchard/Ironwood — which is what
+// makes it usable to show what a multi-receiver UA loses on its way into the PCZT.
+const MULTI_RECEIVER_UA = (
+  JSON.parse(
+    fs.readFileSync(
+      path.resolve(
+        path.dirname(fileURLToPath(import.meta.url)),
+        "../fixtures/zcash/unified_address.json",
+      ),
+      "utf8",
+    ),
+  ) as { testnetWallet: { unified: string } }
+).testnetWallet.unified;
 
 describe("ZcashIronwoodBitGoPsbt v6 (Ironwood)", function () {
   const walletKeys = getWalletKeysForSeed("ironwood-ts");
@@ -225,6 +242,138 @@ describe("ZcashIronwoodBitGoPsbt v6 (Ironwood)", function () {
       const outputs = psbt.parseOutputsWithWalletKeys(walletKeys);
       assert.strictEqual(outputs.length, 1);
       assert.strictEqual(outputs[0].isShielded, false);
+    });
+
+    // A multi-receiver UA is *lossy* through the PSBT by default: `addShieldedOutput` stores only
+    // the 43-byte Orchard receiver in the PCZT's `recipient` field, so the transparent (and any
+    // Sapling) receiver is dropped at construction and cannot come back out unless the caller also
+    // passes `options.unifiedAddress` (see the round-trip test below). Without it, parsing returns a
+    // freshly encoded *single*-receiver UA for the Orchard receiver alone.
+    it("persists only the Orchard receiver of a multi-receiver unified address, if unifiedAddress is omitted", function () {
+      const ua = ZcashUnifiedAddress.parse(MULTI_RECEIVER_UA, "zcashTest");
+      const orchard = ua.orchardReceiver;
+      assert.ok(orchard, "fixture UA has an Orchard receiver");
+      assert.ok(ua.transparentScript, "fixture UA also has a transparent receiver");
+
+      const psbt = ZcashIronwoodBitGoPsbt.createEmpty("zcashTest", walletKeys, {
+        blockHeight: NU6_3_TESTNET_HEIGHT,
+      });
+      psbt.addWalletInput({ txid: "11".repeat(32), vout: 0, value: 200_000_000n }, walletKeys, {
+        scriptId: SCRIPT_ID,
+        signPath: { signer: "user", cosigner: "bitgo" },
+      });
+      psbt.addWalletOutput(walletKeys, { chain: 1, index: 0, value: 99_900_000n });
+      psbt.addShieldedOutput(orchard, 100_000_000n, { anchor: new Uint8Array(32) });
+
+      // Survives a serialize round-trip: the receiver lives in the PSBT bytes, not just in memory.
+      const round = ZcashIronwoodBitGoPsbt.fromBytes(psbt.serialize(), "zcashTest");
+      const shielded = round.parseOutputsWithWalletKeys(walletKeys).filter((o) => o.isShielded);
+      assert.strictEqual(shielded.length, 1);
+      assert.deepStrictEqual(Buffer.from(shielded[0].script), Buffer.from(orchard));
+
+      // The returned address is *not* the UA that was passed in — it re-encodes the Orchard
+      // receiver on its own.
+      const recovered = shielded[0].address;
+      assert.ok(recovered);
+      assert.notStrictEqual(recovered, MULTI_RECEIVER_UA);
+      const recoveredUa = ZcashUnifiedAddress.parse(recovered, "zcashTest");
+      assert.deepStrictEqual(
+        Buffer.from(recoveredUa.orchardReceiver ?? []),
+        Buffer.from(orchard),
+        "same Orchard receiver",
+      );
+      assert.strictEqual(
+        recoveredUa.transparentScript,
+        undefined,
+        "the transparent receiver did not survive",
+      );
+      assert.strictEqual(
+        recoveredUa.saplingReceiver,
+        undefined,
+        "nor would a Sapling receiver have",
+      );
+
+      // Still the same payee, though: every receiver of the recovered UA is a receiver of the
+      // original, so a caller can verify the shielded output against the address the user pasted.
+      assert.strictEqual(ua.contains(recovered), true);
+    });
+
+    // Passing `options.unifiedAddress` stores the full UA verbatim, so it survives a
+    // serialize/deserialize round-trip byte-for-byte — receivers and all — instead of being
+    // rebuilt from just the Orchard receiver.
+    it("round-trips the full multi-receiver unified address when unifiedAddress is provided", function () {
+      const ua = ZcashUnifiedAddress.parse(MULTI_RECEIVER_UA, "zcashTest");
+      const orchard = ua.orchardReceiver;
+      assert.ok(orchard, "fixture UA has an Orchard receiver");
+      assert.ok(ua.transparentScript, "fixture UA also has a transparent receiver");
+
+      const psbt = ZcashIronwoodBitGoPsbt.createEmpty("zcashTest", walletKeys, {
+        blockHeight: NU6_3_TESTNET_HEIGHT,
+      });
+      psbt.addWalletInput({ txid: "11".repeat(32), vout: 0, value: 200_000_000n }, walletKeys, {
+        scriptId: SCRIPT_ID,
+        signPath: { signer: "user", cosigner: "bitgo" },
+      });
+      psbt.addWalletOutput(walletKeys, { chain: 1, index: 0, value: 99_900_000n });
+      psbt.addShieldedOutput(orchard, 100_000_000n, {
+        anchor: new Uint8Array(32),
+        unifiedAddress: MULTI_RECEIVER_UA,
+      });
+
+      // Survives a serialize round-trip: the UA lives in the PSBT bytes, not just in memory.
+      const round = ZcashIronwoodBitGoPsbt.fromBytes(psbt.serialize(), "zcashTest");
+      const shielded = round.parseOutputsWithWalletKeys(walletKeys).filter((o) => o.isShielded);
+      assert.strictEqual(shielded.length, 1);
+      assert.deepStrictEqual(Buffer.from(shielded[0].script), Buffer.from(orchard));
+
+      // The exact original UA comes back, transparent receiver included — not a re-encoded
+      // single-receiver UA.
+      assert.strictEqual(shielded[0].address, MULTI_RECEIVER_UA);
+
+      // Also true through `parseTransactionWithWalletKeys`, which shares the same output-parsing
+      // path.
+      const parsed = round.parseTransactionWithWalletKeys(walletKeys, {
+        replayProtection: { publicKeys: [] },
+      });
+      const parsedShielded = parsed.outputs.filter((o) => o.isShielded);
+      assert.strictEqual(parsedShielded.length, 1);
+      assert.strictEqual(parsedShielded[0].address, MULTI_RECEIVER_UA);
+    });
+
+    function emptyPsbtWithoutShieldedOutput(): ZcashIronwoodBitGoPsbt {
+      const psbt = ZcashIronwoodBitGoPsbt.createEmpty("zcashTest", walletKeys, {
+        blockHeight: NU6_3_TESTNET_HEIGHT,
+      });
+      psbt.addWalletInput({ txid: "11".repeat(32), vout: 0, value: 200_000_000n }, walletKeys, {
+        scriptId: SCRIPT_ID,
+        signPath: { signer: "user", cosigner: "bitgo" },
+      });
+      psbt.addWalletOutput(walletKeys, { chain: 1, index: 0, value: 99_900_000n });
+      return psbt;
+    }
+
+    it("rejects a unifiedAddress whose Orchard receiver does not match recipient", function () {
+      const psbt = emptyPsbtWithoutShieldedOutput();
+      assert.throws(
+        () =>
+          psbt.addShieldedOutput(RECIPIENT, 100_000_000n, {
+            anchor: new Uint8Array(32),
+            unifiedAddress: MULTI_RECEIVER_UA,
+          }),
+        /does not match recipient/,
+      );
+    });
+
+    it("rejects a unifiedAddress that is not a valid unified address", function () {
+      const psbt = emptyPsbtWithoutShieldedOutput();
+      assert.throws(
+        () =>
+          psbt.addShieldedOutput(RECIPIENT, 100_000_000n, {
+            anchor: new Uint8Array(32),
+            unifiedAddress: "not-a-valid-unified-address",
+          }),
+        /invalid unified_address/,
+      );
     });
   });
 


### PR DESCRIPTION
addShieldedOutput only stored the raw 43-byte Orchard receiver, so parsing a shielded output back out always reconstructed a single-receiver Unified Address, silently dropping any transparent/Sapling receiver the original UA carried. Add an optional unifiedAddress parameter, validate its Orchard receiver against recipient, and store it verbatim in the PSBT's proprietary map so parsing returns the original UA, receivers and all, even after a serialize/deserialize round-trip.

Ticket: CSHLD-1528